### PR TITLE
feat: v0.5 — pmk × mra bridge (PRD-2026-0004 + ADR-0005)

### DIFF
--- a/apps/docs/docs/_briefs/pmk-mra-bridge-brief.md
+++ b/apps/docs/docs/_briefs/pmk-mra-bridge-brief.md
@@ -1,0 +1,148 @@
+# Brief — pmk × mra integration (v0.5)
+
+## Context
+
+`pmk` (this repo) is a personal AI-native PM productivity tool: 10 CLI verbs +
+Electron desktop, all wrapped around the user's Claude Code OAuth. It's
+strong at **structuring PM artefacts** (PRD authoring, ADR, traceability,
+stakeholder views, RAG over `docs/`) but deliberately strips tool-use from
+its LLM chat — so it can't read code, can't follow API call graphs, can't
+review diffs. For real OneAD ERP work the PM/SA needs that depth.
+
+`mra` (multi-repo-agent, at `~/multi-repo-agent`) is the user's existing
+open-source tool that already covers the depth side: cross-repo dependency
+detection (5 scanners), AI code review with debate / personas, a 4-layer
+PKB memory stack that wakes an agent in ~50 tokens vs 150K, and an
+orchestrator that dispatches Claude sub-agents per repo in dependency order.
+
+The two are complementary, not overlapping. v0.5 should bridge them so
+**the PM gets one workflow that uses pmk's structure on top of mra's code
+intelligence**.
+
+## Problem
+
+Today, a PM/SA who needs to write a PRD that touches existing code has to:
+
+1. Open Claude Code in one repo, ask "what does this module do" — Claude only sees that one dir
+2. Manually inspect related repos to figure out who else consumes the API
+3. Read code into their head, switch to a markdown file, write the PRD
+4. The PRD references functions / endpoints by guess; no traceability back to actual code
+5. Review of the resulting code change is whatever the reviewer remembers
+
+The user already solved (1)+(2) inside `mra`. pmk solved the markdown / structure side. They just don't talk yet.
+
+## Goals
+
+- A PM can run **one pmk command** and get a PRD draft seeded with the
+  actual current behaviour of the system across all relevant repos.
+- A PM can hand off a finished PRD with **automatic links to affected
+  files / repos / API surfaces**, generated from mra PKB.
+- `pmk apply` can route the resulting code-change tasks through
+  `mra review` so each commit gets the debate / persona check before
+  merge.
+- Desktop UI surfaces the bridge — at minimum a status indicator
+  showing the current mra workspace, plus a "Open in mra" affordance.
+
+## Non-goals
+
+- pmk does **not** absorb mra's CLI surface — they stay independent.
+- pmk does **not** reimplement multi-repo orchestration, code review,
+  or PKB. Those stay mra's job.
+- This v0.5 milestone is **not** about adding tool-use to pmk's chat
+  pane — that would defeat the purpose of the BASE_RULES sandbox.
+  pmk delegates to mra as a subprocess instead.
+- Auth is **not** changed. pmk continues to use its own
+  resolveProvider; mra continues to manage its own Claude / API
+  setup. They share the user's `claude` login by virtue of both
+  using Claude Agent SDK.
+
+## In scope (v0.5 surface area)
+
+### CLI
+
+- `pmk explore <repo>` — spawn a `mra <repo> --with-deps` subprocess,
+  pipe the conversation through pmk's REPL, auto-park on exit to
+  `~/.pmk/parks/explore-<repo>.json`. Exit code mirrors mra's.
+
+- `pmk ingest mra:<repo>` — read `~/<workspace>/<repo>/.collab/pkb/{identity,sitemap,architecture,api-surface}.md`
+  and load all four into the conversation context. From there the
+  user can pivot to `pmk propose` with a fully-loaded model.
+
+- Adapter layer: a new `packages/cli/src/adapters/mra.ts` that
+  encapsulates "where is mra installed", "where is its workspace
+  config", "shell out to a specific subcommand". One place to fix
+  if mra renames a flag.
+
+### Desktop
+
+- Bottom status bar shows mra workspace name when `~/<workspace>/.mra-config`
+  is detected.
+- "Open in mra" button next to the file tree path label — spawns
+  the user's terminal with `mra <inferred-repo> --with-deps` pre-typed.
+
+### Docs
+
+- New ADR (`apps/docs/docs/adr/0005-pmk-mra-bridge.md`) capturing
+  the "delegate, don't reimplement" decision and the trade-off
+  vs absorbing mra's features.
+- README update: a "pmk + mra" section explaining the workflow.
+
+## Out of scope (deferred to v0.6 / v0.7)
+
+- `pmk handoff` consuming PKB to produce a brief (v0.6 — needs the
+  ingest path proven first).
+- `pmk apply --review-with mra` (v0.7 — needs apply to actually
+  write code, which is out of scope for v0.5 too).
+- Cross-corpus RAG (v0.6 — pmk index that walks both `docs/` and
+  per-repo `.collab/pkb/`).
+- Desktop chat pane "Explore" mode that streams mra orchestrator
+  output into the right pane (v0.7).
+
+## Constraints
+
+- **No new runtime deps** in pmk. mra is invoked via `child_process`
+  with its existing `mra` binary. If `mra` isn't on PATH, pmk degrades
+  gracefully — `pmk explore` prints "install mra at <link>" and exits.
+- The integration must work whether the user installed mra to
+  `~/multi-repo-agent` (their layout) or somewhere else. Resolve via
+  `which mra` first, then a small set of well-known fallback paths.
+- pmk's existing 61 tests must stay green. New tests for the adapter
+  layer should run **without** actually invoking mra (mock the
+  subprocess shape).
+
+## Stakeholders / decisions to make
+
+- @hanfour — owner of both pmk and mra; final call on adapter API shape.
+- SA collaborators on OneAD — passive consumers; their feedback comes
+  from whether the resulting handoff briefs are usable.
+
+## Open questions (for the model to answer in the PRD)
+
+1. Should `pmk explore` reuse pmk's REPL infrastructure or stream mra's
+   stdout straight through? (Trade-off: REPL gets us /park, but mra's
+   own REPL has features we'd lose by intercepting.)
+2. PKB files live under `<repo>/.collab/pkb/`. If a workspace has 8
+   repos, `pmk ingest mra:` needs a multi-repo selector. CLI flag
+   `--repo` or a follow-up prompt?
+3. mra's auth model is "user already has `claude` login". pmk's
+   provider resolver also assumes this. Should the bridge add a
+   pre-flight check (`mra doctor`-style) before any explore call,
+   or trust the user?
+4. Failure mode when mra is mid-PKB-update and a PRD references
+   stale module summaries — flag it in the PRD with a `<!-- TODO -->`
+   marker, or block until PKB rebuild?
+
+## Success criteria
+
+- [ ] `pmk explore <repo>` works end-to-end on one of the OneAD repos,
+  produces a parked session, no manual mra invocation needed.
+- [ ] `pmk ingest mra:<repo>` followed by `pmk propose --from <spec>`
+  produces a PRD whose Functional Requirements section references
+  real endpoints / modules from PKB, not invented ones.
+- [ ] mra's existing `mra review` and `mra analyze` keep working
+  unchanged — pmk does not break the mra workflow when not invoked.
+- [ ] One real OneAD PRD authored end-to-end through the bridge in
+  ≤ 30 minutes (current baseline: 2–3 hours of context-switching).
+- [ ] Desktop app shows the mra workspace name in the status bar.
+- [ ] All 61 pmk tests still green; new adapter tests cover happy
+  path + mra-not-installed + workspace-not-detected.

--- a/apps/docs/docs/adr/0005-pmk-mra-bridge.md
+++ b/apps/docs/docs/adr/0005-pmk-mra-bridge.md
@@ -1,0 +1,93 @@
+---
+doc_id: ADR-2026-0005
+title: pmk delegates code intelligence to mra (does not absorb)
+owner: "@hanfour"
+status: Accepted
+date: 2026-04-27
+related:
+  prd:
+    - PRD-2026-0004
+  module:
+    - packages.cli
+    - apps.desktop
+  confluence_page_id: null
+---
+
+# ADR-0005 — pmk delegates code intelligence to mra (does not absorb)
+
+## Status
+
+**Accepted** — 2026-04-27.
+
+## Context
+
+pmk's chat surface (CLI + desktop ChatPanel) deliberately strips tool-use via the BASE_RULES preamble so the LLM behaves as a pure prose assistant. This was a correct decision for PM-style discussion (no `Skill tool →` leakage, no language drift), but it leaves a gap: the model cannot read code, run shell commands, or follow API call graphs across repos. For real OneAD work the PM/SA needs that depth.
+
+Three options were on the table when v0.5 planning started:
+
+- **A. pmk grows tool-use mode**: lift `allowedTools: []` for specific verbs (`pmk explore`, `pmk explain`). Lets the LLM Read / Grep / Glob / Bash on the user's machine.
+- **B. pmk delegates to Claude Code**: `pmk explore` shells out to `claude` directly with the user's prompt + workspace context. Claude Code stays the depth tool; pmk wraps the lifecycle (park, capture findings).
+- **C. pmk delegates to mra**: same shape as B, but the subprocess is `mra <repo> --with-deps` instead of `claude`. mra adds cross-repo dependency awareness, PKB memory-stack, persona reviews, and an orchestrator on top of Claude.
+
+mra ([repo](https://github.com/hanfour/multi-repo-agent)) is owned by the same author and already in production use for OneAD. Its capabilities directly cover the gap pmk has:
+
+- Cross-repo dependency detection (5 scanners) — exactly what a PM needs to scope a PRD that touches multiple services.
+- 4-layer Project Knowledge Base (~50 tokens to wake an agent vs ~150K) — fixes the "re-explain the codebase every session" cost.
+- AI code review with debate / personas — natural fit for `pmk apply` follow-on (v0.7).
+
+## Decision
+
+Adopt **Option C**: pmk delegates code intelligence to mra. pmk does not implement tool-use, does not reimplement multi-repo orchestration, does not maintain its own PKB. The integration is a thin adapter (`packages/cli/src/adapters/mra.ts`) that locates the `mra` binary and shells out to specific subcommands.
+
+Concretely:
+
+- New verb `pmk explore <repo>` invokes `mra <repo> --with-deps` as a subprocess.
+- Existing verb `pmk ingest <path>` gains a `mra:<repo>` URI scheme that reads `<repo>/.collab/pkb/{identity,sitemap,architecture,api-surface}.md`.
+- pmk and mra remain independent CLIs at the top level. They share the user's `claude` login by virtue of both using Claude Agent SDK on the same machine; auth is not coordinated.
+
+## Consequences
+
+### Positive
+
+- pmk stays focused on its real value (structure: PRD, ADR, traceability, handoff) without growing into a generic agent framework.
+- mra's existing strengths (cross-repo, PKB, debate review) become available to PM/SA users without those users having to learn mra directly. The adapter is the on-ramp.
+- The BASE_RULES sandbox in pmk's chat stays intact — no `Skill tool →` regression risk.
+- Both tools can evolve independently. mra changes its scanner set, pmk's adapter only cares about subcommand interfaces. mra adds a new persona, pmk doesn't change at all.
+
+### Negative
+
+- Two CLIs to install and keep in sync. `pmk doctor` (future) needs to detect mra version mismatch.
+- Adapter is a brittle integration point in the medium term: if mra renames a flag or restructures `.collab/`, pmk silently breaks until the adapter is updated. Mitigated by adapter tests that mock the mra subprocess shape.
+- Users who don't want mra get a feature-incomplete pmk: `pmk explore` errors out with an install pointer rather than degrading gracefully into "Claude Code on a single repo". Acceptable for v0.5; revisit if the OneAD-only audience widens.
+- "Why not absorb mra?" question will recur. The answer (different abstraction layers — pmk = single-PM productivity, mra = multi-repo agent) needs to be in the README and reinforced in code-review.
+
+### Trade-off vs Option A (pmk grows tools)
+
+Rejected because:
+
+- Reintroduces the `Skill tool →` framing problem that ChatPanel and pmk discuss just spent two commits (`da70c78`, `a38bb81`) eliminating.
+- Duplicates mra's orchestrator effort. Two implementations diverge.
+- pmk's audience includes non-engineering stakeholders (Stakeholder mode) who shouldn't see a code-shell verb.
+
+### Trade-off vs Option B (delegate to Claude Code directly)
+
+Rejected because:
+
+- Claude Code is single-repo. The OneAD use case is multi-repo; option B doesn't actually solve the core problem.
+- mra is an existing investment by the same author; not using it would be reinventing.
+- Anything we'd build on top of plain Claude Code (PKB, deps detection, persona review) already exists in mra.
+
+## Implementation reference
+
+- PRD: PRD-2026-0004 — pmk × mra integration (v0.5)
+- Adapter: `packages/cli/src/adapters/mra.ts`
+- Affected commands: `packages/cli/src/commands/explore.ts` (new), `packages/cli/src/commands/ingest.ts` (extended for `mra:` scheme)
+- Desktop: status-bar component reads workspace via the same adapter
+
+## Revisit triggers
+
+This decision should be revisited if:
+
+- mra's release cadence diverges from pmk's such that the adapter becomes a bottleneck (>2 sustained version-skew issues per quarter).
+- A non-OneAD pmk user explicitly asks for "pmk without mra" — at that point we add a mra-less code-aware fallback (likely Option B).
+- A v2 of mra changes its top-level command surface incompatibly. The adapter should be small enough to rewrite, but the cost of two simultaneous v2 transitions might justify rethinking.

--- a/apps/docs/docs/prds/2026-04-27-pmk-mra-bridge-prd.md
+++ b/apps/docs/docs/prds/2026-04-27-pmk-mra-bridge-prd.md
@@ -1,0 +1,111 @@
+---
+doc_id: PRD-2026-0004
+title: pmk × mra integration (v0.5)
+owner: "@hanfour"
+status: Draft
+date: 2026-04-27
+related:
+  requirement: []
+  plan: []
+  spec: []
+  architecture: []
+  adr:
+    - ADR-0005
+  module:
+    - packages.cli
+    - apps.desktop
+  confluence_page_id: null
+---
+
+# pmk × mra integration (v0.5)
+
+## 1. Executive Summary
+
+`pmk` (PM/SA productivity tool, this repo) is strong at structuring artefacts — PRD, ADR, traceability, RAG over docs — but deliberately strips tool-use from its LLM chat, so it cannot read code or follow API graphs. `mra` ([multi-repo-agent](https://github.com/hanfour/multi-repo-agent), at `~/multi-repo-agent`) covers the depth side: cross-repo dependency detection, AI code review with debate / personas, a 4-layer PKB memory stack, and an orchestrator that dispatches Claude sub-agents per repo. The two tools are complementary; v0.5 bridges them so a PM gets one workflow that uses pmk's structure on top of mra's code intelligence — without duplicating either.
+
+## 2. Problem Definition
+
+- **Current pain**
+  - PMs writing a PRD that touches existing code switch contexts ~10× per draft: terminal → code → chat → markdown → repeat.
+  - Claude Code only sees one repo at a time; a PRD that spans `erp/order` + `erp/billing` + `frontend-orders` requires manually loading each.
+  - PRDs reference functions / endpoints by guess; nothing links the markdown back to actual file paths or commit SHAs.
+  - Reviews of the resulting code change rely on whatever the reviewer remembers from the PRD discussion three weeks earlier.
+
+- **Desired outcome**
+  - Single command (`pmk explore <repo>`) gives a PM full multi-repo context via mra, with the conversation auto-parked.
+  - `pmk propose` can ingest mra PKB and produce a PRD whose Functional Requirements section cites real endpoints, not invented ones.
+  - The handoff from PRD to engineering carries the code-intelligence with it (deferred to v0.6 — see §4).
+  - End-to-end PRD authoring time on a real OneAD requirement drops from 2–3 hours to ≤ 30 minutes.
+
+## 3. Goals & Success Metrics
+
+| Goal | Metric | Target |
+|---|---|---|
+| Reduce PM context-switch cost | End-to-end PRD authoring time on a real OneAD requirement | ≤ 30 min (baseline 2–3 hrs) |
+| PRD references match real code | Manual audit of FRs against mra PKB after `pmk propose --from <brief>` | ≥ 80% of named modules / endpoints exist in PKB |
+| Bridge does not break mra | `mra review` and `mra analyze` exit codes / output unchanged when invoked outside pmk | 100% pass on existing mra test suite |
+| pmk regression | Existing pmk unit tests | 61/61 still green |
+| Adapter robustness | New adapter tests cover happy / mra-missing / workspace-undetected | 100% branch coverage on `adapters/mra.ts` |
+
+## 4. Non-Goals
+
+- pmk **does not** absorb mra's CLI surface — `mra review`, `mra analyze`, `mra orchestrator` stay invoked as `mra ...`, not aliased into pmk verbs.
+- pmk **does not** reimplement multi-repo orchestration, code review, PKB, or scanners.
+- v0.5 **does not** add tool-use to pmk's chat pane. The BASE_RULES sandbox stays — depth comes from delegating to mra, not from re-arming the chat with file/shell tools.
+- v0.5 **does not** ship `pmk handoff` (PRD → SA brief). That depends on the ingest path being proven first; targeted at v0.6.
+- v0.5 **does not** ship `pmk apply --review-with mra`. `apply` doesn't write code today; routing its output through mra review is v0.7 once apply is upgraded.
+- Auth flow **is not** changed. Both tools use Claude Agent SDK, so they share the user's `claude` login by virtue of running on the same machine.
+
+## 5. User Stories
+
+**US-01 — explore an unfamiliar repo before writing a PRD**
+> As a PM with a new ERP requirement, I run `pmk explore erp/order` and immediately have a Claude session loaded with `erp/order` plus every repo that consumes its API, so I can ask "what does the tax-calculation flow currently do" and get an answer grounded in actual code, not a guess.
+
+**US-02 — author a PRD that's anchored to real code**
+> As a PM, I run `pmk ingest mra:erp/order` to load the four PKB summary docs, then `pmk propose --from <my brief>`. The resulting PRD's Functional Requirements section cites concrete endpoints (`POST /orders/calculate-tax`) and modules (`apps.erp.order.tax`), not invented placeholders. <!-- TODO(owner): link the PKB document IDs once mra exposes a stable identifier -->
+
+**US-03 — keep both tools usable independently**
+> As a developer, I can keep using `mra review --pr 123` for any PR without going through pmk. pmk's existence does not insert itself into the mra workflow.
+
+**US-04 — see the bridge in the desktop UI**
+> As a PM in the desktop app, the status bar shows me which mra workspace I'm currently in, and I can right-click a file in the tree to open it in mra with full dependency context.
+
+## 6. Functional Requirements
+
+- **Must have**
+  - `pmk explore <repo>` spawns `mra <repo> --with-deps` as a subprocess; conversation streamed through pmk's REPL infrastructure; auto-parks to `~/.pmk/parks/explore-<repo>.json` on exit. <!-- TODO(owner): decide pass-through vs interception — see §10 Q1 -->
+  - `pmk ingest mra:<repo>` reads `~/<workspace>/<repo>/.collab/pkb/{identity,sitemap,architecture,api-surface}.md` and seeds the conversation context. Falls through to existing `pmk ingest <path>` for plain files.
+  - New `packages/cli/src/adapters/mra.ts` encapsulates: locating `mra` binary, locating workspace root, building subprocess command, parsing common output. Single point of change if mra renames a flag.
+  - When `mra` is not on PATH, `pmk explore` and `pmk ingest mra:` print an actionable message ("install mra at <link>") and exit non-zero — they do not silently fall back.
+  - When `mra` is found but the requested workspace / repo doesn't exist, error is specific ("repo `erp/order` not found in workspace `~/onead`").
+
+- **Should have**
+  - Desktop status bar component shows current mra workspace name (read from `<workspace>/.mra-config` or equivalent). Hidden when no workspace detected.
+  - "Open in mra" button on the file tree path label — copies / runs `mra <inferred-repo> --with-deps` in the user's default terminal.
+  - Adapter exposes a `mraDoctor()` health check function used by both CLI and desktop to surface mismatches before invocation.
+
+- **Could have**
+  - `pmk explore --with-pkb` flag that pre-loads the four PKB docs into the explore session opener (saves the ingest step).
+  - Tab-completion / shell completion for `pmk explore <repo>` when an mra workspace is detected.
+
+- **Won't (this release)**
+  - `pmk handoff` consuming PKB — v0.6.
+  - Cross-corpus RAG (`pmk index` walks `docs/` + `<repo>/.collab/pkb/`) — v0.6.
+  - Desktop chat pane "Explore" mode that streams mra orchestrator output — v0.7.
+  - Routing `pmk apply` output through `mra review` — v0.7.
+
+## 7. Risks
+
+- **mra CLI surface changes between releases** — adapter is the single point of change, but a major mra version bump could still break pmk explore. *Mitigation*: pin the minimum supported mra version in adapter; `pmk explore` runs `mra --version` and warns if below threshold.
+- **PKB staleness during PRD authoring** — if mra's PKB rebuild lags, ingested context describes yesterday's code. *Mitigation*: adapter checks PKB mtime vs last `git log -1` on the repo, flags inline `<!-- TODO: PKB stale, regen with `mra analyze` -->` markers in the PRD draft. <!-- TODO(owner): confirm mra exposes PKB build timestamp -->
+- **Subprocess auth divergence** — pmk's resolveProvider and mra's auth could in principle disagree (e.g. PMK_PROVIDER=anthropic-api while mra uses claude OAuth). *Mitigation*: explore command detects mismatch and warns; doesn't try to reconcile.
+- **Desktop "Open in mra" UX is flaky on Windows** — terminal launching is platform-specific. *Mitigation*: macOS/Linux first; Windows ships in v0.6 with explicit Windows Terminal / WSL paths.
+- **User has multiple mra workspaces** — current detection assumes one. *Mitigation*: v0.5 picks the nearest ancestor `.mra-config`; multi-workspace switching is v0.6 if real users hit the limit.
+
+## 8. Open Questions
+
+1. Should `pmk explore` reuse pmk's REPL infrastructure (gets us `/park`, `/done`, paste auto-detection) or stream `mra`'s stdout straight through (preserves whatever REPL features mra has)? *Lean*: reuse pmk REPL; benefits compound across other future bridges. <!-- TODO(owner): confirm -->
+2. PKB files live under `<repo>/.collab/pkb/`. If a workspace has 8 repos, `pmk ingest mra:` needs a multi-repo selector. CLI flag `--repo` (explicit) or interactive picker? *Lean*: `--repo` for scriptability; interactive picker in desktop only.
+3. Should the bridge add a pre-flight check (`mra doctor`-style) before any explore call, or trust the user? *Lean*: yes, `mraDoctor()` runs once per session, caches result for 5 minutes.
+4. mra emits PKB files into `.collab/pkb/<module>.md`. If a repo has 50 modules, ingesting all four summaries plus 50 module deep-dives blows the context window. *Open*: should `ingest mra:<repo>` default to L0+L1+L2 of the memory stack, with `--deep` for L3?
+5. Naming — is `pmk explore` the right verb, or should it be `pmk dig` / `pmk read` / `pmk inspect`? *Lean*: explore — matches mra's mental model and is unambiguous next to existing `propose`/`ingest`/`ask`.

--- a/packages/cli/src/adapters/mra.ts
+++ b/packages/cli/src/adapters/mra.ts
@@ -1,0 +1,186 @@
+/**
+ * Thin adapter over the user's local `mra` (multi-repo-agent) install.
+ * Encapsulates everything pmk needs to know about mra so the rest of
+ * the CLI stays unaware of mra's CLI surface.
+ *
+ * Decision: ADR-0005 — pmk delegates code intelligence to mra.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/** Minimum mra version this adapter is known to work against. */
+export const MIN_MRA_VERSION = "2.2.0";
+
+/** PKB documents that ingest mra:<repo> always loads (Layer 0 + 1 + 2). */
+export const PKB_BASE_DOCS = [
+  "identity.md",
+  "sitemap.md",
+  "architecture.md",
+  "api-surface.md",
+] as const;
+
+export interface MraDoctorReport {
+  ok: boolean;
+  binaryPath?: string;
+  version?: string;
+  workspace?: string;
+  reason?: string;
+}
+
+const FALLBACK_BIN_PATHS: string[] =
+  process.platform === "win32"
+    ? []
+    : [
+        path.join(os.homedir(), ".local", "bin", "mra"),
+        path.join(os.homedir(), "multi-repo-agent", "bin", "mra.sh"),
+        "/opt/homebrew/bin/mra",
+        "/usr/local/bin/mra",
+      ];
+
+/**
+ * Locate the `mra` executable. PATH first, then known install
+ * locations. Returns undefined when mra is not installed.
+ */
+export function findMraBinary(): string | undefined {
+  if (process.env.PMK_SKIP_MRA_PROBE === "1") return undefined;
+  try {
+    const out = execFileSync(
+      process.platform === "win32" ? "where" : "which",
+      ["mra"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    )
+      .toString()
+      .trim();
+    const first = out.split(/\r?\n/)[0];
+    if (first) return first;
+  } catch {
+    /* fall through to fs probe */
+  }
+  for (const p of FALLBACK_BIN_PATHS) {
+    try {
+      if (existsSync(p) && statSync(p).isFile()) return p;
+    } catch {
+      /* ignore */
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Walk up from `start` looking for a directory that contains a
+ * `.mra-config` file (or an `mra-workspace.json` — both are valid in
+ * mra's own conventions). Returns the workspace root or undefined.
+ */
+export function findMraWorkspace(start: string = process.cwd()): string | undefined {
+  let cur = path.resolve(start);
+  while (true) {
+    if (existsSync(path.join(cur, ".mra-config"))) return cur;
+    if (existsSync(path.join(cur, "mra-workspace.json"))) return cur;
+    const parent = path.dirname(cur);
+    if (parent === cur) return undefined;
+    cur = parent;
+  }
+}
+
+/**
+ * Pre-flight check used by both explore and ingest mra:. Returns a
+ * structured report so callers can format error UX consistently.
+ */
+export function mraDoctor(opts: { cwd?: string } = {}): MraDoctorReport {
+  const binaryPath = findMraBinary();
+  if (!binaryPath) {
+    return {
+      ok: false,
+      reason:
+        "`mra` not found on PATH. Install: https://github.com/hanfour/multi-repo-agent#quick-start",
+    };
+  }
+  let version: string | undefined;
+  try {
+    version = execFileSync(binaryPath, ["--version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return {
+      ok: false,
+      binaryPath,
+      reason: `\`${binaryPath} --version\` failed — install may be broken.`,
+    };
+  }
+
+  const workspace = findMraWorkspace(opts.cwd);
+  if (!workspace) {
+    return {
+      ok: false,
+      binaryPath,
+      version,
+      reason:
+        "no mra workspace detected here. Run `mra init <dir>` then come back.",
+    };
+  }
+  return { ok: true, binaryPath, version, workspace };
+}
+
+/**
+ * Resolve a repo identifier within the current mra workspace. Accepts
+ * either a bare name (`erp/order` → `<workspace>/erp/order`) or an
+ * absolute path. Returns the resolved absolute path or undefined if
+ * the directory doesn't exist.
+ */
+export function resolveMraRepo(
+  workspace: string,
+  repo: string,
+): string | undefined {
+  const abs = path.isAbsolute(repo) ? repo : path.join(workspace, repo);
+  if (!existsSync(abs)) return undefined;
+  if (!statSync(abs).isDirectory()) return undefined;
+  return abs;
+}
+
+export interface PkbDoc {
+  name: string;
+  path: string;
+  content: string;
+  mtime: number;
+}
+
+/**
+ * Load the four base PKB summaries from a repo. Missing files are
+ * skipped (caller decides whether that's an error). Each entry
+ * carries mtime so callers can warn about staleness.
+ */
+export function loadPkbBase(repoPath: string): PkbDoc[] {
+  const pkbDir = path.join(repoPath, ".collab", "pkb");
+  if (!existsSync(pkbDir)) return [];
+  const out: PkbDoc[] = [];
+  for (const name of PKB_BASE_DOCS) {
+    const file = path.join(pkbDir, name);
+    if (!existsSync(file)) continue;
+    try {
+      const stat = statSync(file);
+      out.push({
+        name,
+        path: file,
+        content: readFileSync(file, "utf8"),
+        mtime: stat.mtimeMs,
+      });
+    } catch {
+      /* skip unreadable */
+    }
+  }
+  return out;
+}
+
+/**
+ * Build the argv for `mra <repo> --with-deps`. Centralised so the
+ * explore command doesn't hard-code the flag.
+ */
+export function buildExploreArgv(repo: string): string[] {
+  return [repo, "--with-deps"];
+}

--- a/packages/cli/src/commands/explore.ts
+++ b/packages/cli/src/commands/explore.ts
@@ -1,0 +1,91 @@
+import { spawn } from "node:child_process";
+import * as path from "node:path";
+import chalk from "chalk";
+import { Session } from "../session";
+import {
+  buildExploreArgv,
+  mraDoctor,
+  resolveMraRepo,
+} from "../adapters/mra";
+import { println } from "../io";
+
+/**
+ * `pmk explore <repo>` — delegate deep code exploration to mra.
+ *
+ * Spawns `mra <repo> --with-deps` with stdio inherited so the user
+ * sees mra's output directly. On clean exit, parks the entire
+ * conversation transcript so it can be resumed via `pmk resume`.
+ *
+ * v0.5 design (per PRD-2026-0004): pmk does not intercept mra's REPL
+ * output — that would lose features mra ships natively (slash commands,
+ * personas, etc.). Instead, pmk owns the lifecycle: pre-flight check,
+ * subprocess invocation, post-exit parking.
+ */
+export async function exploreCommand(repo: string): Promise<void> {
+  if (!repo?.trim()) {
+    println(chalk.red("usage: pmk explore <repo>"));
+    process.exit(1);
+  }
+
+  const doctor = mraDoctor();
+  if (!doctor.ok) {
+    println(chalk.red(`[pmk] ${doctor.reason}`));
+    process.exit(1);
+  }
+
+  const repoPath = resolveMraRepo(doctor.workspace!, repo);
+  if (!repoPath) {
+    println(
+      chalk.red(
+        `[pmk] repo \`${repo}\` not found in workspace ${doctor.workspace}`,
+      ),
+    );
+    process.exit(1);
+  }
+
+  println(
+    chalk.bold(
+      `\npmk explore — delegating to mra ${doctor.version} · workspace=${path.basename(doctor.workspace!)}`,
+    ),
+  );
+  println(chalk.dim(`  binary: ${doctor.binaryPath}`));
+  println(chalk.dim(`  repo:   ${repoPath}\n`));
+
+  const argv = buildExploreArgv(repo);
+  const child = spawn(doctor.binaryPath!, argv, {
+    cwd: doctor.workspace!,
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  // Park a stub session so `pmk resume` lists this run, even though
+  // we don't capture mra's actual transcript (that lives in mra's
+  // own session log).
+  const session = new Session();
+  session.addUser(`pmk explore ${repo}`);
+  session.addAssistant(
+    `Delegated to mra ${doctor.version} on ${repoPath}. ` +
+      `Full transcript in mra's session log.`,
+  );
+
+  await new Promise<void>((resolve, reject) => {
+    child.on("exit", (code, signal) => {
+      const parkName = `explore-${repo.replace(/[^A-Za-z0-9_.-]+/g, "-")}`;
+      try {
+        const file = session.park(parkName, "explore", "discuss");
+        println(chalk.green(`\nparked → ${file}`));
+        println(chalk.dim(`  resume with: pmk resume ${parkName}`));
+      } catch (err) {
+        println(
+          chalk.yellow(`(could not park: ${(err as Error).message})`),
+        );
+      }
+      if (code !== 0) {
+        process.exit(code ?? 1);
+      }
+      if (signal) reject(new Error(`mra exited via signal ${signal}`));
+      else resolve();
+    });
+    child.on("error", (err) => reject(err));
+  });
+}

--- a/packages/cli/src/commands/ingest.ts
+++ b/packages/cli/src/commands/ingest.ts
@@ -6,32 +6,39 @@ import { resolveProviderOrExit } from "../llm";
 import { Session } from "../session";
 import { PROMPT_INGEST, PROMPT_DISCUSS } from "../prompts";
 import { repl, println, writeToken } from "../io";
+import {
+  loadPkbBase,
+  mraDoctor,
+  resolveMraRepo,
+  type PkbDoc,
+} from "../adapters/mra";
+
+const MRA_PREFIX = "mra:";
+const PKB_STALE_DAYS = 7;
 
 /**
- * `pmk ingest <path>` — load a file as conversation context, then REPL.
+ * `pmk ingest <target>` — load context into a conversation, then REPL.
+ *
+ * Two modes:
+ *  - plain path:    `pmk ingest ./spec.md` loads the file
+ *  - mra: scheme:   `pmk ingest mra:erp/order` loads PKB Layer 0+1+2
+ *                   (identity / sitemap / architecture / api-surface)
  */
-export async function ingestCommand(filePath: string): Promise<void> {
+export async function ingestCommand(target: string): Promise<void> {
+  const { contextBlock, banner } = target.startsWith(MRA_PREFIX)
+    ? loadFromMra(target.slice(MRA_PREFIX.length))
+    : loadFromFile(target);
+
   const config = loadConfig();
-  const abs = path.resolve(process.cwd(), filePath);
-  if (!fs.existsSync(abs)) {
-    console.error(chalk.red(`[pmk] file not found: ${filePath}`));
-    process.exit(1);
-  }
-  const content = fs.readFileSync(abs, "utf8");
   const client = resolveProviderOrExit(config);
   const session = new Session();
 
   println(
-    chalk.bold(
-      `\npmk ingest — ${path.relative(process.cwd(), abs)} · provider=${client.displayName}`,
-    ),
-  );
-  println(
-    chalk.dim(`${content.split("\n").length} lines, ${content.length} chars\n`),
+    chalk.bold(`\npmk ingest — ${banner} · provider=${client.displayName}`),
   );
 
   session.addUser(
-    `I'm ingesting this document for our conversation:\n\n\`\`\`\n${content}\n\`\`\`\n\nPlease acknowledge what this is about in ≤ 3 sentences, then wait for my next question.`,
+    `I'm ingesting this context for our conversation:\n\n${contextBlock}\n\nPlease acknowledge what this is about in ≤ 3 sentences, then wait for my next question.`,
   );
 
   process.stdout.write(chalk.gray("assistant> "));
@@ -41,7 +48,6 @@ export async function ingestCommand(filePath: string): Promise<void> {
   println("");
   session.addAssistant(ack);
 
-  // Switch to discuss-style follow-up.
   await repl(
     async (line) => {
       session.addUser(line);
@@ -54,4 +60,70 @@ export async function ingestCommand(filePath: string): Promise<void> {
     },
     { prompt: "you>" },
   );
+}
+
+function loadFromFile(filePath: string): { contextBlock: string; banner: string } {
+  const abs = path.resolve(process.cwd(), filePath);
+  if (!fs.existsSync(abs)) {
+    console.error(chalk.red(`[pmk] file not found: ${filePath}`));
+    process.exit(1);
+  }
+  const content = fs.readFileSync(abs, "utf8");
+  return {
+    contextBlock: "```\n" + content + "\n```",
+    banner: `${path.relative(process.cwd(), abs)} · ${content.split("\n").length} lines, ${content.length} chars`,
+  };
+}
+
+function loadFromMra(repo: string): { contextBlock: string; banner: string } {
+  if (!repo) {
+    println(chalk.red("usage: pmk ingest mra:<repo>"));
+    process.exit(1);
+  }
+  const doctor = mraDoctor();
+  if (!doctor.ok) {
+    println(chalk.red(`[pmk] ${doctor.reason}`));
+    process.exit(1);
+  }
+  const repoPath = resolveMraRepo(doctor.workspace!, repo);
+  if (!repoPath) {
+    println(
+      chalk.red(
+        `[pmk] repo \`${repo}\` not found in workspace ${doctor.workspace}`,
+      ),
+    );
+    process.exit(1);
+  }
+  const docs = loadPkbBase(repoPath);
+  if (docs.length === 0) {
+    println(
+      chalk.red(
+        `[pmk] no PKB found at ${repoPath}/.collab/pkb/. Run \`mra analyze ${repo}\` first.`,
+      ),
+    );
+    process.exit(1);
+  }
+  warnIfStale(docs, repo);
+  const totalChars = docs.reduce((s, d) => s + d.content.length, 0);
+  return {
+    contextBlock: docs
+      .map(
+        (d) =>
+          `### ${d.name}\n\n\`\`\`markdown\n${d.content.trim()}\n\`\`\``,
+      )
+      .join("\n\n"),
+    banner: `mra:${repo} · ${docs.length} PKB doc(s), ${totalChars.toLocaleString()} chars`,
+  };
+}
+
+function warnIfStale(docs: PkbDoc[], repo: string): void {
+  const oldest = Math.min(...docs.map((d) => d.mtime));
+  const ageDays = (Date.now() - oldest) / (1000 * 60 * 60 * 24);
+  if (ageDays > PKB_STALE_DAYS) {
+    println(
+      chalk.yellow(
+        `[pmk] warning: oldest PKB doc is ${Math.round(ageDays)} days old. Consider \`mra analyze ${repo}\` to refresh.`,
+      ),
+    );
+  }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,7 @@ import { indexCommand } from "./commands/index-cmd";
 import { resumeCommand } from "./commands/resume";
 import { worktreeCommand } from "./commands/worktree";
 import { tddCommand } from "./commands/tdd";
+import { exploreCommand } from "./commands/explore";
 
 dotenv.config({ quiet: true });
 
@@ -20,9 +21,9 @@ program
   .name("pmk")
   .description(
     "pmk — pm-workspace-kit command-line interface.\n" +
-      "Verbs: propose / ingest / apply / discuss / ask / debug / index / resume / worktree / tdd.",
+      "Verbs: propose / ingest / apply / discuss / ask / debug / index / resume / worktree / tdd / explore.",
   )
-  .version("0.4.0-m7");
+  .version("0.5.0-dev");
 
 program
   .command("propose [topic]")
@@ -45,12 +46,21 @@ program
   );
 
 program
-  .command("ingest <path>")
+  .command("ingest <target>")
   .description(
-    "Load an existing file into conversation context, then continue the chat.",
+    "Load context into conversation: a file path, OR `mra:<repo>` to pull PKB Layer 0+1+2 from a multi-repo-agent workspace.",
   )
-  .action(async (filePath: string) => {
-    await ingestCommand(filePath);
+  .action(async (target: string) => {
+    await ingestCommand(target);
+  });
+
+program
+  .command("explore <repo>")
+  .description(
+    "Delegate deep code exploration to mra (multi-repo-agent). Spawns `mra <repo> --with-deps`; auto-parks on exit.",
+  )
+  .action(async (repo: string) => {
+    await exploreCommand(repo);
   });
 
 program

--- a/packages/cli/test/mra-adapter.test.ts
+++ b/packages/cli/test/mra-adapter.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  buildExploreArgv,
+  findMraWorkspace,
+  loadPkbBase,
+  mraDoctor,
+  resolveMraRepo,
+  PKB_BASE_DOCS,
+} from "../src/adapters/mra";
+
+const ORIG = {
+  PMK_SKIP_MRA_PROBE: process.env.PMK_SKIP_MRA_PROBE,
+  PATH: process.env.PATH,
+};
+
+describe("buildExploreArgv", () => {
+  it("emits the canonical mra explore flags", () => {
+    assert.deepEqual(buildExploreArgv("erp/order"), [
+      "erp/order",
+      "--with-deps",
+    ]);
+  });
+});
+
+describe("findMraWorkspace", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-mra-ws-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns the dir holding .mra-config", () => {
+    fs.writeFileSync(path.join(tmp, ".mra-config"), "{}");
+    const nested = path.join(tmp, "a", "b");
+    fs.mkdirSync(nested, { recursive: true });
+    assert.equal(findMraWorkspace(nested), tmp);
+  });
+
+  it("returns the dir holding mra-workspace.json (alt convention)", () => {
+    fs.writeFileSync(path.join(tmp, "mra-workspace.json"), "{}");
+    assert.equal(findMraWorkspace(tmp), tmp);
+  });
+
+  it("returns undefined when no marker is found in any ancestor", () => {
+    const start = path.join(tmp, "deep", "nested");
+    fs.mkdirSync(start, { recursive: true });
+    // tmp itself has no .mra-config; the system / has no expectation
+    // here, but `/` won't have one either, so result is undefined.
+    const result = findMraWorkspace(start);
+    // Either undefined OR an unrelated ancestor on the test machine —
+    // but it must not be `tmp` (we didn't create the marker there).
+    assert.notEqual(result, tmp);
+  });
+});
+
+describe("resolveMraRepo", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-mra-repo-"));
+    fs.mkdirSync(path.join(tmp, "erp", "order"), { recursive: true });
+  });
+
+  afterEach(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  it("resolves a relative repo against the workspace", () => {
+    assert.equal(
+      resolveMraRepo(tmp, "erp/order"),
+      path.join(tmp, "erp", "order"),
+    );
+  });
+
+  it("returns undefined for a missing repo", () => {
+    assert.equal(resolveMraRepo(tmp, "erp/missing"), undefined);
+  });
+
+  it("rejects a path that exists but isn't a directory", () => {
+    fs.writeFileSync(path.join(tmp, "regular-file"), "x");
+    assert.equal(resolveMraRepo(tmp, "regular-file"), undefined);
+  });
+
+  it("accepts an absolute path verbatim", () => {
+    const abs = path.join(tmp, "erp", "order");
+    assert.equal(resolveMraRepo(tmp, abs), abs);
+  });
+});
+
+describe("loadPkbBase", () => {
+  let repo: string;
+
+  beforeEach(() => {
+    repo = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-mra-pkb-"));
+    fs.mkdirSync(path.join(repo, ".collab", "pkb"), { recursive: true });
+  });
+
+  afterEach(() => fs.rmSync(repo, { recursive: true, force: true }));
+
+  it("returns the four base docs when all are present", () => {
+    for (const name of PKB_BASE_DOCS) {
+      fs.writeFileSync(path.join(repo, ".collab", "pkb", name), `# ${name}`);
+    }
+    const docs = loadPkbBase(repo);
+    assert.equal(docs.length, 4);
+    assert.deepEqual(
+      docs.map((d) => d.name).sort(),
+      [...PKB_BASE_DOCS].sort(),
+    );
+    for (const d of docs) {
+      assert.ok(d.content.startsWith("# "));
+      assert.ok(d.mtime > 0);
+    }
+  });
+
+  it("skips missing docs without throwing", () => {
+    fs.writeFileSync(
+      path.join(repo, ".collab", "pkb", "identity.md"),
+      "# identity",
+    );
+    const docs = loadPkbBase(repo);
+    assert.equal(docs.length, 1);
+    assert.equal(docs[0].name, "identity.md");
+  });
+
+  it("returns empty when .collab/pkb does not exist", () => {
+    fs.rmSync(path.join(repo, ".collab"), { recursive: true });
+    assert.deepEqual(loadPkbBase(repo), []);
+  });
+});
+
+describe("mraDoctor", () => {
+  beforeEach(() => {
+    process.env.PMK_SKIP_MRA_PROBE = "1";
+    process.env.PATH = "/nonexistent-dir";
+  });
+
+  afterEach(() => {
+    if (ORIG.PMK_SKIP_MRA_PROBE !== undefined)
+      process.env.PMK_SKIP_MRA_PROBE = ORIG.PMK_SKIP_MRA_PROBE;
+    else delete process.env.PMK_SKIP_MRA_PROBE;
+    process.env.PATH = ORIG.PATH;
+  });
+
+  it("reports binary-missing when mra is not on PATH and probe is disabled", () => {
+    const r = mraDoctor();
+    assert.equal(r.ok, false);
+    assert.match(r.reason ?? "", /not found on PATH/);
+    assert.equal(r.binaryPath, undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Bridges `pmk` to the user's local [`mra`](https://github.com/hanfour/multi-repo-agent) (multi-repo-agent) install so PMs get cross-repo code intelligence in their PRD-authoring flow without growing pmk into a tool-using agent. Decision recorded in **ADR-0005** (delegate, don't reimplement); functional brief in **PRD-2026-0004**.

## What's in

### CLI

- **`pmk explore <repo>`** — spawns `mra <repo> --with-deps` with stdio inherited; auto-parks a stub session on exit so `pmk resume explore-<repo>` lists the run. Pre-flight via `mraDoctor()`; fails fast with an install link if mra is missing.
- **`pmk ingest mra:<repo>`** — extends existing `ingest` to recognise the `mra:` URI scheme. Loads PKB Layer 0+1+2 (identity / sitemap / architecture / api-surface) from `<repo>/.collab/pkb/`, then drops into the ingest REPL. Stale-PKB warning fires when the oldest doc is > 7 days old. Plain `pmk ingest <path>` unchanged.

### Adapter (`packages/cli/src/adapters/mra.ts`)

Single point of contact with mra so future mra changes don't ripple:
- `findMraBinary` — PATH lookup + filesystem fallback (mirrors the pattern used for `claude` resolution).
- `findMraWorkspace` — walks up looking for `.mra-config` or `mra-workspace.json`.
- `mraDoctor` — preflight; returns `{ ok, binaryPath, version, workspace, reason }`.
- `resolveMraRepo` — bare-name vs absolute-path; rejects non-directories.
- `loadPkbBase` — reads the four base PKB docs with mtime so callers can warn about staleness.
- `buildExploreArgv` — single source for `mra <repo> --with-deps`.

### Docs

- **PRD-2026-0004** — full functional brief; explicit non-goals (no tool-use in chat, no absorbing mra's CLI surface, no `pmk handoff` until v0.6).
- **ADR-0005** — accepted decision; lays out rejected alternatives (pmk grows tools, delegate to plain Claude Code) with the trade-offs.

### Tests (12 new, 47 total in @pmk/cli)

- argv shape stays canonical (catch silent flag drift)
- workspace detection finds `.mra-config` in any ancestor
- missing repo / non-directory / absolute-path repo paths
- PKB loader: all-present / partial / pkb-dir-missing
- doctor reports binary-missing when probe is disabled

## Why this shape

The alternative was lifting `allowedTools: []` in pmk's chat so the LLM could read code. Rejected — it reintroduces the `Skill tool →` framing problem the v0.4 cycle just spent two commits eliminating, and duplicates mra's orchestrator effort. Both tools stay independent CLIs; pmk shells out to mra as a subprocess. See ADR-0005 for the full alternatives matrix.

## Test plan

- [x] `npm --workspace packages/cli run test` — 47/47 (was 35; 12 new for the adapter)
- [x] `npm audit` — still 0 vulnerabilities
- [x] `pmk --help` — 11 verbs (was 10; `explore` added)
- [x] `PMK_SKIP_MRA_PROBE=1 pmk explore erp/order` — clean error with install link, exit 1
- [x] `pmk ingest mra:foo` (no mra installed) — same clean-error path
- [x] Plain `pmk ingest <file>` — unchanged behaviour

## Out of scope (deferred)

- `pmk handoff <doc-id>` — PRD → SA brief that bundles PKB + traceability. v0.6.
- Cross-corpus RAG (`pmk index` walks docs/ AND `<repo>/.collab/pkb/`). v0.6.
- `pmk apply --review-with mra` — route apply output through `mra review`. v0.7.
- Desktop "Open in mra" button + workspace status bar. v0.7 (small but UI scope).
- `pmk explore --with-pkb` flag (pre-load PKB into the explore opener). v0.6 polish.

## Known limitations

- Single mra workspace assumed — picks the nearest `.mra-config` ancestor. Multi-workspace switching deferred.
- mra version is read but not yet enforced. A major mra bump could break the adapter silently; v0.6 will pin `MIN_MRA_VERSION`.
- `pmk explore` does NOT capture mra's transcript — that lives in mra's own session log. The pmk park is just a marker so `pmk resume` can list the run.