### PR TITLE
feat(gateway): atom approval — TTL hybrid (option C)

### DIFF
--- a/packages/cli/src/commands/gateway.ts
+++ b/packages/cli/src/commands/gateway.ts
@@ -13,6 +13,12 @@ import {
 import { gatewayRunningPid, runGateway } from "../gateway";
 import { userStats } from "../gateway/session-store";
 import { findMraWorkspace } from "../adapters/mra";
+import {
+  approveAtom,
+  findAtomByPrefix,
+  loadAtoms,
+  rejectAtom,
+} from "../gateway/knowledge";
 
 export async function gatewayCommand(
   action: string,
@@ -31,10 +37,12 @@ export async function gatewayCommand(
       return audienceCmd(rest);
     case "escalation":
       return escalationCmd(rest);
+    case "atoms":
+      return atomsCmd(rest);
     default:
       println(
         chalk.yellow(
-          "usage: pmk gateway <init|start|status|stats|audience|escalation>",
+          "usage: pmk gateway <init|start|status|stats|audience|escalation|atoms>",
         ),
       );
       process.exit(1);
@@ -444,6 +452,153 @@ function escalationCmd(rest: string[]): void {
     }
     default:
       escalationUsage();
+      process.exit(1);
+  }
+}
+
+function atomsUsage(): void {
+  println(
+    chalk.yellow(
+      "usage:\n" +
+        "  pmk gateway atoms list [--all|--pending|--approved] [--scope <name>]\n" +
+        "  pmk gateway atoms show <id-or-prefix>\n" +
+        "  pmk gateway atoms approve <id-or-prefix>\n" +
+        "  pmk gateway atoms reject <id-or-prefix>",
+    ),
+  );
+}
+
+function formatAtomRow(atom: {
+  id: string;
+  scope: string;
+  question: string;
+  status?: string;
+  expiresAt?: number;
+}): string {
+  const statusTag =
+    atom.status === "pending"
+      ? chalk.yellow("pending ")
+      : chalk.green("approved");
+  const idShort = atom.id
+    .split("-")
+    .slice(0, 2)
+    .join("-")
+    .padEnd(20)
+    .slice(0, 20);
+  const ttl = atom.expiresAt
+    ? ` (TTL ${Math.max(0, Math.floor((atom.expiresAt - Date.now()) / 60_000))}m)`
+    : "";
+  const q = atom.question.slice(0, 70);
+  return `  ${statusTag}  ${idShort}  ${atom.scope.padEnd(10).slice(0, 10)}  ${q}${ttl}`;
+}
+
+function atomsCmd(rest: string[]): void {
+  const [action, ...args] = rest;
+  switch (action) {
+    case undefined:
+    case "list": {
+      const filter = args.includes("--pending")
+        ? "pending"
+        : args.includes("--approved")
+          ? "approved"
+          : "all";
+      const scopeIdx = args.indexOf("--scope");
+      const scope = scopeIdx >= 0 ? args[scopeIdx + 1] : undefined;
+      const atoms = loadAtoms({ scope }).filter((a) =>
+        filter === "all" ? true : a.status === filter,
+      );
+      println(chalk.bold(`\npmk gateway atoms (${filter})`));
+      if (atoms.length === 0) {
+        println(chalk.dim("  (none)"));
+        return;
+      }
+      println(
+        chalk.dim("  status    id-prefix             scope       question"),
+      );
+      for (const a of atoms) println(formatAtomRow(a));
+      return;
+    }
+    case "show": {
+      const [idOrPrefix] = args;
+      if (!idOrPrefix) {
+        atomsUsage();
+        process.exit(1);
+      }
+      const found = findAtomByPrefix(idOrPrefix);
+      if (!found) {
+        println(
+          chalk.red(
+            `no unique match for '${idOrPrefix}'. Try a longer prefix.`,
+          ),
+        );
+        process.exit(1);
+      }
+      println(chalk.bold(`\n${found.atom.question}`));
+      println(chalk.dim(`  id:       ${found.atom.id}`));
+      println(chalk.dim(`  scope:    ${found.atom.scope}`));
+      println(chalk.dim(`  status:   ${found.atom.status}`));
+      if (found.atom.expiresAt) {
+        const minsLeft = Math.max(
+          0,
+          Math.floor((found.atom.expiresAt - Date.now()) / 60_000),
+        );
+        println(chalk.dim(`  expires:  in ${minsLeft}m`));
+      }
+      println(
+        chalk.dim(
+          `  source:   ${found.atom.source.threadKey} via <@${found.atom.source.contributorUserId}>`,
+        ),
+      );
+      println(chalk.dim(`  tags:     ${found.atom.tags.join(", ") || "—"}`));
+      println(chalk.dim(`  file:     ${found.file}`));
+      println("");
+      if (found.atom.summary) {
+        println(chalk.bold("Summary"));
+        println(found.atom.summary);
+        println("");
+      }
+      println(chalk.bold("Answer"));
+      println(found.atom.answer);
+      return;
+    }
+    case "approve": {
+      const [idOrPrefix] = args;
+      if (!idOrPrefix) {
+        atomsUsage();
+        process.exit(1);
+      }
+      const atom = approveAtom(idOrPrefix);
+      if (!atom) {
+        println(
+          chalk.red(
+            `no unique match for '${idOrPrefix}'. Try a longer prefix.`,
+          ),
+        );
+        process.exit(1);
+      }
+      println(chalk.green(`approved: ${atom.id}`));
+      return;
+    }
+    case "reject": {
+      const [idOrPrefix] = args;
+      if (!idOrPrefix) {
+        atomsUsage();
+        process.exit(1);
+      }
+      const ok = rejectAtom(idOrPrefix);
+      if (!ok) {
+        println(
+          chalk.red(
+            `no unique match for '${idOrPrefix}'. Try a longer prefix.`,
+          ),
+        );
+        process.exit(1);
+      }
+      println(chalk.green(`rejected (file deleted): ${idOrPrefix}`));
+      return;
+    }
+    default:
+      atomsUsage();
       process.exit(1);
   }
 }

--- a/packages/cli/src/gateway/extractor.ts
+++ b/packages/cli/src/gateway/extractor.ts
@@ -7,7 +7,12 @@
  */
 
 import type { LlmProvider } from "../llm";
-import { generateAtomId, safeScope, type KnowledgeAtom } from "./knowledge";
+import {
+  ATOM_PENDING_TTL_MS,
+  generateAtomId,
+  safeScope,
+  type KnowledgeAtom,
+} from "./knowledge";
 
 const EXTRACTOR_PROMPT = `You are a knowledge-base curator. You receive a Slack thread snippet:
 - The original question someone asked pmk
@@ -66,11 +71,9 @@ export async function extractKnowledgeAtom(
   let out: string;
   try {
     out = await withTimeout(
-      llm.chat(
-        EXTRACTOR_PROMPT,
-        [{ role: "user", content: userMessage }],
-        { onToken: () => {} },
-      ),
+      llm.chat(EXTRACTOR_PROMPT, [{ role: "user", content: userMessage }], {
+        onToken: () => {},
+      }),
       EXTRACT_TIMEOUT_MS,
     );
   } catch {
@@ -99,9 +102,10 @@ export async function extractKnowledgeAtom(
         .filter(Boolean)
         .slice(0, 8)
     : [];
+  const now = Date.now();
   return {
     id: generateAtomId(parsed.question),
-    createdAt: Date.now(),
+    createdAt: now,
     scope: safeScope(input.scope),
     question: parsed.question.trim(),
     answer: input.expertAnswer.trim(),
@@ -111,6 +115,10 @@ export async function extractKnowledgeAtom(
       threadKey: input.threadKey,
       contributorUserId: input.contributorUserId,
     },
+    // v0.7.4 TTL hybrid gate: fresh atoms are pending and invisible
+    // to retrieval until the host approves or the TTL elapses.
+    status: "pending",
+    expiresAt: now + ATOM_PENDING_TTL_MS,
   };
 }
 

--- a/packages/cli/src/gateway/knowledge.ts
+++ b/packages/cli/src/gateway/knowledge.ts
@@ -15,6 +15,21 @@ import * as os from "node:os";
 import * as path from "node:path";
 import matter from "gray-matter";
 
+/**
+ * TTL hybrid approval state (v0.7.4):
+ *   - "pending"  — fresh atom, NOT visible to retrieval; auto-promotes
+ *                  to "approved" once `expiresAt` passes, or earlier
+ *                  via `pmk gateway atoms approve <id>`.
+ *   - "approved" — visible to retrieval; no expiry.
+ *
+ * Atoms written by older builds (no `status` field) are treated as
+ * "approved" on load so the v0.7.0–v0.7.3 corpus keeps working.
+ */
+export type KnowledgeAtomStatus = "pending" | "approved";
+
+/** How long a fresh atom sits in pending before auto-promoting. */
+export const ATOM_PENDING_TTL_MS = 24 * 60 * 60 * 1000;
+
 export interface KnowledgeAtom {
   id: string;
   createdAt: number;
@@ -34,6 +49,16 @@ export interface KnowledgeAtom {
     /** Slack user ID of whoever supplied the answer. */
     contributorUserId: string;
   };
+  /**
+   * Approval state — see {@link KnowledgeAtomStatus}. Optional at the
+   * type level so test fixtures + back-compat callers don't need
+   * boilerplate; saveAtom defaults a missing value to "approved".
+   * The extractor always sets "pending" explicitly, so production
+   * absorb-flow atoms are never accidentally approved-on-creation.
+   */
+  status?: KnowledgeAtomStatus;
+  /** Epoch ms when a pending atom auto-promotes; absent on approved. */
+  expiresAt?: number;
 }
 
 export function knowledgeRoot(): string {
@@ -101,6 +126,8 @@ interface AtomFrontMatter {
   summary?: string;
   tags: string[];
   source: { threadKey: string; contributorUserId: string };
+  status?: KnowledgeAtomStatus;
+  expiresAt?: number;
 }
 
 function renderAtomMarkdown(atom: KnowledgeAtom): string {
@@ -115,8 +142,10 @@ function renderAtomMarkdown(atom: KnowledgeAtom): string {
     question: atom.question,
     tags: atom.tags,
     source: atom.source,
+    status: atom.status,
   };
   if (atom.summary) data.summary = atom.summary;
+  if (atom.expiresAt !== undefined) data.expiresAt = atom.expiresAt;
   const body = [
     `# ${atom.question}`,
     "",
@@ -153,6 +182,10 @@ function parseAtomMarkdown(raw: string): KnowledgeAtom | undefined {
     parsed.content,
   );
   const answer = answerMatch ? answerMatch[1].trim() : parsed.content.trim();
+  // Back-compat: atoms written before v0.7.4 have no `status` field —
+  // they were already in the store, so treat them as approved.
+  const status: KnowledgeAtomStatus =
+    data.status === "pending" ? "pending" : "approved";
   return {
     id: data.id,
     createdAt: data.createdAt,
@@ -167,12 +200,20 @@ function parseAtomMarkdown(raw: string): KnowledgeAtom | undefined {
       threadKey: data.source?.threadKey ?? "",
       contributorUserId: data.source?.contributorUserId ?? "",
     },
+    status,
+    expiresAt: typeof data.expiresAt === "number" ? data.expiresAt : undefined,
   };
 }
 
 export function saveAtom(atom: KnowledgeAtom): string {
   // Sanitise on the way in — caller may pass an LLM-influenced scope.
-  const safe: KnowledgeAtom = { ...atom, scope: safeScope(atom.scope) };
+  // Default status to "approved" when caller didn't specify; production
+  // absorb-flow always sets "pending" explicitly via the extractor.
+  const safe: KnowledgeAtom = {
+    ...atom,
+    scope: safeScope(atom.scope),
+    status: atom.status ?? "approved",
+  };
   const dir = scopeDir(safe.scope);
   fs.mkdirSync(dir, { recursive: true });
   const file = atomFile(safe);
@@ -197,6 +238,7 @@ export function loadAtoms(opts: { scope?: string } = {}): KnowledgeAtom[] {
           return false;
         }
       });
