### PR TITLE
feat(gateway): startup mra validation + retry-once + extract messaging helpers

### DIFF
--- a/packages/cli/src/adapters/mra.ts
+++ b/packages/cli/src/adapters/mra.ts
@@ -235,6 +235,33 @@ export interface MraAskResult {
   stdout: string;
   stderr: string;
   reason?: string;
+  /** How many subprocess attempts were made (1 = no retry). */
+  attempts: number;
+}
+
+/**
+ * Heuristic for "this looks transient enough to retry once". Live
+ * dogfood (2026-04-28) saw `mra ask` return `Command failed: <argv>`
+ * with **empty stderr** while a manual retry succeeded — the kind of
+ * non-deterministic flake worth one retry. Excluded:
+ *
+ *   - timeouts (the next try will likely also time out)
+ *   - explicit stderr (mra clearly reported a problem; not transient)
+ *   - binary-not-found (won't suddenly appear)
+ */
+function looksTransient(result: MraAskResult): boolean {
+  if (!result.reason) return false;
+  if (result.reason.includes("not found on PATH")) return false;
+  if (result.reason.includes("timed out")) return false;
+  if (result.stderr.trim().length > 0) return false;
+  return true;
+}
+
+interface RunMraAskOpts {
+  /** Max retries on transient failures (default 1 = at most one extra try). */
+  maxRetries?: number;
+  /** Optional progress callback fired before each retry. */
+  onRetry?: (attempt: number, prevResult: MraAskResult) => void;
 }
 
 /**
@@ -249,13 +276,20 @@ export interface MraAskResult {
  *
  * Timeout defaults to 120s — `mra ask` involves an embedded LLM call
  * over the repo, which routinely takes 30–60s.
+ *
+ * Retries: on a transient-looking failure (see {@link looksTransient}),
+ * this function silently retries once. The returned `attempts` field
+ * lets callers see whether a retry happened.
  */
