### PR TITLE
fix(gateway): override BASE_RULES no-tools clause for v0.7 directives

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -212,7 +212,10 @@ Rules:
  * of audience. Defines how the model can ask pmk to run a deep code
  * search (mra-ask) or escalate to a human IT contact (escalate).
  */
-const GATEWAY_TOOLBOX = `CRITICAL — mra-ask directive:
+const GATEWAY_TOOLBOX = `IMPORTANT — TOOL OVERRIDE FOR GATEWAY-DM:
+Earlier in this prompt the BASE_RULES say "you have no tools, no skills, no file access, never announce or invoke any tool". For *this* gateway-DM context that rule is REPLACED. You DO have two structured tools you can invoke by emitting a fenced directive at the END of your response: \`mra-ask\` (deep code search via the host's mra subprocess) and \`escalate\` (tag a human IT/domain expert). Use them whenever appropriate; never claim you "don't have access to code" without first emitting an \`mra-ask\` block.
+
+CRITICAL — mra-ask directive:
 When answering requires details that are NOT in the loaded PKB summaries (e.g. specific implementation, business logic embedded in code, scope blocks, ability rules, exact column lists, controller chains), do NOT guess and do NOT say "I don't have access to the code". Instead, emit a fenced \`mra-ask\` block at the END of your response asking the host to run a deep code search on your behalf via the \`mra ask\` tool. The host will run it and feed the result back so you can synthesise a final answer.
 
 Format (omit the block entirely when PKB is sufficient):


### PR DESCRIPTION
## Bug

Live Slack dogfood on 2026-04-28 (slack-webhook workspace) exposed that the v0.7 directive layer (\`mra-ask\`, \`escalate\`) was **effectively dead** because the LLM never emitted the fenced blocks. Root cause:

\`BASE_RULES\` (inherited by all three gateway-DM audience prompts) opens with:

> You have NO tools, NO skills, NO file access, NO shell, and NO agent capabilities available — only prose. Never announce, reference, or attempt to invoke any tool, skill, agent, sub-agent, hook, or capability...

This directly contradicts the \`GATEWAY_TOOLBOX\` section appended to the same prompt that teaches the model to emit \`mra-ask\` / \`escalate\` blocks. Models trained for honesty defer to the safer "no tools" rule, so:

- Bot would say "我無法存取程式碼" instead of emitting \`mra-ask\` ✗
- Bot would say "請查 ERP / 請問 IT" instead of emitting \`escalate\` ✗
- All v0.7 unit tests still pass (the parser/runner code is correct), but the upstream LLM never starts the chain.

## Fix

Prepend an explicit override at the top of \`GATEWAY_TOOLBOX\` naming the conflict and re-permitting mra-ask + escalate for this context.

## Verified end-to-end

After the fix (and a session wipe to clear hallucinated "mra failed" history):

- **mra-ask round** ✅
  Question: \"erp 裡 OneCampaign 的 AASM events 有哪些？\"
  Bot emitted \`mra-ask\` block → pmk ran \`mra ask\` → synthesised answer cited \`one_campaign.rb:141-147\` with \`event\` definitions and \`from/to\` table; even debunked \`architecture.md\`'s outdated description.

- **escalate → absorb → retrieval** ✅
  Question: \"這個月所有部門的廣告預算分配比例？\"
  Bot emitted \`escalate\` block → pmk \`@\`-mentioned \`U0AVBM41F6Z\` (asker doubled as IT for the test) → IT replied with answer in thread → pmk extracted atom to \`~/.pmk/knowledge/erp/<id>.md\` with full front-matter (tags: \`廣告預算\`, \`sales_performances\`, \`budget_allocation\`, ...) → next similar question retrieved the atom and bot answered directly with the IT-supplied numbers.

- **Audience switching** ✅
  Same retrieved question answered in tech vs biz tones, with biz adding \"如需明細，可請 IT 從該報表拉資料\" — implementation-detail-deferral working as designed.

## Out of scope (follow-up tickets)

- Mra subprocess flakiness on long CJK queries — first attempt failed transiently with \"Command failed\" (no stderr captured), retry succeeded; might warrant beefing up runMraAsk's error reporting.
- Gateway cwd dependence — \`mraDoctor()\` walks up from the launch cwd; if started from anywhere outside the mra workspace tree, mra-ask short-circuits to synthetic-fail. Should add explicit \`mraWorkspace\` field to gateway.json.

## Tests

Existing 128/128 still green. No new tests; this is a prompt-only fix that requires live LLM to verify (covered by manual dogfood above).