### PR TITLE
fix(cli): mra adapter aligned with real mra layout (v0.5.1)

### DIFF
--- a/packages/cli/src/adapters/mra.ts
+++ b/packages/cli/src/adapters/mra.ts
@@ -4,6 +4,15 @@
  * the CLI stays unaware of mra's CLI surface.
  *
  * Decision: ADR-0005 — pmk delegates code intelligence to mra.
+ *
+ * Layout (verified against mra v2.2.0+, lib/init.sh + lib/pkb.sh):
+ *   - workspace marker: `<workspace>/.collab/repos.json`
+ *   - per-repo PKB:     `<workspace>/<repo>/.mra/pkb/`
+ *   - PKB doc set:      sitemap.md, architecture.md, conventions.md,
+ *                       api-surface.md (no identity.md — earlier brief
+ *                       was wrong)
+ *   - mra has no `--version` flag; existence + workspace marker is
+ *     the proxy for "install looks healthy".
  */
 
 import { execFileSync } from "node:child_process";
@@ -11,21 +20,29 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-/** Minimum mra version this adapter is known to work against. */
-export const MIN_MRA_VERSION = "2.2.0";
-
-/** PKB documents that ingest mra:<repo> always loads (Layer 0 + 1 + 2). */
+/**
+ * Documents pmk pulls when ingesting `mra:<repo>`. Aligned to mra's
+ * actual PKB layout (see lib/pkb.sh::PKB_DIR_NAME=".mra/pkb").
+ */
 export const PKB_BASE_DOCS = [
-  "identity.md",
   "sitemap.md",
   "architecture.md",
+  "conventions.md",
   "api-surface.md",
 ] as const;
+
+/** Subpath inside each repo where PKB summaries live. */
+export const PKB_DIR_RELATIVE = path.join(".mra", "pkb");
+
+/** File mra creates at `mra init`; presence = workspace root. */
+const WORKSPACE_MARKER_PRIMARY = path.join(".collab", "repos.json");
+
+/** Older / alternate markers we still detect for forward-compat. */
+const WORKSPACE_MARKER_FALLBACKS = [".collab", ".mra-config", "mra-workspace.json"];
 
 export interface MraDoctorReport {
   ok: boolean;
   binaryPath?: string;
-  version?: string;
   workspace?: string;
   reason?: string;
 }
