### PR TITLE
docs: cover v0.7.1-v0.7.4 gateway surface in README + getting-started

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,28 @@ npm start
 npm run cli:build                  # builds packages/cli → dist
 npx pmk --help                     # or: npm run pmk -- --help
 
-# A few of the verbs:
-npx pmk propose "weekly digest"    # PRD-authoring interview → docs/prds/*.md
+# Doc-authoring + investigation verbs
+npx pmk propose "weekly digest"              # PRD interview → docs/prds/*.md
 npx pmk ask "how does our auth flow work?"   # RAG over your indexed docs
 npx pmk case open prod-checkout-503          # long-lived bug investigation file
-npx pmk gateway init                          # Slack bridge: paste tokens once
-npx pmk gateway start                         # run the bridge in the foreground
+
+# Slack gateway (v0.7) — host-run bridge so PMs/stakeholders DM pmk in Slack
+npx pmk gateway init                          # one-time: paste Slack tokens + mra workspace path
+npx pmk gateway start                         # run the bridge (foreground)
+npx pmk gateway status                        # configured? running? mra workspace ok?
+npx pmk gateway audience set <userId> biz     # tech / biz / exec tone per user
+npx pmk gateway escalation add <repo> <userId>  # IT/domain contact pool for `escalate`
+npx pmk gateway atoms list --pending          # absorbed knowledge atoms awaiting promotion
+npx pmk gateway atoms approve <id-prefix>     # promote a pending atom to retrieval-visible
 ```
 
-The CLI delegates code-intelligence work to [**multi-repo-agent (mra)**](https://github.com/hanfour/multi-repo-agent) when present — `pmk ingest mra:--all` loads PKB summaries for every repo in the workspace, and the gateway can auto-trigger `mra ask` when a Slack question requires deep code search. mra is optional; pmk degrades gracefully when it's not installed.
+The CLI delegates code-intelligence work to [**multi-repo-agent (mra)**](https://github.com/hanfour/multi-repo-agent) when present. The gateway specifically uses three integrated mechanisms:
+
+- **PKB seed** — first DM/channel turn loads the `mra:--all` summary set so the model grounds answers in real module names from turn one.
+- **Auto-mra-ask** — when PKB isn't enough, the model emits a fenced `mra-ask` block; pmk runs `mra ask <repo>` and feeds the result back for synthesis.
+- **Escalate → absorb → retrieval** — when neither PKB nor mra-ask suffices, the model emits an `escalate` block; pmk @-mentions a registered IT contact in the thread, absorbs their reply as a `KnowledgeAtom`, and retrieves it (after a 24h pending TTL or explicit `pmk gateway atoms approve`) for future similar questions.
+
+mra is optional; pmk degrades gracefully when it's not installed (mra-ask becomes a no-op, the model falls back to PKB-only).
 
 ### C. Desktop app
 
@@ -88,6 +101,20 @@ You don't have to take the whole monorepo. Pick the layer that matches your need
 
 Read [Getting Started](https://hanfour.github.io/pm-workspace-kit/docs/getting-started) to set up front-matter on your first PRD; the [Confluence sync guide](https://hanfour.github.io/pm-workspace-kit/docs/guides/confluence-sync) covers the Confluence loop.
 
+## Latest release: v0.7.4 (2026-04-28)
+
+The v0.7.x series matured the Slack gateway through real dogfood. Highlights:
+
+| Release | Highlight |
+|---|---|
+| [`v0.7.0`](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.7.0) | Gateway baseline (Socket Mode, audience prompts, escalate/absorb/retrieval scaffolding) |
+| [`v0.7.1`](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.7.1) | Prompt override fix — without it, mra-ask / escalate directives silently never fired |
+| [`v0.7.2`](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.7.2) | Explicit `mraWorkspace` config, mra stderr surfaced, `pmk gateway escalation add default` positional |
+| [`v0.7.3`](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.7.3) | Startup mra validation, `runMraAsk` retry-once on transient flake, helpers extracted |
+| [`v0.7.4`](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.7.4) | Atom approval **TTL hybrid** — fresh atoms enter `pending` for 24h, auto-promote, or `pmk gateway atoms approve <id>` early |
+
+The full knowledge loop — *PM asks in Slack → bot tries PKB → escalates to mra-ask → escalates to a human IT contact → absorbs the answer → next person who asks gets the cached answer* — works end-to-end. Tests: 75 → **148** in the v0.7 series.
+
 ## Design principles
 
 1. **Git is the single source of truth.** Everything worth arguing about lives in markdown with front-matter.
@@ -97,6 +124,7 @@ Read [Getting Started](https://hanfour.github.io/pm-workspace-kit/docs/getting-s
 5. **Migration is a protocol, not a heroic effort.** The Strangler Fig template gives you four named stages and quantitative exit criteria.
 6. **Verbs over commands.** `pmk` exposes PM workflows as named verbs (`propose`, `case`, `gateway`); each one is a structured conversation, not a flag soup.
 7. **Code intelligence is delegated.** The CLI doesn't grep; it leans on `mra` for repo-scale code understanding so prompts stay grounded in real module names.
+8. **Knowledge needs a half-life.** Absorbed atoms enter a 24h pending state; the host can approve early or let the timer run. Mistakes get a window to be caught before they propagate via retrieval.
 
 ## GitHub Pages
 

--- a/apps/docs/docs/getting-started.md
+++ b/apps/docs/docs/getting-started.md
@@ -134,11 +134,33 @@ npx pmk ask "how does our auth flow work?"
 If you want stakeholders to drive `pmk` from Slack instead of a terminal:
 
 ```bash
