### PR TITLE
feat(cli): multi-repo ingest mra: (v0.5.2)

### DIFF
--- a/packages/cli/src/adapters/mra.ts
+++ b/packages/cli/src/adapters/mra.ts
@@ -38,7 +38,11 @@ export const PKB_DIR_RELATIVE = path.join(".mra", "pkb");
 const WORKSPACE_MARKER_PRIMARY = path.join(".collab", "repos.json");
 
 /** Older / alternate markers we still detect for forward-compat. */
-const WORKSPACE_MARKER_FALLBACKS = [".collab", ".mra-config", "mra-workspace.json"];
+const WORKSPACE_MARKER_FALLBACKS = [
+  ".collab",
+  ".mra-config",
+  "mra-workspace.json",
+];
 
 export interface MraDoctorReport {
   ok: boolean;
@@ -200,4 +204,36 @@ export function loadPkbBase(repoPath: string): PkbDoc[] {
  */
 export function buildExploreArgv(repo: string): string[] {
   return [repo, "--with-deps"];
+}
+
+interface ReposJson {
+  repos: Array<{ name: string; archived?: boolean; clone?: boolean }>;
+}
+
+/**
+ * Read `<workspace>/.collab/repos.json` and return the names of every
+ * repo that (a) is not archived and (b) has a `.mra/pkb/` directory
+ * with at least one base doc. Returns empty if the file or workspace
+ * is missing.
+ *
+ * Used by `pmk ingest mra:--all` to pick the load set without forcing
+ * the user to enumerate 27 repo names.
+ */
+export function listMraWorkspaceReposWithPkb(workspace: string): string[] {
+  const reposJson = path.join(workspace, ".collab", "repos.json");
+  if (!existsSync(reposJson)) return [];
+  let manifest: ReposJson;
+  try {
+    manifest = JSON.parse(readFileSync(reposJson, "utf8")) as ReposJson;
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const r of manifest.repos ?? []) {
+    if (r.archived) continue;
+    const repoPath = path.join(workspace, r.name);
+    if (!existsSync(repoPath)) continue;
+    if (loadPkbBase(repoPath).length > 0) out.push(r.name);
+  }
+  return out;
 }

--- a/packages/cli/src/commands/ingest.ts
+++ b/packages/cli/src/commands/ingest.ts
@@ -7,6 +7,7 @@ import { Session } from "../session";
 import { PROMPT_INGEST, PROMPT_DISCUSS } from "../prompts";
 import { repl, println, writeToken } from "../io";
 import {
+  listMraWorkspaceReposWithPkb,
   loadPkbBase,
   mraDoctor,
   resolveMraRepo,
@@ -17,12 +18,20 @@ const MRA_PREFIX = "mra:";
 const PKB_STALE_DAYS = 7;
 
 /**
+ * Soft cap on total ingested context size. ~150 KB ≈ 50K tokens; well
+ * within Sonnet's 200K window once you account for system prompt + the
+ * response itself. Above this we warn but proceed.
+ */
+const PKB_TOTAL_CHAR_WARN = 150_000;
+
+/**
  * `pmk ingest <target>` — load context into a conversation, then REPL.
  *
- * Two modes:
- *  - plain path:    `pmk ingest ./spec.md` loads the file
- *  - mra: scheme:   `pmk ingest mra:erp/order` loads PKB Layer 0+1+2
- *                   (identity / sitemap / architecture / api-surface)
+ * Three modes:
+ *   - plain path:           `pmk ingest ./spec.md`
+ *   - single mra repo:      `pmk ingest mra:erp`
+ *   - multi mra repos:      `pmk ingest mra:erp,oss-ui-v2,api-gateway`
+ *   - whole workspace:      `pmk ingest mra:--all` (every repo with PKB)
  */
 export async function ingestCommand(target: string): Promise<void> {
   const { contextBlock, banner } = target.startsWith(MRA_PREFIX)
@@ -62,7 +71,10 @@ export async function ingestCommand(target: string): Promise<void> {
   );
 }
 
-function loadFromFile(filePath: string): { contextBlock: string; banner: string } {
+function loadFromFile(filePath: string): {
+  contextBlock: string;
+  banner: string;
+} {
   const abs = path.resolve(process.cwd(), filePath);
   if (!fs.existsSync(abs)) {
     console.error(chalk.red(`[pmk] file not found: ${filePath}`));
@@ -75,54 +87,128 @@ function loadFromFile(filePath: string): { contextBlock: string; banner: string 
   };
 }
 
-function loadFromMra(repo: string): { contextBlock: string; banner: string } {
-  if (!repo) {
-    println(chalk.red("usage: pmk ingest mra:<repo>"));
+function loadFromMra(spec: string): { contextBlock: string; banner: string } {
+  if (!spec) {
+    println(
+      chalk.red("usage: pmk ingest mra:<repo> | mra:repo1,repo2 | mra:--all"),
+    );
     process.exit(1);
   }
+
   const doctor = mraDoctor();
   if (!doctor.ok) {
     println(chalk.red(`[pmk] ${doctor.reason}`));
     process.exit(1);
   }
-  const repoPath = resolveMraRepo(doctor.workspace!, repo);
-  if (!repoPath) {
+  const workspace = doctor.workspace!;
+
+  const repos = resolveRepoSpec(spec, workspace);
+  if (repos.length === 0) {
     println(
       chalk.red(
-        `[pmk] repo \`${repo}\` not found in workspace ${doctor.workspace}`,
+        `[pmk] no repos with PKB found for spec \`${spec}\` in ${workspace}`,
       ),
     );
     process.exit(1);
   }
-  const docs = loadPkbBase(repoPath);
-  if (docs.length === 0) {
+
+  const blocks: string[] = [];
+  const allDocs: Array<{ repo: string; doc: PkbDoc }> = [];
+  const missing: string[] = [];
+
+  for (const repo of repos) {
+    const repoPath = resolveMraRepo(workspace, repo);
+    if (!repoPath) {
+      missing.push(`${repo} (dir not found)`);
+      continue;
+    }
+    const docs = loadPkbBase(repoPath);
+    if (docs.length === 0) {
+      missing.push(`${repo} (no PKB)`);
+      continue;
+    }
+    for (const d of docs) allDocs.push({ repo, doc: d });
+    blocks.push(formatRepoBlock(repo, docs));
+  }
+
+  if (allDocs.length === 0) {
     println(
       chalk.red(
-        `[pmk] no PKB found at ${repoPath}/.collab/pkb/. Run \`mra analyze ${repo}\` first.`,
+        `[pmk] none of the requested repos have PKB. Run \`mra analyze <repo>\` first.`,
       ),
     );
     process.exit(1);
   }
-  warnIfStale(docs, repo);
-  const totalChars = docs.reduce((s, d) => s + d.content.length, 0);
+
+  if (missing.length) {
+    println(chalk.yellow(`[pmk] skipped: ${missing.join(", ")}`));
+  }
+
+  warnIfStale(allDocs);
+  const totalChars = allDocs.reduce((s, e) => s + e.doc.content.length, 0);
+  if (totalChars > PKB_TOTAL_CHAR_WARN) {
+    println(
+      chalk.yellow(
+        `[pmk] context is ${totalChars.toLocaleString()} chars (~${Math.round(totalChars / 3.5).toLocaleString()} tokens). Above ${PKB_TOTAL_CHAR_WARN.toLocaleString()} the conversation may run tight on long answers.`,
+      ),
+    );
+  }
+
+  const loadedRepos = Array.from(new Set(allDocs.map((e) => e.repo)));
+  const repoSummary =
+    loadedRepos.length === 1
+      ? `mra:${loadedRepos[0]}`
+      : `mra:${loadedRepos.length} repos (${loadedRepos.slice(0, 3).join(", ")}${loadedRepos.length > 3 ? ", …" : ""})`;
   return {
-    contextBlock: docs
-      .map(
-        (d) =>
-          `### ${d.name}\n\n\`\`\`markdown\n${d.content.trim()}\n\`\`\``,
-      )
-      .join("\n\n"),
-    banner: `mra:${repo} · ${docs.length} PKB doc(s), ${totalChars.toLocaleString()} chars`,
+    contextBlock: blocks.join("\n\n---\n\n"),
+    banner: `${repoSummary} · ${allDocs.length} PKB doc(s), ${totalChars.toLocaleString()} chars`,
   };
 }
 
-function warnIfStale(docs: PkbDoc[], repo: string): void {
-  const oldest = Math.min(...docs.map((d) => d.mtime));
-  const ageDays = (Date.now() - oldest) / (1000 * 60 * 60 * 24);
-  if (ageDays > PKB_STALE_DAYS) {
+/**
+ * Resolve a repo spec into the actual list of repos to load.
+ *  - `--all` walks the workspace via repos.json and picks ones with PKB
+ *  - comma-separated list is split and trimmed
+ *  - single name is returned as a one-element list
+ */
+function resolveRepoSpec(spec: string, workspace: string): string[] {
+  if (spec === "--all") {
+    return listMraWorkspaceReposWithPkb(workspace);
+  }
+  return spec
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function formatRepoBlock(repo: string, docs: PkbDoc[]): string {
+  return [
+    `## repo: ${repo}`,
+    ...docs.map(
+      (d) => `### ${d.name}\n\n\`\`\`markdown\n${d.content.trim()}\n\`\`\``,
+    ),
+  ].join("\n\n");
+}
+
+function warnIfStale(entries: Array<{ repo: string; doc: PkbDoc }>): void {
+  // Group oldest mtime per repo so the warning lists every stale repo,
+  // not just the single oldest doc.
+  const perRepo = new Map<string, number>();
+  for (const { repo, doc } of entries) {
+    const cur = perRepo.get(repo);
+    if (cur === undefined || doc.mtime < cur) perRepo.set(repo, doc.mtime);
+  }
+  const stale: string[] = [];
+  for (const [repo, mtime] of perRepo) {
+    const ageDays = (Date.now() - mtime) / (1000 * 60 * 60 * 24);
+    if (ageDays > PKB_STALE_DAYS) {
+      stale.push(`${repo} (${Math.round(ageDays)}d)`);
+    }
+  }
+  if (stale.length) {
     println(
       chalk.yellow(
-        `[pmk] warning: oldest PKB doc is ${Math.round(ageDays)} days old. Consider \`mra analyze ${repo}\` to refresh.`,
+        `[pmk] warning: PKB stale in ${stale.join(", ")}. Consider \`mra analyze\` on each.`,
       ),
     );
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -48,7 +48,7 @@ program
 program
   .command("ingest <target>")
   .description(
-    "Load context into conversation: a file path, OR `mra:<repo>` to pull PKB Layer 0+1+2 from a multi-repo-agent workspace.",
+    "Load context: a file path, OR `mra:<repo>` / `mra:repo1,repo2` / `mra:--all` to pull PKB from a multi-repo-agent workspace.",
   )
   .action(async (target: string) => {
     await ingestCommand(target);

--- a/packages/cli/test/mra-adapter.test.ts
+++ b/packages/cli/test/mra-adapter.test.ts
@@ -6,6 +6,7 @@ import * as path from "node:path";
 import {
   buildExploreArgv,
   findMraWorkspace,
+  listMraWorkspaceReposWithPkb,
   loadPkbBase,
   mraDoctor,
   PKB_BASE_DOCS,
@@ -119,10 +120,7 @@ describe("loadPkbBase", () => {
     }
     const docs = loadPkbBase(repo);
     assert.equal(docs.length, 4);
-    assert.deepEqual(
-      docs.map((d) => d.name).sort(),
-      [...PKB_BASE_DOCS].sort(),
-    );
+    assert.deepEqual(docs.map((d) => d.name).sort(), [...PKB_BASE_DOCS].sort());
     for (const d of docs) {
       assert.ok(d.content.startsWith("# "));
       assert.ok(d.mtime > 0);
@@ -168,6 +166,67 @@ describe("loadPkbBase", () => {
   it("returns empty when .mra/pkb does not exist", () => {
     fs.rmSync(path.join(repo, ".mra"), { recursive: true });
     assert.deepEqual(loadPkbBase(repo), []);
+  });
+});
+
+describe("listMraWorkspaceReposWithPkb", () => {
+  let ws: string;
+
+  beforeEach(() => {
+    ws = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-mra-list-"));
+    fs.mkdirSync(path.join(ws, ".collab"));
+  });
+
+  afterEach(() => fs.rmSync(ws, { recursive: true, force: true }));
+
+  it("returns repos that exist on disk and have PKB", () => {
+    fs.writeFileSync(
+      path.join(ws, ".collab", "repos.json"),
+      JSON.stringify({
+        repos: [
+          { name: "with-pkb" },
+          { name: "no-pkb" },
+          { name: "missing-dir" },
+        ],
+      }),
+    );
+    fs.mkdirSync(path.join(ws, "with-pkb", PKB_DIR_RELATIVE), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(ws, "with-pkb", PKB_DIR_RELATIVE, "sitemap.md"),
+      "# m",
+    );
+    fs.mkdirSync(path.join(ws, "no-pkb"));
+    // missing-dir: not on disk
+
+    assert.deepEqual(listMraWorkspaceReposWithPkb(ws), ["with-pkb"]);
+  });
+
+  it("skips archived entries", () => {
+    fs.writeFileSync(
+      path.join(ws, ".collab", "repos.json"),
+      JSON.stringify({
+        repos: [{ name: "active" }, { name: "old", archived: true }],
+      }),
+    );
+    for (const name of ["active", "old"]) {
+      fs.mkdirSync(path.join(ws, name, PKB_DIR_RELATIVE), { recursive: true });
+      fs.writeFileSync(
+        path.join(ws, name, PKB_DIR_RELATIVE, "sitemap.md"),
+        "# m",
+      );
+    }
+    assert.deepEqual(listMraWorkspaceReposWithPkb(ws), ["active"]);
+  });
+
+  it("returns empty when repos.json is missing", () => {
+    assert.deepEqual(listMraWorkspaceReposWithPkb(ws), []);
+  });
+
+  it("returns empty when repos.json is malformed", () => {
+    fs.writeFileSync(path.join(ws, ".collab", "repos.json"), "{not json");
+    assert.deepEqual(listMraWorkspaceReposWithPkb(ws), []);
   });
 });
 


### PR DESCRIPTION
## Summary

v0.5 single-repo ingest broke down on the second turn during real OneAD dogfood: PM opens a chat about `advertising-knowledge`, then immediately pivots to a bug in `oss-ui-v2` + `erp`, but those PKBs aren't loaded. PM/SA work is **always multi-repo**; this PR fixes the impedance mismatch.

## Spec forms

\`\`\`bash
pmk ingest mra:erp                    # single (unchanged)
pmk ingest mra:erp,oss-ui-v2,masa     # comma-separated
pmk ingest mra:--all                  # every repo with PKB in workspace
\`\`\`

## What changed

- **\`listMraWorkspaceReposWithPkb(workspace)\`** in the adapter. Reads \`.collab/repos.json\`, skips archived entries, filters to repos whose \`.mra/pkb/\` actually has docs.
- **Multi-block context** in ingest with \`## repo: <name>\` headers between blocks so the model knows which content belongs to which repo.
- **Skipped repos surface clearly**: \`[pmk] skipped: foo (dir not found), bar (no PKB)\`.
- **Stale warning lists every stale repo**: \`[pmk] warning: PKB stale in adv-knowledge (25d), erp (12d). Consider \\\`mra analyze\\\` on each.\`
- **Soft 150K char cap** (~50K tokens). Above that we warn but proceed.
- **Banner uses LOADED repos** not requested. \`mra:adv-k,does-not-exist\` displays as \`mra:adv-k\` (1 repo).

## Test plan

- [x] 55/55 (was 51; +4 covering \`listMraWorkspaceReposWithPkb\`)
- [x] \`mra:does-not-exist\` → clean error
- [x] \`mra:advertising-knowledge,does-not-exist\` → skip line + load valid one + 25d stale warning + REPL
- [x] \`mra:--all\` against ~/OneAD picks 1 repo (advertising-knowledge — only one currently \`mra analyze\`'d in this workspace)
- [x] Banner reports loaded count, not requested count

## Why this matters

This is **second-contact-with-reality**. v0.5.0 shipped the wrong layout (fixed in v0.5.1). v0.5.2 fixes the wrong scope. Every dogfood turn so far has surfaced a real correctness gap that no amount of pre-shipping review would have caught.

## Tag plan

After merge: \`v0.5.2\` — minor surface addition, no breaking changes.