-export async function runMraAsk(args: {
-  repo: string;
-  question: string;
-  cwd: string;
-  timeoutMs?: number;
-}): Promise<MraAskResult> {
+export async function runMraAsk(
+  args: {
+    repo: string;
+    question: string;
+    cwd: string;
+    timeoutMs?: number;
+  },
+  opts: RunMraAskOpts = {},
+): Promise<MraAskResult> {
   const binary = findMraBinary();
   if (!binary) {
     return {
@@ -263,10 +297,30 @@ export async function runMraAsk(args: {
       stdout: "",
       stderr: "",
       reason: "`mra` binary not found on PATH",
+      attempts: 1,
     };
   }
+  const maxRetries = opts.maxRetries ?? 1;
   const timeoutMs = args.timeoutMs ?? 120_000;
-  return await new Promise<MraAskResult>((resolve) => {
+  let last: MraAskResult | undefined;
+  for (let attempt = 1; attempt <= maxRetries + 1; attempt++) {
+    const result = await runMraAskOnce(binary, args, timeoutMs);
+    if (result.ok || !looksTransient(result) || attempt > maxRetries) {
+      return { ...result, attempts: attempt };
+    }
+    last = result;
+    opts.onRetry?.(attempt, result);
+  }
+  // Unreachable in practice but appeases the type checker.
+  return { ...(last as MraAskResult), attempts: maxRetries + 1 };
+}
+
+function runMraAskOnce(
+  binary: string,
+  args: { repo: string; question: string; cwd: string },
+  timeoutMs: number,
+): Promise<MraAskResult> {
+  return new Promise<MraAskResult>((resolve) => {
     const child = execFile(
       binary,
       ["ask", args.repo, args.question],
@@ -286,6 +340,7 @@ export async function runMraAsk(args: {
             reason: killed
               ? `mra ask timed out after ${timeoutMs}ms`
               : err.message,
+            attempts: 1,
           });
           return;
         }
@@ -293,6 +348,7 @@ export async function runMraAsk(args: {
           ok: true,
           stdout: String(stdout ?? ""),
           stderr: String(stderr ?? ""),
+          attempts: 1,
         });
       },
     );
@@ -302,6 +358,7 @@ export async function runMraAsk(args: {
         stdout: "",
         stderr: "",
         reason: err.message,
+        attempts: 1,
       });
     });
   });

--- a/packages/cli/src/gateway/index.ts
+++ b/packages/cli/src/gateway/index.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as path from "node:path";
 import { SlackAdapter } from "./slack";
 import {
   gatewayPidPath,
@@ -29,6 +30,24 @@ export async function runGateway(opts: GatewayRunOptions = {}): Promise<void> {
   if (!hasValidSlackTokens(cfg)) {
     throw new Error(
       "gateway not configured. Run `pmk gateway init` and paste your Slack tokens.",
+    );
+  }
+
+  // Pre-flight validate the configured mra workspace so the host
+  // catches a stale path at start-up, not at first DM. Non-fatal —
+  // mra-ask will degrade gracefully later either way.
+  if (cfg.mraWorkspace) {
+    const marker = path.join(cfg.mraWorkspace, ".collab", "repos.json");
+    if (!fs.existsSync(marker)) {
+      log(
+        `WARN: mraWorkspace='${cfg.mraWorkspace}' has no .collab/repos.json — mra-ask will fail until you run \`mra init\` there or fix the path with \`pmk gateway init\``,
+      );
+    } else {
+      log(`mra workspace: ${cfg.mraWorkspace}`);
+    }
+  } else {
+    log(
+      "mra workspace: not configured (set via `pmk gateway init`); falling back to launch-cwd walk",
     );
   }
 

--- a/packages/cli/src/gateway/messaging.ts
+++ b/packages/cli/src/gateway/messaging.ts
@@ -1,0 +1,123 @@
+/**
+ * Gateway message builders + small text utilities. Extracted from the
+ * Slack adapter so they can be unit-tested in isolation and reused by
+ * other adapters (LINE etc.) when those land.
+ */
+
+import {
+  listMraWorkspaceReposWithPkb,
+  loadPkbBase,
+  mraDoctor,
+  resolveMraRepo,
+} from "../adapters/mra";
+
+/**
+ * Trim a string to `max` characters, appending a one-line "(truncated
+ * N chars)" marker so consumers can see something was clipped. Strings
+ * shorter than `max` are returned verbatim.
+ */
+export function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max)}\n…(truncated ${s.length - max} chars)`;
+}
+
+/**
+ * Build a one-shot seed message containing PKB content for the
+ * configured ingest spec. Returns undefined when no PKB is found
+ * (mra workspace missing, no repos with PKB, etc.).
+ *
+ * Pattern: same as the case command's buildSeedMessage — we package
+ * the four base docs per repo so the model can ground answers in real
+ * module names / API endpoints from turn one.
+ *
+ * `mraWorkspace` overrides the cwd-walk in mraDoctor; pass through
+ * `cfg.mraWorkspace` so the seed can be built from any launch
+ * directory.
+ */
+export function buildIngestSeed(
+  ingestSpec: string,
+  mraWorkspace?: string,
+): string | undefined {
+  const doctor = mraDoctor({ workspace: mraWorkspace });
+  if (!doctor.ok) return undefined;
+  const tail = ingestSpec.startsWith("mra:") ? ingestSpec.slice(4) : ingestSpec;
+  const repos =
+    tail === "--all"
+      ? listMraWorkspaceReposWithPkb(doctor.workspace!)
+      : tail
+          .split(",")
+          .map((r) => r.trim())
+          .filter(Boolean);
+
+  const blocks: string[] = [];
+  for (const repo of repos) {
+    const repoPath = resolveMraRepo(doctor.workspace!, repo);
+    if (!repoPath) continue;
+    const docs = loadPkbBase(repoPath);
+    if (docs.length === 0) continue;
+    blocks.push(
+      [
+        `## repo: ${repo}`,
+        ...docs.map(
+          (d) => `### ${d.name}\n\n\`\`\`markdown\n${d.content.trim()}\n\`\`\``,
+        ),
+      ].join("\n\n"),
+    );
+  }
+  if (blocks.length === 0) return undefined;
+  return [
+    "我先把 workspace 的 PKB context 給你（後續對話請用這些事實作答；缺的就老實說沒有，不要編造）：",
+    "",
+    blocks.join("\n\n---\n\n"),
+  ].join("\n");
+}
+
+/**
+ * Compose the user-message that flows back to the LLM after `mra ask`
+ * failed. Includes stderr / stdout excerpts when present so the model
+ * can apologise with a specific cause ("mra reported missing PKB",
+ * "mra timed out") instead of a generic "unknown" — which is all
+ * Node's err.message gives us by default.
+ */
+export function buildMraFailureMessage(
+  repo: string,
+  result: { stdout: string; stderr: string; reason?: string },
+): string {
+  const lines = [`\`mra ask ${repo}\` 失敗：${result.reason ?? "unknown"}`];
+  if (result.stderr.trim()) {
+    lines.push(
+      "",
+      "```mra-stderr",
+      truncate(result.stderr.trim(), 4_000),
+      "```",
+    );
+  }
+  if (result.stdout.trim()) {
+    lines.push(
+      "",
+      "```mra-partial-stdout",
+      truncate(result.stdout.trim(), 2_000),
+      "```",
+    );
+  }
+  lines.push(
+    "",
+    "請以目前已載入的 PKB context 直接回答；若 PKB 也不足，請老實說「目前資料不夠」並引用上面 stderr 提到的具體原因（如有），不要編造。",
+  );
+  return lines.join("\n");
+}
+
+/**
+ * Compose the user-message that flows back to the LLM after `mra ask`
+ * succeeded — wraps stdout in a fenced `mra-result` block with
+ * priority instructions for synthesis.
+ */
+export function buildMraSuccessMessage(repo: string, stdout: string): string {
+  return [
+    `這是 \`mra ask ${repo}\` 的回傳結果（請依此 synthesise 最終答案；若這份結果不足，可再 emit 一次 mra-ask，但仍以 PKB + 這份結果優先）：`,
+    "",
+    "```mra-result",
+    truncate(stdout.trim(), 24_000),
+    "```",
+  ].join("\n");
+}

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -39,14 +39,14 @@ import {
   saveCase,
   stripCaseUpdateBlock,
 } from "../../case";