@@ -43,6 +60,11 @@ const FALLBACK_BIN_PATHS: string[] =
 /**
  * Locate the `mra` executable. PATH first, then known install
  * locations. Returns undefined when mra is not installed.
+ *
+ * Note: many users alias `mra` as a shell function pointing at
+ * `~/multi-repo-agent/bin/mra.sh`. `which mra` won't see shell
+ * functions from non-interactive shells, so the fs fallback list
+ * includes that canonical path.
  */
 export function findMraBinary(): string | undefined {
   if (process.env.PMK_SKIP_MRA_PROBE === "1") return undefined;
@@ -70,15 +92,20 @@ export function findMraBinary(): string | undefined {
 }
 
 /**
- * Walk up from `start` looking for a directory that contains a
- * `.mra-config` file (or an `mra-workspace.json` — both are valid in
- * mra's own conventions). Returns the workspace root or undefined.
+ * Walk up from `start` looking for a directory that holds an mra
+ * workspace. Primary signal is `.collab/repos.json` (what `mra init`
+ * creates); fallbacks accept just the `.collab` dir or older marker
+ * files for forward-compat.
  */
-export function findMraWorkspace(start: string = process.cwd()): string | undefined {
+export function findMraWorkspace(
+  start: string = process.cwd(),
+): string | undefined {
   let cur = path.resolve(start);
   while (true) {
-    if (existsSync(path.join(cur, ".mra-config"))) return cur;
-    if (existsSync(path.join(cur, "mra-workspace.json"))) return cur;
+    if (existsSync(path.join(cur, WORKSPACE_MARKER_PRIMARY))) return cur;
+    for (const m of WORKSPACE_MARKER_FALLBACKS) {
+      if (existsSync(path.join(cur, m))) return cur;
+    }
     const parent = path.dirname(cur);
     if (parent === cur) return undefined;
     cur = parent;
@@ -88,6 +115,9 @@ export function findMraWorkspace(start: string = process.cwd()): string | undefi
 /**
  * Pre-flight check used by both explore and ingest mra:. Returns a
  * structured report so callers can format error UX consistently.
+ *
+ * mra has no `--version` flag, so we don't claim a version. A future
+ * mra release may add one — adapter will pick it up then.
  */
 export function mraDoctor(opts: { cwd?: string } = {}): MraDoctorReport {
   const binaryPath = findMraBinary();
@@ -98,33 +128,16 @@ export function mraDoctor(opts: { cwd?: string } = {}): MraDoctorReport {
         "`mra` not found on PATH. Install: https://github.com/hanfour/multi-repo-agent#quick-start",
     };
   }
-  let version: string | undefined;
-  try {
-    version = execFileSync(binaryPath, ["--version"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    })
-      .toString()
-      .trim();
-  } catch {
-    return {
-      ok: false,
-      binaryPath,
-      reason: `\`${binaryPath} --version\` failed — install may be broken.`,
-    };
-  }
-
   const workspace = findMraWorkspace(opts.cwd);
   if (!workspace) {
     return {
       ok: false,
       binaryPath,
-      version,
       reason:
         "no mra workspace detected here. Run `mra init <dir>` then come back.",
     };
   }
-  return { ok: true, binaryPath, version, workspace };
+  return { ok: true, binaryPath, workspace };
 }
 
 /**
@@ -151,12 +164,12 @@ export interface PkbDoc {
 }
 
 /**
- * Load the four base PKB summaries from a repo. Missing files are
+ * Load the base PKB summaries from a repo. Missing files are
  * skipped (caller decides whether that's an error). Each entry
  * carries mtime so callers can warn about staleness.
  */
 export function loadPkbBase(repoPath: string): PkbDoc[] {
-  const pkbDir = path.join(repoPath, ".collab", "pkb");
+  const pkbDir = path.join(repoPath, PKB_DIR_RELATIVE);
   if (!existsSync(pkbDir)) return [];
   const out: PkbDoc[] = [];
   for (const name of PKB_BASE_DOCS) {
@@ -180,6 +193,10 @@ export function loadPkbBase(repoPath: string): PkbDoc[] {
 /**
  * Build the argv for `mra <repo> --with-deps`. Centralised so the
  * explore command doesn't hard-code the flag.
+ *
+ * Per `mra --help`, "mra <command|project...>" makes a bare project
+ * name a valid invocation that triggers `launch_claude` with the
+ * project context. `--with-deps` extends to upstream/downstream repos.
  */
 export function buildExploreArgv(repo: string): string[] {
   return [repo, "--with-deps"];

--- a/packages/cli/src/commands/explore.ts
+++ b/packages/cli/src/commands/explore.ts
@@ -2,11 +2,7 @@ import { spawn } from "node:child_process";
 import * as path from "node:path";
 import chalk from "chalk";
 import { Session } from "../session";
-import {
-  buildExploreArgv,
-  mraDoctor,
-  resolveMraRepo,
-} from "../adapters/mra";
+import { buildExploreArgv, mraDoctor, resolveMraRepo } from "../adapters/mra";
 import { println } from "../io";
 
 /**
@@ -45,7 +41,7 @@ export async function exploreCommand(repo: string): Promise<void> {
 
   println(
     chalk.bold(
-      `\npmk explore — delegating to mra ${doctor.version} · workspace=${path.basename(doctor.workspace!)}`,
+      `\npmk explore — delegating to mra · workspace=${path.basename(doctor.workspace!)}`,
     ),
   );
   println(chalk.dim(`  binary: ${doctor.binaryPath}`));
@@ -64,8 +60,7 @@ export async function exploreCommand(repo: string): Promise<void> {
   const session = new Session();
   session.addUser(`pmk explore ${repo}`);
   session.addAssistant(
-    `Delegated to mra ${doctor.version} on ${repoPath}. ` +
-      `Full transcript in mra's session log.`,
+    `Delegated to mra on ${repoPath}. Full transcript in mra's session log.`,
   );
 
   await new Promise<void>((resolve, reject) => {
@@ -76,9 +71,7 @@ export async function exploreCommand(repo: string): Promise<void> {
         println(chalk.green(`\nparked → ${file}`));
         println(chalk.dim(`  resume with: pmk resume ${parkName}`));
       } catch (err) {
-        println(
-          chalk.yellow(`(could not park: ${(err as Error).message})`),
-        );
+        println(chalk.yellow(`(could not park: ${(err as Error).message})`));
       }
       if (code !== 0) {
         process.exit(code ?? 1);

--- a/packages/cli/test/mra-adapter.test.ts
+++ b/packages/cli/test/mra-adapter.test.ts
@@ -8,8 +8,9 @@ import {
   findMraWorkspace,
   loadPkbBase,
   mraDoctor,
-  resolveMraRepo,
   PKB_BASE_DOCS,
+  PKB_DIR_RELATIVE,
+  resolveMraRepo,
 } from "../src/adapters/mra";
 
 const ORIG = {
@@ -37,14 +38,25 @@ describe("findMraWorkspace", () => {
     fs.rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("returns the dir holding .mra-config", () => {
-    fs.writeFileSync(path.join(tmp, ".mra-config"), "{}");
+  it("returns the dir holding .collab/repos.json (primary marker)", () => {
+    fs.mkdirSync(path.join(tmp, ".collab"));
+    fs.writeFileSync(path.join(tmp, ".collab", "repos.json"), "{}");
     const nested = path.join(tmp, "a", "b");
     fs.mkdirSync(nested, { recursive: true });
     assert.equal(findMraWorkspace(nested), tmp);
   });
 
-  it("returns the dir holding mra-workspace.json (alt convention)", () => {
+  it("falls back to a bare .collab dir (mid-init state)", () => {
+    fs.mkdirSync(path.join(tmp, ".collab"));
+    assert.equal(findMraWorkspace(tmp), tmp);
+  });
+
+  it("falls back to .mra-config (legacy / future-compat marker)", () => {
+    fs.writeFileSync(path.join(tmp, ".mra-config"), "{}");
+    assert.equal(findMraWorkspace(tmp), tmp);
+  });
+
+  it("falls back to mra-workspace.json (alt convention)", () => {
     fs.writeFileSync(path.join(tmp, "mra-workspace.json"), "{}");
     assert.equal(findMraWorkspace(tmp), tmp);
   });
@@ -52,11 +64,9 @@ describe("findMraWorkspace", () => {
   it("returns undefined when no marker is found in any ancestor", () => {
     const start = path.join(tmp, "deep", "nested");
     fs.mkdirSync(start, { recursive: true });
-    // tmp itself has no .mra-config; the system / has no expectation
-    // here, but `/` won't have one either, so result is undefined.
     const result = findMraWorkspace(start);
-    // Either undefined OR an unrelated ancestor on the test machine —
-    // but it must not be `tmp` (we didn't create the marker there).
+    // tmp itself has no marker. Result must not be tmp; may be undefined
+    // or an unrelated ancestor on the test machine.
     assert.notEqual(result, tmp);
   });
 });
@@ -98,14 +108,14 @@ describe("loadPkbBase", () => {
 
   beforeEach(() => {
     repo = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-mra-pkb-"));
-    fs.mkdirSync(path.join(repo, ".collab", "pkb"), { recursive: true });
+    fs.mkdirSync(path.join(repo, PKB_DIR_RELATIVE), { recursive: true });
   });
 
   afterEach(() => fs.rmSync(repo, { recursive: true, force: true }));
 
   it("returns the four base docs when all are present", () => {
     for (const name of PKB_BASE_DOCS) {
-      fs.writeFileSync(path.join(repo, ".collab", "pkb", name), `# ${name}`);
+      fs.writeFileSync(path.join(repo, PKB_DIR_RELATIVE, name), `# ${name}`);
     }
     const docs = loadPkbBase(repo);
     assert.equal(docs.length, 4);
@@ -119,18 +129,44 @@ describe("loadPkbBase", () => {
     }
   });
 
-  it("skips missing docs without throwing", () => {
+  it("loads from .mra/pkb/, not the older .collab/pkb/", () => {
+    // Plant docs at the WRONG path (the v0.5 layout); loader must skip.
+    const wrongDir = path.join(repo, ".collab", "pkb");
+    fs.mkdirSync(wrongDir, { recursive: true });
+    fs.writeFileSync(path.join(wrongDir, "sitemap.md"), "# old");
+    // Plant a doc at the RIGHT path.
     fs.writeFileSync(
-      path.join(repo, ".collab", "pkb", "identity.md"),
-      "# identity",
+      path.join(repo, PKB_DIR_RELATIVE, "sitemap.md"),
+      "# correct",
     );
     const docs = loadPkbBase(repo);
     assert.equal(docs.length, 1);
-    assert.equal(docs[0].name, "identity.md");
+    assert.equal(docs[0].content.trim(), "# correct");
   });
 
-  it("returns empty when .collab/pkb does not exist", () => {
-    fs.rmSync(path.join(repo, ".collab"), { recursive: true });
+  it("skips missing docs without throwing", () => {
+    fs.writeFileSync(
+      path.join(repo, PKB_DIR_RELATIVE, "sitemap.md"),
+      "# sitemap",
+    );
+    const docs = loadPkbBase(repo);
+    assert.equal(docs.length, 1);
+    assert.equal(docs[0].name, "sitemap.md");
+  });
+
+  it("does NOT include identity.md (not produced by current mra)", () => {
+    // Even if a stray identity.md exists, it isn't in PKB_BASE_DOCS so
+    // it should be ignored.
+    fs.writeFileSync(
+      path.join(repo, PKB_DIR_RELATIVE, "identity.md"),
+      "# stray",
+    );
+    const docs = loadPkbBase(repo);
+    assert.equal(docs.length, 0);
+  });
+
+  it("returns empty when .mra/pkb does not exist", () => {
+    fs.rmSync(path.join(repo, ".mra"), { recursive: true });
     assert.deepEqual(loadPkbBase(repo), []);
   });
 });


### PR DESCRIPTION
## Summary

v0.5.0 shipped the mra adapter against an **outdated reading of mra's README**. Real-workspace dogfood against \`~/OneAD\` immediately caught four layout mismatches; this PR fixes them all.

## What was wrong

| # | v0.5.0 adapter | Real mra |
|---|----------------|----------|
| 1 | Workspace marker: \`.mra-config\` / \`mra-workspace.json\` | \`.collab/repos.json\` (created by \`mra init\`) |
| 2 | PKB path: \`<repo>/.collab/pkb/\` | \`<repo>/.mra/pkb/\` (per \`lib/pkb.sh::PKB_DIR_NAME\`) |
| 3 | PKB docs include \`identity.md\` | mra produces sitemap / architecture / conventions / api-surface — no identity.md |
| 4 | \`mraDoctor\` calls \`mra --version\` and treats failure as broken | mra has no \`--version\` flag; existence + workspace marker is the only proxy |

Net effect: against any real mra install, **v0.5.0's \`pmk explore\` and \`pmk ingest mra:\` always errored out at the doctor step.** They were broken on shipment.

## Verified on real layout

\`\`\`
cwd=~/OneAD →
  mraDoctor: { ok: true, binary: ~/multi-repo-agent/bin/mra.sh,
               workspace: ~/OneAD }
  loadPkbBase('~/OneAD/advertising-knowledge') → 4 docs:
    - sitemap.md      (4058 chars)
    - architecture.md (3934 chars)
    - conventions.md  (5663 chars)
    - api-surface.md  (6924 chars)
\`\`\`

## Test plan

- [x] 51/51 \`@pmk/cli\` tests (was 47; +4 covering new layout)
- [x] New test asserts \`identity.md\` is **not** picked up even when planted (catches future regression)
- [x] New test asserts \`.collab/pkb/\` is **ignored** in favour of \`.mra/pkb/\` when both exist
- [x] Workspace detection: primary marker (\`.collab/repos.json\`), bare \`.collab\` mid-init, legacy markers (\`.mra-config\`, \`mra-workspace.json\`) all covered

## Why this matters for the project

This is a **process win**, not just a bug fix. v0.4 → v0.5 was driven by docs and review; v0.5 → v0.5.1 is driven by **first contact with reality**. Three more turns like this and pmk × mra is genuinely usable.

## Out of scope (deferred to v0.5.2 / v0.6)

- mra adds a \`--version\` flag → adapter picks it up + enforces \`MIN_MRA_VERSION\`
- ingest \`mra:\` warns when PKB is > 7 days stale (already in code; needs verification on a stale workspace)
- ingest \`mra:\` reads \`meta.json\` for project-type awareness
- per-module PKB ingest (\`<repo>/.mra/pkb/modules/*.md\`) for deeper context

## Tag plan

After merge: \`v0.5.1\` — patch release, no breaking surface change.