-npx pmk gateway init    # one-time: paste Slack app + bot tokens
+npx pmk gateway init    # one-time: paste Slack app + bot tokens, set mra workspace path
 npx pmk gateway start   # foreground bridge — leave this running
 ```
 
 The gateway is a host-run Slack bridge (Socket Mode), not a SaaS bot — your tokens and your code stay on your machine. See [ADR-0006: pmk gateway](./adr/0006-pmk-gateway-slack.md) for the design rationale.
+
+### v0.7 gateway features
+
+The v0.7.x series matured the gateway through real Slack dogfood. Key surface beyond `init` / `start` / `status` / `stats`:
+
+```bash
+# Audience switching (tech / biz / exec) — same answers, different tone
+pmk gateway audience set <userId> biz       # this user gets business-meaning-first replies
+pmk gateway audience default tech           # default for everyone else
+
+# Escalation pool — who pmk @-mentions when neither PKB nor mra-ask can answer
+pmk gateway escalation add <repo> <userId>  # repo-specific contact
+pmk gateway escalation add default <userId> # fallback contact
+
+# Knowledge atoms — IT replies absorbed for retrieval after a 24h TTL gate
+pmk gateway atoms list --pending            # awaiting promotion
+pmk gateway atoms show <id-prefix>          # full content
+pmk gateway atoms approve <id-prefix>       # promote early (skip the TTL wait)
+pmk gateway atoms reject <id-prefix>        # delete
+```
+
+The full gateway flow — *PM asks → bot tries PKB → asks mra → escalates to a human → absorbs the answer → retrieves it for next person* — is documented in [PRD-2026-0005](./prds/2026-04-27-pmk-gateway-prd.md) and the v0.7 [release notes](https://github.com/hanfour/pm-workspace-kit/releases).
 
 ## What next
 

--- a/apps/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/apps/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/getting-started.md
@@ -113,11 +113,33 @@ npx pmk ask "how does our auth flow work?"
 若希望利害關係人直接從 Slack 驅動 `pmk`，而不是進終端機：
 
 ```bash
-npx pmk gateway init    # 一次性：貼上 Slack App + Bot tokens
+npx pmk gateway init    # 一次性：貼上 Slack tokens + 設定 mra workspace 路徑
 npx pmk gateway start   # 前景跑 bridge — 讓它一直跑
 ```
 
 Gateway 是 host 自架的 Slack bridge（Socket Mode），不是 SaaS bot — token 與你的 code 都不離開你自己的機器。設計動機請見 [ADR-0006: pmk gateway](./adr/0006-pmk-gateway-slack.md)。
+
+### v0.7 gateway 表面
+
+v0.7.x 透過實際 Slack dogfood 把 gateway 磨成熟。在 `init` / `start` / `status` / `stats` 之外的關鍵指令：
+
+```bash
+# Audience 切換（tech / biz / exec）— 同樣答案、不同口吻
+pmk gateway audience set <userId> biz       # 這個人收到的是商業語意優先的回覆
+pmk gateway audience default tech           # 其他人的預設
+
+# Escalation pool — PKB 與 mra-ask 都答不出時，pmk 要 @ 誰
+pmk gateway escalation add <repo> <userId>  # repo 特定的人選
+pmk gateway escalation add default <userId> # 沒指定 repo 時的後援
+
+# Knowledge atoms — IT 回覆吸收後，24h TTL 才會被檢索
+pmk gateway atoms list --pending            # 待生效清單
+pmk gateway atoms show <id-prefix>          # 看完整內容
+pmk gateway atoms approve <id-prefix>       # 提前生效（不等 24h）
+pmk gateway atoms reject <id-prefix>        # 刪除
+```
+
+完整 gateway 流程 — *PM 在 Slack 問 → bot 看 PKB → 不夠就問 mra → 仍不夠就 @ 真人 → 吸收答案 → 下一個人問同樣問題直接命中* — 見 [PRD-2026-0005](./prds/2026-04-27-pmk-gateway-prd.md) 與 v0.7 系列 [release notes](https://github.com/hanfour/pm-workspace-kit/releases)。
 
 ## 接下來
 


### PR DESCRIPTION
README and getting-started docs were last updated for the v0.7.0 baseline. Four releases later (v0.7.1-v0.7.4) the CLI surface expanded substantially without any docs catching up — \`pmk gateway audience\`, \`escalation\`, \`atoms\` were nowhere on the public-facing site.

## Changes

- **README.md**
  - CLI section now lists the gateway sub-verbs (status / audience / escalation / atoms) with one-line descriptions
  - Three integrated mra mechanisms named (PKB seed, auto-mra-ask, escalate→absorb→retrieval)
  - "Latest release: v0.7.4" section linking each tag's GitHub release notes
  - New design principle #8: "Knowledge needs a half-life" (names the TTL approval gate as a deliberate stance)
- **apps/docs/docs/getting-started.md** (+ zh-TW mirror)
  - "v0.7 gateway features" subsection with sample invocations of audience / escalation / atoms commands
  - Notes the \`init\` flow now also asks for the mra workspace path
  - Links to PRD-2026-0005 + release notes for context

## Build

Docusaurus production build green (\`npm run build && npm run serve\`). The LICENSE.txt broken-link warnings are pre-existing — separate issue.

## Auto-deploy

GitHub Pages workflow [\`deploy.yml\`](https://github.com/hanfour/pm-workspace-kit/blob/main/.github/workflows/deploy.yml) triggers on \`apps/docs/**\` paths; this PR will rebuild + redeploy on merge.