-import {
-  listMraWorkspaceReposWithPkb,
-  loadPkbBase,
-  mraDoctor,
-  resolveMraRepo,
-  runMraAsk,
-} from "../../adapters/mra";
+import { mraDoctor, runMraAsk } from "../../adapters/mra";
 import { parseMraAsk, stripMraAskBlock } from "../mra-ask";
+import {
+  buildIngestSeed,
+  buildMraFailureMessage,
+  buildMraSuccessMessage,
+  truncate,
+} from "../messaging";
 import { parseEscalate, stripEscalateBlock } from "../escalate";
 import {
   formatAtomsForInjection,
@@ -727,11 +727,23 @@ export class SlackAdapter {
     this.onLog(
       `mra ask repo=${request.repo} q=${truncate(request.question, 120)}`,
     );
-    const result = await runMraAsk({
-      repo: request.repo,
-      question: request.question,
-      cwd: doctor.workspace,
-    });
+    const result = await runMraAsk(
+      {
+        repo: request.repo,
+        question: request.question,
+        cwd: doctor.workspace,
+      },
+      {
+        onRetry: (attempt) => {
+          this.onLog(
+            `mra ask attempt ${attempt} failed without stderr; retrying once`,
+          );
+        },
+      },
+    );
+    if (result.ok && result.attempts > 1) {
+      this.onLog(`mra ask succeeded on attempt ${result.attempts}`);
+    }
     if (!result.ok) {
       // Diagnostic-friendly: surface stderr / partial stdout so the
       // host operator can see WHY mra exited non-zero. Without this,
@@ -782,13 +794,7 @@ export class SlackAdapter {
     } = args;
     session.messages.push({ role: "assistant", content: firstResponse });
     const mraMessage = result.ok
-      ? [
-          `這是 \`mra ask ${request.repo}\` 的回傳結果（請依此 synthesise 最終答案；若這份結果不足，可再 emit 一次 mra-ask，但仍以 PKB + 這份結果優先）：`,
-          "",
-          "```mra-result",
-          truncate(result.stdout.trim(), 24_000),
-          "```",
-        ].join("\n")
+      ? buildMraSuccessMessage(request.repo, result.stdout)
       : buildMraFailureMessage(request.repo, result);
     session.messages.push({ role: "user", content: mraMessage });
 
@@ -1041,95 +1047,6 @@ export class SlackAdapter {
       }
     }
   }
-}
-
-/**
- * Build a one-shot seed message containing PKB content for the
- * configured ingest spec. Returns undefined when no PKB is found.
- *
- * Pattern: same as the case command's buildSeedMessage — we package
- * the four base docs per repo so the model can ground answers in real
- * module names / API endpoints.
- *
- * `mraWorkspace` overrides the cwd-walk in mraDoctor; pass through
- * cfg.mraWorkspace so the seed can be built from any launch directory.
- */
-function buildIngestSeed(
-  ingestSpec: string,
-  mraWorkspace?: string,
-): string | undefined {
-  const doctor = mraDoctor({ workspace: mraWorkspace });
-  if (!doctor.ok) return undefined;
-  const tail = ingestSpec.startsWith("mra:") ? ingestSpec.slice(4) : ingestSpec;
-  const repos =
-    tail === "--all"
-      ? listMraWorkspaceReposWithPkb(doctor.workspace!)
-      : tail
-          .split(",")
-          .map((r) => r.trim())
-          .filter(Boolean);
-
-  const blocks: string[] = [];
-  for (const repo of repos) {
-    const repoPath = resolveMraRepo(doctor.workspace!, repo);
-    if (!repoPath) continue;
-    const docs = loadPkbBase(repoPath);
-    if (docs.length === 0) continue;
-    blocks.push(
-      [
-        `## repo: ${repo}`,
-        ...docs.map(
-          (d) => `### ${d.name}\n\n\`\`\`markdown\n${d.content.trim()}\n\`\`\``,
-        ),
-      ].join("\n\n"),
-    );
-  }
-  if (blocks.length === 0) return undefined;
-  return [
-    "我先把 workspace 的 PKB context 給你（後續對話請用這些事實作答；缺的就老實說沒有，不要編造）：",
-    "",
-    blocks.join("\n\n---\n\n"),
-  ].join("\n");
-}
-
-function truncate(s: string, max: number): string {
-  if (s.length <= max) return s;
-  return `${s.slice(0, max)}\n…(truncated ${s.length - max} chars)`;
-}
-
-/**
- * Compose the user-message that flows back to the LLM after mra ask
- * failed. Includes stderr / stdout excerpts when present so the model
- * can apologise with a specific cause ("mra reported missing PKB",
- * "mra timed out") instead of a generic "unknown" — which is all
- * Node's err.message gives us by default.
- */
-function buildMraFailureMessage(
-  repo: string,
-  result: { stdout: string; stderr: string; reason?: string },
-): string {
-  const lines = [`\`mra ask ${repo}\` 失敗：${result.reason ?? "unknown"}`];
-  if (result.stderr.trim()) {
-    lines.push(
-      "",
-      "```mra-stderr",
-      truncate(result.stderr.trim(), 4_000),
-      "```",
-    );
-  }
-  if (result.stdout.trim()) {
-    lines.push(
-      "",
-      "```mra-partial-stdout",
-      truncate(result.stdout.trim(), 2_000),
-      "```",
-    );
-  }
-  lines.push(
-    "",
-    "請以目前已載入的 PKB context 直接回答；若 PKB 也不足，請老實說「目前資料不夠」並引用上面 stderr 提到的具體原因（如有），不要編造。",
-  );
-  return lines.join("\n");
 }
 
 // ─────────────────────────── ambient Slack types ──────────────────────