+  const now = Date.now();
   for (const scope of scopes) {
     const dir = scopeDir(scope);
     if (!fs.existsSync(dir)) continue;
@@ -205,7 +247,28 @@ export function loadAtoms(opts: { scope?: string } = {}): KnowledgeAtom[] {
       try {
         const raw = fs.readFileSync(path.join(dir, f), "utf8");
         const atom = parseAtomMarkdown(raw);
-        if (atom) atoms.push(atom);
+        if (!atom) continue;
+        // Auto-promote pending atoms whose TTL has passed. Rewrite to
+        // disk so the side-effect is persistent (next load is a no-op).
+        if (
+          atom.status === "pending" &&
+          atom.expiresAt !== undefined &&
+          atom.expiresAt <= now
+        ) {
+          atom.status = "approved";
+          atom.expiresAt = undefined;
+          try {
+            fs.writeFileSync(
+              path.join(dir, f),
+              renderAtomMarkdown(atom),
+              "utf8",
+            );
+          } catch {
+            /* best-effort; if rewrite fails, in-memory promotion still
+               applies for this load() call. */
+          }
+        }
+        atoms.push(atom);
       } catch {
         /* skip corrupt */
       }
@@ -213,6 +276,76 @@ export function loadAtoms(opts: { scope?: string } = {}): KnowledgeAtom[] {
   }
   atoms.sort((a, b) => b.createdAt - a.createdAt);
   return atoms;
+}
+
+/**
+ * Approve a pending atom by id (or unique id-prefix). Returns the
+ * promoted atom on success, undefined if no match / multiple matches.
+ * If already approved, returns the existing atom unchanged.
+ */
+export function approveAtom(idOrPrefix: string): KnowledgeAtom | undefined {
+  const found = findAtomByPrefix(idOrPrefix);
+  if (!found) return undefined;
+  if (found.atom.status === "approved") return found.atom;
+  found.atom.status = "approved";
+  found.atom.expiresAt = undefined;
+  fs.writeFileSync(found.file, renderAtomMarkdown(found.atom), "utf8");
+  return found.atom;
+}
+
+/**
+ * Reject a pending or approved atom by id (or unique id-prefix).
+ * Deletes the file. Returns true on success, false when no match /
+ * multiple matches.
+ */
+export function rejectAtom(idOrPrefix: string): boolean {
+  const found = findAtomByPrefix(idOrPrefix);
+  if (!found) return false;
+  fs.unlinkSync(found.file);
+  return true;
+}
+
+interface AtomLocation {
+  atom: KnowledgeAtom;
+  file: string;
+}
+
+/**
+ * Resolve an atom by full id or unique prefix. Used by the CLI so the
+ * host doesn't have to type the full timestamp-suffixed id.
+ *
+ * Multi-match returns undefined — caller should ask the user to add
+ * more chars.
+ */
+export function findAtomByPrefix(idOrPrefix: string): AtomLocation | undefined {
+  const root = knowledgeRoot();
+  if (!fs.existsSync(root)) return undefined;
+  const matches: AtomLocation[] = [];
+  for (const scope of fs.readdirSync(root)) {
+    const dir = scopeDir(scope);
+    if (!fs.existsSync(dir)) continue;
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(dir);
+    } catch {
+      continue;
+    }
+    if (!stat.isDirectory()) continue;
+    for (const f of fs.readdirSync(dir)) {
+      if (!f.endsWith(".md")) continue;
+      const id = f.replace(/\.md$/, "");
+      if (id !== idOrPrefix && !id.startsWith(idOrPrefix)) continue;
+      try {
+        const raw = fs.readFileSync(path.join(dir, f), "utf8");
+        const atom = parseAtomMarkdown(raw);
+        if (atom) matches.push({ atom, file: path.join(dir, f) });
+      } catch {
+        /* skip */
+      }
+    }
+  }
+  if (matches.length !== 1) return undefined;
+  return matches[0];
 }
 
 /**
@@ -231,7 +364,12 @@ export function searchAtoms(
   opts: { scope?: string; limit?: number } = {},
 ): KnowledgeAtom[] {
   const limit = opts.limit ?? 3;
-  const atoms = loadAtoms({ scope: opts.scope });
+  // Pending atoms are deliberately invisible to retrieval — that's the
+  // whole point of the TTL gate. They become visible after auto-promote
+  // (loadAtoms rewrites them) or after manual approval.
+  const atoms = loadAtoms({ scope: opts.scope }).filter(
+    (a) => a.status === "approved",
+  );
   if (atoms.length === 0) return [];
   const tokens = tokenize(query);
   if (tokens.length === 0) return [];

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -590,12 +590,16 @@ export class SlackAdapter {
     }
     try {
       const file = saveAtom(atom);
-      this.onLog(`absorbed knowledge atom → ${file}`);
+      this.onLog(`absorbed knowledge atom (pending) → ${file}`);
+      const idShort = atom.id.split("-").slice(0, 2).join("-");
       await this.web.chat
         .postMessage({
           channel: channelId,
           thread_ts: threadTs,
-          text: `:books: pmk 已吸收這份補充（標籤：${atom.tags.join(", ") || "—"}）。下次有人問類似問題會直接帶進來。`,
+          text:
+            `:hourglass_flowing_sand: pmk 已收下這份補充（標籤：${atom.tags.join(", ") || "—"}），暫存為 *pending*，` +
+            `24 小時後自動生效，期間不會被其他查詢抓到。\n` +
+            `要立即生效或刪除：\`pmk gateway atoms approve ${idShort}\` / \`pmk gateway atoms reject ${idShort}\``,
         })
         .catch(() => {});
     } catch (err) {

--- a/packages/cli/test/gateway.test.ts
+++ b/packages/cli/test/gateway.test.ts
@@ -51,10 +51,12 @@ import {
   PROMPT_GATEWAY_DM_TECH,
 } from "@pmk/shared";
 import {
+  approveAtom,
   formatAtomsForInjection,
   generateAtomId,
   knowledgeRoot,
   loadAtoms,
+  rejectAtom,
   safeScope,
   saveAtom,
   searchAtoms,
@@ -885,6 +887,167 @@ describe("knowledge store", () => {
     assert.match(atoms[0].question, /quotes/);
     assert.match(atoms[0].answer, /Line one/);
     assert.match(atoms[0].answer, /Line three/);
+  });
+});
+
+describe("atom TTL approval", () => {
+  let tmpHome: string;
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-atom-ttl-"));
+    process.env.HOME = tmpHome;
+  });
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+  });
+
+  it("pending atoms are excluded from searchAtoms", () => {
+    saveAtom({
+      id: generateAtomId("pending widget"),
+      createdAt: Date.now(),
+      scope: "erp",
+      question: "How is widget configured?",
+      answer: "Pending answer about widget setup.",
+      summary: "Widget pending summary.",
+      tags: ["widget"],
+      source: { threadKey: "T1", contributorUserId: "U_IT1" },
+      status: "pending",
+      expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+    });
+    const hits = searchAtoms("widget", { limit: 5 });
+    assert.equal(hits.length, 0);
+  });
+
+  it("approved atoms are visible to searchAtoms", () => {
+    saveAtom({
+      id: generateAtomId("approved widget"),
+      createdAt: Date.now(),
+      scope: "erp",
+      question: "How is widget configured?",
+      answer: "Approved answer about widget setup.",
+      summary: "Widget summary.",
+      tags: ["widget"],
+      source: { threadKey: "T1", contributorUserId: "U_IT1" },
+      status: "approved",
+    });
+    const hits = searchAtoms("widget", { limit: 5 });
+    assert.equal(hits.length, 1);
+  });
+
+  it("legacy atoms (no status field on disk) are treated as approved", () => {
+    // Simulate v0.7.3 atom: write a markdown file without `status`
+    // in the front-matter and ensure searchAtoms still finds it.
+    const dir = path.join(knowledgeRoot(), "erp");
+    fs.mkdirSync(dir, { recursive: true });
+    const id = generateAtomId("legacy widget");
+    fs.writeFileSync(
+      path.join(dir, `${id}.md`),
+      `---\nid: ${id}\ncreatedAt: 1700000000000\nscope: erp\nquestion: How is widget legacy?\ntags: [widget]\nsource:\n  threadKey: T-old\n  contributorUserId: U_OLD\n---\n# How is widget legacy?\n\n## Answer\n\nLegacy answer about widget.\n`,
+    );
+    const hits = searchAtoms("widget", { limit: 5 });
+    assert.equal(hits.length, 1);
+    assert.match(hits[0].question, /legacy/);
+  });
+
+  it("loadAtoms auto-promotes pending atoms past expiresAt", () => {
+    const id = generateAtomId("expired pending");
+    saveAtom({
+      id,
+      createdAt: Date.now() - 25 * 60 * 60 * 1000,
+      scope: "erp",
+      question: "expired question",
+      answer: "expired answer",
+      summary: "expired summary",
+      tags: ["expired"],
+      source: { threadKey: "T1", contributorUserId: "U_IT1" },
+      status: "pending",
+      expiresAt: Date.now() - 60_000, // already expired
+    });
+    // First load triggers auto-promote.
+    loadAtoms({ scope: "erp" });
+    // Second load reads the rewritten atom — should now be approved
+    // and visible to retrieval.
+    const hits = searchAtoms("expired", { limit: 5 });
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0].status, "approved");
+    assert.equal(hits[0].expiresAt, undefined);
+  });
+
+  it("approveAtom by id-prefix promotes pending → approved", () => {
+    const id = generateAtomId("approve me");
+    saveAtom({
+      id,
+      createdAt: Date.now(),
+      scope: "erp",
+      question: "approve me?",
+      answer: "yes",
+      summary: "promote test",
+      tags: ["t"],
+      source: { threadKey: "T1", contributorUserId: "U1" },
+      status: "pending",
+      expiresAt: Date.now() + 60_000,
+    });
+    // Use a unique short prefix from the id.
+    const prefix = id.slice(0, 12);
+    const promoted = approveAtom(prefix);
+    assert.ok(promoted);
+    assert.equal(promoted?.status, "approved");
+    assert.equal(promoted?.expiresAt, undefined);
+    // After approve, retrieval finds it.
+    const hits = searchAtoms("approve", { limit: 5 });
+    assert.equal(hits.length, 1);
+  });
+
+  it("rejectAtom by id-prefix deletes the file", () => {
+    const id = generateAtomId("reject me");
+    saveAtom({
+      id,
+      createdAt: Date.now(),
+      scope: "erp",
+      question: "reject me?",
+      answer: "no",
+      summary: "reject test",
+      tags: ["t"],
+      source: { threadKey: "T1", contributorUserId: "U1" },
+      status: "pending",
+      expiresAt: Date.now() + 60_000,
+    });
+    const ok = rejectAtom(id.slice(0, 12));
+    assert.equal(ok, true);
+    const atoms = loadAtoms();
+    assert.equal(atoms.length, 0);
+  });
+
+  it("approveAtom returns undefined when prefix matches multiple atoms", () => {
+    // Two atoms whose ids share a prefix because generateAtomId uses
+    // a timestamp; force collision by using identical timestamps.
+    const sharedPrefix = "20990101T0000000-aaaa";
+    saveAtom({
+      id: `${sharedPrefix}-one`,
+      createdAt: Date.now(),
+      scope: "erp",
+      question: "one",
+      answer: "a",
+      summary: "s",
+      tags: [],
+      source: { threadKey: "T1", contributorUserId: "U1" },
+      status: "pending",
+      expiresAt: Date.now() + 60_000,
+    });
+    saveAtom({
+      id: `${sharedPrefix}-two`,
+      createdAt: Date.now(),
+      scope: "erp",
+      question: "two",
+      answer: "b",
+      summary: "s",
+      tags: [],
+      source: { threadKey: "T1", contributorUserId: "U1" },
+      status: "pending",
+      expiresAt: Date.now() + 60_000,
+    });
+    const r = approveAtom(sharedPrefix);
+    assert.equal(r, undefined);
   });
 });
 


### PR DESCRIPTION
Closes #14. Implements the option-C TTL hybrid chosen for atom approval.

## What changes

Fresh atoms now enter the store as \`status: "pending"\` with \`expiresAt: now + 24h\`. They are **invisible to retrieval** during this window — \`searchAtoms()\` filters out anything with \`status: "pending"\`. After 24h or on the next \`loadAtoms()\`, the atom auto-promotes to \`approved\` (file rewritten in place; idempotent on subsequent loads).

Host can approve early or reject outright via the new CLI:

\`\`\`
pmk gateway atoms list [--all|--pending|--approved] [--scope <name>]
pmk gateway atoms show <id-or-prefix>
pmk gateway atoms approve <id-or-prefix>
pmk gateway atoms reject <id-or-prefix>
\`\`\`

ID prefix matching: any unique prefix resolves; ambiguous prefixes return an error asking for more chars.

## Slack copy

Absorb confirmation in-thread changes from:

> :books: pmk 已吸收這份補充（標籤：…）。下次有人問類似問題會直接帶進來。

to:

> :hourglass_flowing_sand: pmk 已收下這份補充（標籤：…），暫存為 *pending*，24 小時後自動生效，期間不會被其他查詢抓到。
> 要立即生效或刪除：\`pmk gateway atoms approve <id-prefix>\` / \`pmk gateway atoms reject <id-prefix>\`

## Back-compat

- v0.7.0–v0.7.3 atoms on disk have no \`status\` field. \`parseAtomMarkdown\` treats missing as \`"approved"\` so the existing corpus keeps working without rewrites.
- \`saveAtom\` defaults \`status\` to \`"approved"\` when caller doesn't specify, so test fixtures and any future non-extractor caller stay simple. The extractor always sets \`"pending"\` explicitly, so production absorb-flow atoms are never accidentally approved on creation.

## Tests

141 → 148 (+7). Covers:

- pending excluded from \`searchAtoms\`
- approved included
- legacy atoms (no status on disk) treated as approved
- auto-promotion past \`expiresAt\` (file rewritten with status=approved, expiresAt cleared)
- \`approveAtom\` by id-prefix
- \`rejectAtom\` deletes file
- multi-match prefix returns undefined

Live-smoked against the dogfood atom from 2026-04-28: \`pmk gateway atoms list\` and \`atoms show <prefix>\` both work.

## Test plan

- [ ] Trigger an escalate flow → bot \`@\`-mentions IT → IT replies → bot posts hourglass message with id prefix + approve/reject hint
- [ ] \`pmk gateway atoms list\` shows pending atom; \`--approved\` doesn't
- [ ] Re-ask same question while pending → bot does NOT use the atom (PKB-only answer)
- [ ] \`pmk gateway atoms approve <prefix>\` → status flips, retrieval starts using it
- [ ] \`pmk gateway atoms reject <prefix>\` → file deleted, gone from list
- [ ] Manually edit an atom's \`expiresAt\` to a past timestamp → next load auto-promotes (verify by reading the file)
- [ ] Existing v0.7.3 atoms still appear as \`approved\` in \`atoms list\`

## Out of scope

- Slack-side reactions (✅/❌ on bot's confirmation message). Could layer on later as additional approve/reject affordance without changing storage; not strictly needed since the CLI covers it.
- Atom edit before approve. Hand-edit the .md file works for now; could add \`atoms edit <id>\` if hosts find themselves doing this often.