### PR TITLE
fix(gateway): mra stderr surface + escalation CLI default positional

### DIFF
--- a/packages/cli/src/commands/gateway.ts
+++ b/packages/cli/src/commands/gateway.ts
@@ -344,10 +344,33 @@ function escalationUsage(): void {
     chalk.yellow(
       "usage:\n" +
         "  pmk gateway escalation list\n" +
-        "  pmk gateway escalation add <repo|--default> <userId>\n" +
-        "  pmk gateway escalation remove <repo|--default> <userId>",
+        "  pmk gateway escalation add <repo|default> <userId>\n" +
+        "  pmk gateway escalation remove <repo|default> <userId>",
     ),
   );
+}
+
+/**
+ * Resolve a user-supplied scope token to the canonical form. The
+ * canonical name for the default pool is `default` (positional, no
+ * dashes), but we also tolerate the legacy `--default` form for
+ * scripts that worked around the commander option-eating bug with
+ * `pmk gateway escalation add -- --default <id>`. Returns `null` when
+ * the token is the default sentinel; the actual repo string otherwise.
+ *
+ * Side effect: warns once when the deprecated form is used.
+ */
+function normaliseEscalationScope(scope: string): string | null {
+  if (scope === "default") return null;
+  if (scope === "--default") {
+    println(
+      chalk.yellow(
+        "  warning: `--default` is deprecated; use the positional `default` (no dashes) instead.",
+      ),
+    );
+    return null;
+  }
+  return scope;
 }
 
 function escalationCmd(rest: string[]): void {
@@ -382,15 +405,16 @@ function escalationCmd(rest: string[]): void {
         process.exit(1);
       }
       if (!ensureValidSlackUserId(userId)) process.exit(1);
+      const repo = normaliseEscalationScope(scope);
       const pool =
-        scope === "--default"
+        repo === null
           ? cfg.escalation.default
-          : (cfg.escalation.repos[scope] ??= []);
+          : (cfg.escalation.repos[repo] ??= []);
       if (!pool.includes(userId)) pool.push(userId);
       saveGatewayConfig(cfg);
       println(
         chalk.green(
-          `added ${userId} to ${scope === "--default" ? "default pool" : `${scope} pool`}`,
+          `added ${userId} to ${repo === null ? "default pool" : `${repo} pool`}`,
         ),
       );
       return;
@@ -401,12 +425,11 @@ function escalationCmd(rest: string[]): void {
         process.exit(1);
       }
       if (!ensureValidSlackUserId(userId)) process.exit(1);
+      const repo = normaliseEscalationScope(scope);
       const pool =
-        scope === "--default"
-          ? cfg.escalation.default
-          : cfg.escalation.repos[scope];
+        repo === null ? cfg.escalation.default : cfg.escalation.repos[repo];
       if (!pool) {
-        println(chalk.dim(`(${scope} pool empty; nothing to do)`));
+        println(chalk.dim(`(${repo} pool empty; nothing to do)`));
         return;
       }
       const idx = pool.indexOf(userId);
@@ -414,7 +437,7 @@ function escalationCmd(rest: string[]): void {
       saveGatewayConfig(cfg);
       println(
         chalk.green(
-          `removed ${userId} from ${scope === "--default" ? "default pool" : `${scope} pool`}`,
+          `removed ${userId} from ${repo === null ? "default pool" : `${repo} pool`}`,
         ),
       );
       return;

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -733,7 +733,19 @@ export class SlackAdapter {
       cwd: doctor.workspace,
     });
     if (!result.ok) {
+      // Diagnostic-friendly: surface stderr / partial stdout so the
+      // host operator can see WHY mra exited non-zero. Without this,
+      // failures collapse to Node's default "Command failed: <argv>"
+      // which is useless when triaging mra integration issues.
       this.onLog(`mra ask failed: ${result.reason ?? "(no reason)"}`);
+      if (result.stderr.trim()) {
+        this.onLog(`mra ask stderr: ${truncate(result.stderr.trim(), 600)}`);
+      }
+      if (result.stdout.trim()) {
+        this.onLog(
+          `mra ask partial stdout: ${truncate(result.stdout.trim(), 200)}`,
+        );
+      }
     }
 
     return await this.synthesiseAfterMra({
@@ -777,10 +789,7 @@ export class SlackAdapter {
           truncate(result.stdout.trim(), 24_000),
           "```",
         ].join("\n")
-      : [
-          `\`mra ask ${request.repo}\` 失敗：${result.reason ?? "unknown"}`,
-          "請以目前已載入的 PKB context 直接回答；若 PKB 也不足，請老實說「目前資料不夠」，不要編造。",
-        ].join("\n");
+      : buildMraFailureMessage(request.repo, result);
     session.messages.push({ role: "user", content: mraMessage });
 
     // Retrieval atoms come back here too — synthesis benefits from
@@ -1086,6 +1095,41 @@ function buildIngestSeed(
 function truncate(s: string, max: number): string {
   if (s.length <= max) return s;
   return `${s.slice(0, max)}\n…(truncated ${s.length - max} chars)`;
+}
+
+/**
+ * Compose the user-message that flows back to the LLM after mra ask
+ * failed. Includes stderr / stdout excerpts when present so the model
+ * can apologise with a specific cause ("mra reported missing PKB",
+ * "mra timed out") instead of a generic "unknown" — which is all
+ * Node's err.message gives us by default.
+ */
+function buildMraFailureMessage(
+  repo: string,
+  result: { stdout: string; stderr: string; reason?: string },
+): string {
+  const lines = [`\`mra ask ${repo}\` 失敗：${result.reason ?? "unknown"}`];
+  if (result.stderr.trim()) {
+    lines.push(
+      "",
+      "```mra-stderr",
+      truncate(result.stderr.trim(), 4_000),
+      "```",
+    );
+  }
+  if (result.stdout.trim()) {
+    lines.push(
+      "",
+      "```mra-partial-stdout",
+      truncate(result.stdout.trim(), 2_000),
+      "```",
+    );
+  }
+  lines.push(
+    "",
+    "請以目前已載入的 PKB context 直接回答；若 PKB 也不足，請老實說「目前資料不夠」並引用上面 stderr 提到的具體原因（如有），不要編造。",
+  );
+  return lines.join("\n");
 }
 
 // ─────────────────────────── ambient Slack types ──────────────────────


### PR DESCRIPTION
Closes #8 and #10. Bundled into one PR because they share trivial diff and both are dogfood-driven UX fixes.

## #8 — mra stderr surface

Live test (2026-04-28) hit a transient \`mra ask\` failure that surfaced as bare \`Command failed: <argv>\` in the gateway log — useless for triage, and the synthetic-fail message back to the LLM said only \"unknown\".

\`runMraAsk\` already captures stderr/stdout on the result struct; we just weren't using them.

- **Host log**: on \`!result.ok\`, now adds two diagnostic lines:
  - \`mra ask stderr: …\` (≤ 600 chars)
  - \`mra ask partial stdout: …\` (≤ 200 chars)
- **LLM context**: \`buildMraFailureMessage\` (extracted) wraps stderr in a \`\\\`\\\`\\\`mra-stderr\` block and partial stdout in \`mra-partial-stdout\`, then instructs the model to cite the specific cause when apologising.

## #10 — \`default\` positional

\`pmk gateway escalation add --default <id>\` was rejected by commander as an unknown option; the workaround was \`-- --default <id>\`.

Fixed by switching to a positional sentinel: \`pmk gateway escalation add default <id>\`. The legacy \`--default\` form still works (so existing scripts don't break) but emits a deprecation warning pointing at the new form.

Both \`add\` and \`remove\` share the same \`normaliseEscalationScope\` helper.

### Smoke-tested

\`\`\`
$ pmk gateway escalation add default U0AVBM41F6Z
added U0AVBM41F6Z to default pool

$ pmk gateway escalation add -- --default U0AVBM41F6Z
  warning: \`--default\` is deprecated; use the positional \`default\` (no dashes) instead.
added U0AVBM41F6Z to default pool

$ pmk gateway escalation remove default U0AVBM41F6Z
removed U0AVBM41F6Z from default pool
\`\`\`

## Tests

Existing 132/132 still pass. No new tests — the helpers are file-internal and the integration is covered by manual smoke + the existing escalation pool picker tests. Extracting them just for unit tests would balloon the diff; if dogfood reveals edge cases later we can promote them then.

## Test plan

- [ ] \`pmk gateway escalation add default <id>\` works without separator (#10)
- [ ] \`-- --default <id>\` still works, prints deprecation warning (#10)
- [ ] Help text updated to show \`default\` instead of \`--default\` (#10)
- [ ] When mra exits non-zero, gateway log shows stderr excerpt (#8)
- [ ] LLM follow-up reply quotes the specific stderr cause, not \"unknown\" (#8)