--- a/packages/cli/test/gateway.test.ts
+++ b/packages/cli/test/gateway.test.ts
@@ -38,6 +38,11 @@ import {
 import { parseMraAsk, stripMraAskBlock } from "../src/gateway/mra-ask";
 import { parseEscalate, stripEscalateBlock } from "../src/gateway/escalate";
 import { mraDoctor, runMraAsk } from "../src/adapters/mra";
+import {
+  buildMraFailureMessage,
+  buildMraSuccessMessage,
+  truncate,
+} from "../src/gateway/messaging";
 import { pickAudience, pickEscalationPool } from "../src/gateway/config";
 import {
   pickGatewayPrompt,
@@ -436,6 +441,90 @@ describe("runMraAsk", () => {
     });
     assert.equal(r.ok, false);
     assert.match(r.reason ?? "", /not found/);
+  });
+});
+
+describe("messaging helpers", () => {
+  it("truncate is a no-op below the cap", () => {
+    assert.equal(truncate("short", 100), "short");
+  });
+
+  it("truncate slices and appends a marker", () => {
+    const out = truncate("a".repeat(200), 50);
+    assert.equal(out.startsWith("a".repeat(50)), true);
+    assert.match(out, /truncated 150 chars/);
+  });
+
+  it("buildMraSuccessMessage wraps stdout in mra-result fence", () => {
+    const m = buildMraSuccessMessage(
+      "erp",
+      "module X lives at app/models/x.rb",
+    );
+    assert.match(m, /^這是 `mra ask erp`/);
+    assert.match(m, /```mra-result\n/);
+    assert.match(m, /app\/models\/x\.rb/);
+  });
+
+  it("buildMraSuccessMessage truncates very long stdout", () => {
+    const big = "x".repeat(40_000);
+    const m = buildMraSuccessMessage("erp", big);
+    assert.ok(m.length < 30_000);
+    assert.match(m, /truncated/);
+  });
+
+  it("buildMraFailureMessage uses 'unknown' when reason missing", () => {
+    const m = buildMraFailureMessage("erp", { stdout: "", stderr: "" });
+    assert.match(m, /失敗：unknown/);
+    assert.ok(!m.includes("mra-stderr"));
+    assert.ok(!m.includes("mra-partial-stdout"));
+  });
+
+  it("buildMraFailureMessage emits stderr fence when stderr present", () => {
+    const m = buildMraFailureMessage("erp", {
+      stdout: "",
+      stderr: "PKB index not built; run `mra build erp` first.",
+      reason: "exit 1",
+    });
+    assert.match(m, /失敗：exit 1/);
+    assert.match(m, /```mra-stderr\n/);
+    assert.match(m, /PKB index not built/);
+  });
+
+  it("buildMraFailureMessage emits partial-stdout fence when present", () => {
+    const m = buildMraFailureMessage("erp", {
+      stdout: "[ask] querying erp\nfound 3 results before crash",
+      stderr: "",
+      reason: "killed",
+    });
+    assert.match(m, /```mra-partial-stdout\n/);
+    assert.match(m, /found 3 results/);
+  });
+
+  it("buildMraFailureMessage instructs model to cite stderr cause", () => {
+    const m = buildMraFailureMessage("erp", {
+      stdout: "",
+      stderr: "rate limited",
+    });
+    assert.match(m, /引用上面 stderr 提到的具體原因/);
+  });
+});
+
+describe("runMraAsk retry-once", () => {
+  const ORIG_PROBE = process.env.PMK_SKIP_MRA_PROBE;
+  afterEach(() => {
+    if (ORIG_PROBE === undefined) delete process.env.PMK_SKIP_MRA_PROBE;
+    else process.env.PMK_SKIP_MRA_PROBE = ORIG_PROBE;
+  });
+
+  it("returns attempts=1 for binary-not-found (no retry)", async () => {
+    process.env.PMK_SKIP_MRA_PROBE = "1";
+    const r = await runMraAsk({
+      repo: "erp",
+      question: "anything",
+      cwd: process.cwd(),
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.attempts, 1);
   });
 });
 


### PR DESCRIPTION
Three v0.7.3-milestone follow-ups bundled together — all small, all dogfood-driven.

## #1 startup-time \`mraWorkspace\` validation

\`runGateway()\` logs the mra-workspace state at boot:

\`\`\`
[pmk-gw] mra workspace: /Users/hanfourhuang/OneAD            # valid
[pmk-gw] WARN: mraWorkspace='/bogus' has no .collab/repos.json — mra-ask will fail until you run \`mra init\` there or fix the path with \`pmk gateway init\`
[pmk-gw] mra workspace: not configured (set via \`pmk gateway init\`); falling back to launch-cwd walk
\`\`\`

Catches stale paths at startup instead of at first DM where the failure was silently swallowed before stderr surfacing landed in v0.7.2.

## #3 \`runMraAsk\` retry-once on transient failure

- Extracted \`runMraAskOnce\`; the public \`runMraAsk\` wraps it in a bounded retry loop (default 1 retry).
- \`looksTransient()\` heuristic: retry only when reason is non-specific (no "not found on PATH", no "timed out", and no stderr). Matches the 2026-04-28 dogfood signature: bare \`Command failed: <argv>\` with empty stderr, manual retry succeeds.
- New \`attempts\` field on \`MraAskResult\`; SlackAdapter logs \`mra ask attempt N failed without stderr; retrying once\` via \`onRetry\` callback, plus \`succeeded on attempt N\` when retry won.

## #2 extract gateway message helpers

- Move \`buildIngestSeed\`, \`buildMraFailureMessage\`, \`truncate\` (plus a new \`buildMraSuccessMessage\`) into \`packages/cli/src/gateway/messaging.ts\`.
- \`slack/index.ts\` imports them; ~95 lines lighter and now far easier to unit-test.
- 8 new unit tests cover truncate edge cases, success-message fence, failure-message branching (no-stderr / with-stderr / partial-stdout / cite-stderr instruction).

## Tests

132 → 141 (+9). Build green across @pmk/shared and @pmk/cli.

## Test plan

- [ ] \`pmk gateway start\` from a host with valid \`mraWorkspace\` — log shows \`mra workspace: …\`
- [ ] Edit \`mraWorkspace\` to a bogus path → \`pmk gateway start\` shows the WARN line at boot
- [ ] Force a transient mra failure (e.g. kill mra process mid-run) → log shows \`attempt 1 failed without stderr; retrying once\` + outcome
- [ ] Slack synthesised reply still cites mra stderr cause when the failure is real (regression check on #8 wiring)
- [ ] Existing audience / escalate / retrieval flows unchanged

## Out of scope

#4 (atom approval workflow) deferred — needs UX decision (emoji-react vs host-CLI vs TTL hybrid). Will file separate design issue.