### PR TITLE
docs: gateway lifecycle deep-dive + Mermaid + CHANGELOG + sidebar category

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The v0.7.x series matured the Slack gateway through real dogfood. Highlights:
 | [`v0.7.3`](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.7.3) | Startup mra validation, `runMraAsk` retry-once on transient flake, helpers extracted |
 | [`v0.7.4`](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.7.4) | Atom approval **TTL hybrid** — fresh atoms enter `pending` for 24h, auto-promote, or `pmk gateway atoms approve <id>` early |
 
-The full knowledge loop — *PM asks in Slack → bot tries PKB → escalates to mra-ask → escalates to a human IT contact → absorbs the answer → next person who asks gets the cached answer* — works end-to-end. Tests: 75 → **148** in the v0.7 series.
+The full knowledge loop — *PM asks in Slack → bot tries PKB → escalates to mra-ask → escalates to a human IT contact → absorbs the answer → next person who asks gets the cached answer* — works end-to-end. Tests: 75 → **148** in the v0.7 series. Walk through it phase-by-phase in the [Gateway lifecycle](https://hanfour.github.io/pm-workspace-kit/docs/gateway/lifecycle) deep-dive, or skim the release-by-release [changelog](https://hanfour.github.io/pm-workspace-kit/docs/changelog).
 
 ## Design principles
 

--- a/apps/docs/docs/changelog.md
+++ b/apps/docs/docs/changelog.md
@@ -1,0 +1,129 @@
+---
+sidebar_position: 99
+---
+
+# Changelog
+
+All notable changes to **pm-workspace-kit** are documented here.
+
+The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each release also has a longer narrative on [GitHub Releases](https://github.com/hanfour/pm-workspace-kit/releases) with rationale, dogfood notes, and test plans.
+
+## [v0.7.4] — 2026-04-28 — atom approval (TTL hybrid)
+
+[GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.7.4) · PR [#15](https://github.com/hanfour/pm-workspace-kit/pull/15) · closes [#14](https://github.com/hanfour/pm-workspace-kit/issues/14)
+
+### Added
+
+- `KnowledgeAtom` gains `status: "pending" | "approved"` and `expiresAt?: number`. Fresh atoms enter `pending` with a 24h TTL.
+- `pmk gateway atoms` CLI: `list [--all|--pending|--approved] [--scope <name>]`, `show <id-or-prefix>`, `approve <id-or-prefix>`, `reject <id-or-prefix>`. ID prefix matching: any unique prefix resolves.
+- `loadAtoms()` auto-promotes pending atoms whose `expiresAt` has passed (idempotent on subsequent loads).
+
+### Changed
+
+- `searchAtoms()` now filters out `status: "pending"` atoms — pending content is invisible to retrieval until promoted.
+- Slack absorb confirmation message changed from ":books: 已吸收..." to ":hourglass_flowing_sand: 暫存為 pending, 24h 後自動生效..." with id prefix + approve/reject CLI hints.
+
+### Compatibility
+
+Atoms written by v0.7.0–v0.7.3 have no `status` field on disk; the parser treats missing as `approved` so the existing corpus keeps working without rewrites.
+
+### Tests
+
+141 → 148 (+7 covering pending exclusion, auto-promotion, approve/reject, prefix collision).
+
+## [v0.7.3] — 2026-04-28 — gateway dogfood follow-ups (round 2)
+
+[GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.7.3) · PR [#13](https://github.com/hanfour/pm-workspace-kit/pull/13)
+
+### Added
+
+- Startup-time `mraWorkspace` validation: `runGateway()` logs the workspace state at boot — `mra workspace: <path>`, a stale-warn, or `not configured … falling back to launch-cwd walk`. Stale paths surface at startup instead of at first DM.
+- `MraAskResult.attempts` field; `runMraAsk` retries once on transient failures (no stderr, not timeout, not binary-missing). Matches the 2026-04-28 dogfood signature where a manual retry succeeded.
+- New `packages/cli/src/gateway/messaging.ts` — `buildIngestSeed`, `buildMraFailureMessage`, `buildMraSuccessMessage`, `truncate` extracted from `slack/index.ts` for testability.
+
+### Tests
+
+132 → 141 (+9 covering helper formatting, retry attempts, startup hooks).
+
+## [v0.7.2] — 2026-04-28 — gateway dogfood follow-ups (round 1)
+
+[GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.7.2) · PRs [#11](https://github.com/hanfour/pm-workspace-kit/pull/11), [#12](https://github.com/hanfour/pm-workspace-kit/pull/12) · closes [#8](https://github.com/hanfour/pm-workspace-kit/issues/8), [#9](https://github.com/hanfour/pm-workspace-kit/issues/9), [#10](https://github.com/hanfour/pm-workspace-kit/issues/10)
+
+### Added
+
+- `GatewayConfig.mraWorkspace?: string` — explicit absolute path to the workspace dir holding `.collab/repos.json`. Lets `pmk gateway start` run from any cwd. `PMK_MRA_WORKSPACE` env override available for CI/containers.
+- `mraDoctor({workspace?})` — explicit workspace wins when set AND valid; stale config returns a clear hint instead of silently falling through to cwd walk.
+- `pmk gateway init` prompts for the path (auto-suggests detected workspace from cwd).
+- `pmk gateway status` shows configured path with `(ok)` / `(no .collab/repos.json)` marker.
+
+### Changed
+
+- Failed `mra ask` now surfaces stderr / partial stdout in both the gateway host log AND the LLM's apology context (via `mra-stderr` / `mra-partial-stdout` fenced blocks). The model is instructed to cite the specific cause instead of a generic "unknown".
+- `pmk gateway escalation add/remove` accepts the canonical positional `default` (no dashes); legacy `--default` form still works but emits a deprecation warning.
+- Slack userId validation in CLI (`^[UW][A-Z0-9]{2,}$`) rejects typos like `@hanfour` early.
+
+### Tests
+
+119 → 132 (+13 covering config back-fill, env override, mraDoctor branches, escalate parsing, audience picker, runMraAsk hard-failure).
+
+## [v0.7.1] — 2026-04-27 — gateway prompt override
+
+[GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.7.1) · PR [#7](https://github.com/hanfour/pm-workspace-kit/pull/7)
+
+### Fixed
+
+- **Critical**: live dogfood revealed the v0.7 directive layer (`mra-ask`, `escalate`) was effectively dead. `BASE_RULES` (inherited by all gateway-DM prompts) opens with "you have NO tools, NO skills…" which contradicts the `GATEWAY_TOOLBOX` rules. Models defaulted to the safer no-tools rule and refused to emit directives.
+- Fix: prepend an explicit override at the top of `GATEWAY_TOOLBOX` re-permitting the directive blocks for gateway-DM context.
+
+Without this fix all the v0.7 plumbing worked in unit tests but the LLM never started the chain — the bot would say "I don't have access to the code" exactly when it should have asked pmk to run mra-ask.
+
+## [v0.7.0] — 2026-04-27 — pmk gateway (Slack bridge, Socket Mode)
+
+[GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.7.0) · PR [#6](https://github.com/hanfour/pm-workspace-kit/pull/6) · ADR-0006, PRD-2026-0005
+
+### Added
+
+- **`pmk gateway`** CLI verb with `init / start / status / stats` plus the audience and escalation pool subcommands. Host runs the bridge in the foreground; users DM or `@`-mention `@pmk` from their existing Slack workspace.
+- **Slack Socket Mode adapter** (`@slack/socket-mode` v2). No public URL, no tunnel, no SaaS. Heartbeat-driven offline UX with `:zzz:` / `:wave:` broadcasts.
+- **DM personal sessions + channel-shared cases** persisted under `~/.pmk/gateway/slack/`.
+- **Per-thread session isolation** — top-level DMs share a "main" session, each Slack thread gets its own.
+- **Channel free-chat fallback** when no active case (with PKB grounding instead of refusing).
+- **Audience-aware prompts** (`tech` / `biz` / `exec`) — same answers, different tone. Per-user override.
+- **Auto-mra-ask round** — model emits a fenced `mra-ask` block, pmk runs `mra ask <repo>`, synthesises with the result.
+- **Escalate → absorb → retrieval** — model emits `escalate`, pmk `@`-mentions an IT contact, absorbs their reply as a `KnowledgeAtom` (`~/.pmk/knowledge/<scope>/<slug>.md`), retrieves it for future similar questions.
+- **Slash commands** inside Slack: `/pmk open|show|close|cases|help`.
+- **Honest offline UX** — heartbeat file ticked every 30s; on stale (> 60s) or graceful shutdown, broadcasts presence change to recent conversations.
+
+### Security / hardening
+
+- **Path traversal sandbox** for atom storage — `safeScope()` strips everything outside `[a-zA-Z0-9_-]` at every entry point. Prompt-injected `repo: ../../tmp/foo` lands as `tmp-foo`, never escapes `~/.pmk/knowledge/`.
+- **Bounded envelope LRU** (2 000 entries) prevents memory growth on long-running hosts.
+- **gray-matter** for atom front-matter — newlines / quotes / backslashes don't corrupt files.
+- **Race fix**: pending-escalation marker claimed before LLM extraction (no duplicate atoms on fast IT replies).
+- **Timeouts** — extractor + mra-ask both capped at 120s.
+
+### Tests
+
+75 → 119 (+44 covering thread isolation, audience picker, escalate parser, atom round-trip, ranked search).
+
+## [v0.6] — 2026-04 — pmk case (long-lived bug investigation files)
+
+PR [#5](https://github.com/hanfour/pm-workspace-kit/pull/5)
+
+`pmk case` verb — symptom / hypotheses / evidence / next-questions persisted across sessions. The `case-update` fenced-block protocol becomes the foundation reused by v0.7's gateway flow.
+
+## [v0.5] — 2026-04 — pmk × mra bridge
+
+PRs [#2](https://github.com/hanfour/pm-workspace-kit/pull/2), [#3](https://github.com/hanfour/pm-workspace-kit/pull/3), [#4](https://github.com/hanfour/pm-workspace-kit/pull/4) · ADR-0005, PRD-2026-0004
+
+`pmk ingest mra:--all` and `pmk explore <repo>` — code-intelligence work delegated to [multi-repo-agent](https://github.com/hanfour/multi-repo-agent) instead of growing pmk's own grep.
+
+## [v0.4] — 2026-04 — desktop app + full CLI
+
+PR [#1](https://github.com/hanfour/pm-workspace-kit/pull/1)
+
+Electron desktop app (chat panel + worktree manager). CLI verbs M0-M7: `propose / draft / discuss / ask / debug / index / resume / worktree / tdd`.
+
+## [v0.1–v0.3] — 2026-03 to 2026-04 — initial templates + traceability
+
+Front-matter validation, Mermaid dependency graph, ADR / handoff / north-star templates, Confluence sync, Docusaurus docs site (EN + zh-TW). See [git log](https://github.com/hanfour/pm-workspace-kit/commits/main) for the early PRs.

--- a/apps/docs/docs/gateway/lifecycle.md
+++ b/apps/docs/docs/gateway/lifecycle.md
@@ -1,0 +1,200 @@
+---
+sidebar_position: 1
+---
+
+# Gateway lifecycle
+
+How a single Slack DM walks through `pmk gateway` end-to-end. This page is the integrated story; the design rationale lives in [ADR-0006](../adr/0006-pmk-gateway-slack.md) and the v0.7.0 surface contract in [PRD-2026-0005](../prds/2026-04-27-pmk-gateway-prd.md). Each numbered phase in the diagram below is described in the section of the same name.
+
+## The flow
+
+```mermaid
+flowchart TD
+    A([User DMs / @-mentions pmk in Slack]) --> B{1. Inbound dispatch}
+    B -->|DM| C[2. Per-user / per-thread session]
+    B -->|Channel mention| C
+    C --> D[3. PKB seed on first turn]
+    D --> E[4. Retrieval prefix from approved atoms]
+    E --> F[5. LLM call with audience-picked prompt]
+    F --> G{Model emits a directive?}
+    G -->|none| H([Reply in thread])
+    G -->|mra-ask| I[6. mra ask subprocess]
+    I --> I2[Synthesise with mra-result]
+    I2 --> H
+    G -->|escalate| J[7. Tag IT in thread]
+    J --> K[8. Wait for IT reply in same thread]
+    K --> L[9. LLM extractor → KnowledgeAtom]
+    L --> M[(.pmk/knowledge/&lt;scope&gt;/&lt;id&gt;.md<br/>status: pending<br/>expiresAt: now + 24h)]
+    M --> N{10. Approval gate}
+    N -->|24h passes| O[Auto-promote → approved]
+    N -->|pmk gateway atoms approve| O
+    N -->|pmk gateway atoms reject| P[Delete file]
+    O --> E
+
+    style M fill:#fff5e6
+    style O fill:#e8f5e8
+    style P fill:#ffe8e8
+```
+
+## 1. Inbound dispatch
+
+`SlackAdapter` subscribes to two Slack Socket Mode events:
+
+- **`message`** — fires for every DM (`im.history` scope). The handler ignores messages from the bot itself and from anyone on `cfg.blocklist`.
+- **`app_mention`** — fires when `@pmk` appears in a channel (`app_mentions:read` scope). Channel mentions without an active case fall through to the same free-chat path as DMs.
+
+Both handlers ack the envelope **before** the LLM round-trip starts (Slack retries unacked events within ~3s, faster than any LLM reply). Envelope IDs are deduplicated via a bounded LRU so retries can never trigger the same turn twice.
+
+## 2. Per-user / per-thread session isolation
+
+Sessions are persisted on the host machine:
+
+```
+~/.pmk/gateway/slack/users/<userId>/session.json                    # main DM
+~/.pmk/gateway/slack/users/<userId>/threads/<threadTs>/session.json # in-thread reply
+~/.pmk/gateway/slack/channels/<channelId>/main.chat-session.json    # channel main
+~/.pmk/gateway/slack/channels/<channelId>/threads/<ts>/...          # channel thread
+```
+
+A reply that lives in a Slack thread gets its own session file — context from thread A never bleeds into thread B. Top-level DMs share one "main" session per user (back-compat with v0.7.0 layout).
+
+## 3. PKB seed on first turn
+
+The very first turn of any session, if `cfg.defaultIngest` is set (typically `mra:--all`), the gateway packages the four base PKB docs of every repo with a PKB directory and prepends them as a synthetic `(user → assistant)` turn pair:
+
+```
+[user]      "我先把 workspace 的 PKB context 給你 (請當作 ground truth ...) ..."
+[assistant] "了解，已載入 workspace PKB context。請繼續。"
+```
+
+This is what lets the model say *"app/services/sales_budget_performance/ exists; the budget worker chains call this path"* on turn one without any retrieval round-trip.
+
+## 4. Retrieval prefix from approved atoms
+
+On every turn (not just the first), `searchAtoms(userText, { limit: 3 })` looks up the approved knowledge atoms most relevant to what the user just typed. If any match, they're prepended to the LLM call as **ephemeral** messages — they don't get persisted to `session.messages`, so old retrieved answers don't keep stacking up turn after turn.
+
+Pending atoms are deliberately invisible here. See [Phase 10](#10-approval-gate).
+
+## 5. Audience-picked prompt
+
+The system prompt for the LLM call comes from `pickGatewayPrompt(audience)` where `audience = pickAudience(cfg, userId)`. Three flavours, all sharing a `GATEWAY_TOOLBOX` suffix that defines the `mra-ask` and `escalate` directives:
+
+| Audience | Tone |
+|---|---|
+| `tech` | Cites `app/models/x.rb`, API endpoints, scope names directly |
+| `biz` | Leads with business meaning, translates jargon, defers code questions to IT |
+| `exec` | Strict 結論 / 影響(含風險) / 建議行動 — no code, no API, no file paths |
+
+Configured per user via `pmk gateway audience set <userId> <key>`; default via `pmk gateway audience default <key>`.
+
+## 6. mra-ask round (optional)
+
+When PKB summaries don't cover the question (specific implementation, scope blocks, ability rules, exact column lists), the model emits a fenced directive:
+
+````markdown
+```mra-ask
+repo: erp
+question: where is the sales_performances scope defined?
+```
+````
+
+The gateway parses this, runs `mra ask <repo> <question>` as a subprocess (120s timeout, retry-once on transient empty-stderr failures since v0.7.3), wraps the stdout in a `mra-result` user message, and re-calls the LLM for synthesis. Failures are surfaced verbatim — stderr appears in the host log AND in the LLM's apology context (since v0.7.2), so the user never sees a mysterious "unknown" error.
+
+## 7. Escalate directive (optional, falls back from mra-ask)
+
+When neither PKB nor mra-ask suffices (live ops state, business decisions, undocumented rules), the model emits:
+
+````markdown
+```escalate
+repo: erp
+question: <restated cleanly>
+reason: <why neither PKB nor mra-ask works>
+```
+````
+
+The gateway picks an IT contact pool via `pickEscalationPool(cfg, repo)` (repo-specific takes priority over default), `@`-mentions them in the same Slack thread, and saves a `ThreadEscalation` marker:
+
+```
+~/.pmk/gateway/slack/escalations/<channelId>__<threadTs>.json
+```
+
+The asker's `userId` is stored too so the post-absorb synthesised reply can tag them when the answer lands.
+
+## 8. Wait for IT reply
+
+The thread is now "pending escalation". When any subsequent message arrives in that channel-thread, the absorb-first hook in `handleMessage` / `handleAppMention` checks:
+
+1. Does this `(channelId, threadTs)` have a pending marker?
+2. Is the message's sender in `marker.mentionedUserIds`?
+
+If both true → it's an IT contact's reply → run the absorb path. If sender isn't on the list, the marker stays pending. (For channel context the IT contact must `@pmk` their reply because we don't hold `channels:history` scope — DMs don't need this since `im:history` already gives us message visibility.)
+
+## 9. LLM extractor → KnowledgeAtom
+
+`extractKnowledgeAtom` runs a focused LLM call (120s timeout) with a curator-style system prompt. Input: original question + escalation reason + IT's verbatim reply. Output: bare JSON with `{ question, summary, tags }` — three keys, validated, sliced to ≤8 tags.
+
+The result is wrapped in a `KnowledgeAtom`:
+
+```yaml
+---
+id: 2026-04-28T0213-5388-如何查詢本月各部門廣告預算分配比例
+createdAt: 1777342416133
+scope: erp
+question: 如何查詢本月各部門廣告預算分配比例？
+tags: [廣告預算, 部門分配, sales_performances, budget_allocation, erp, 財務報表]
+source:
+  threadKey: 'D0B0E9UV52M:1777342320.134509'
+  contributorUserId: U0AVBM41F6Z
+status: pending
+expiresAt: 1777428816133
+summary: '截至 2026-04-28，本月各部門廣告預算分配比例為...'
+---
+
+# 如何查詢本月各部門廣告預算分配比例？
+
+## Answer
+<verbatim IT reply>
+
+## Summary
+<summary, also in front-matter>
+```
+
+Saved via `saveAtom()` to `~/.pmk/knowledge/<scope>/<slug>.md`, with the scope name **strictly sanitised** to `[a-zA-Z0-9_-]` characters (path traversal closed in v0.7.0).
+
+The pending marker is cleared eagerly **before** extraction starts so two fast IT replies can't both produce duplicates (race fix landed in v0.7.0).
+
+## 10. Approval gate
+
+This is the v0.7.4 TTL hybrid. Atoms enter as `status: "pending"` with `expiresAt = now + 24h`. While pending:
+
+- **Invisible to retrieval** (`searchAtoms` filters them out) — Phase 4 above won't find them.
+- **Visible in CLI listings** — `pmk gateway atoms list --pending`.
+
+Three exits:
+
+| Trigger | Effect |
+|---|---|
+| 24h passes; next `loadAtoms()` call | Auto-promote: rewrite file with `status: approved`, drop `expiresAt`. Idempotent on subsequent loads. |
+| `pmk gateway atoms approve <id-prefix>` | Same as above, but immediately. ID prefix matching: any unique prefix resolves. |
+| `pmk gateway atoms reject <id-prefix>` | Delete the `.md` file. |
+
+After promotion, the atom is now retrieval-visible. The next person who asks a similar question gets it prepended in Phase 4 — the loop closes.
+
+The post-absorb synthesised reply (sent to the original asker after Phase 9 completes) bypasses the approval gate by design — the human asked a question, an authorised IT contact answered it, the answer should reach them now even if the atom is still pending for *future* queries. Only the persistent retrieval store is gated.
+
+## Honest offline UX
+
+Orthogonal to the directive flow but part of the gateway lifecycle:
+
+- A heartbeat file ticks every 30s. If it's stale (> 60s) on next start, the host was offline.
+- On graceful `SIGINT/SIGTERM`, the bot broadcasts `:zzz: pmk gateway 暫離` to every DM that interacted in the last 24h plus every channel with active cases.
+- On startup after stale heartbeat, broadcasts `:wave: pmk gateway 重新上線（離線約 N 分鐘）`.
+
+No `caffeinate` / launchd hacks ship by default — accepting bounded availability for honest transparency.
+
+## See also
+
+- [ADR-0006: pmk gateway — Slack/LINE bot, not SaaS](../adr/0006-pmk-gateway-slack.md)
+- [PRD-2026-0005: pmk gateway v0.7.0 surface](../prds/2026-04-27-pmk-gateway-prd.md)
+- [v0.7.0–v0.7.4 release notes on GitHub](https://github.com/hanfour/pm-workspace-kit/releases)
+- [Changelog](../changelog.md) — release-by-release summary

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -29,6 +29,14 @@ const config: Config = {
     },
   },
 
+  // Enable Mermaid in markdown so docs can embed flow diagrams.
+  // Used by gateway/lifecycle.md (v0.7+).
+  markdown: {
+    mermaid: true,
+  },
+
+  themes: ["@docusaurus/theme-mermaid"],
+
   presets: [
     [
       "classic",

--- a/apps/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/gateway/lifecycle.md
+++ b/apps/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/gateway/lifecycle.md
@@ -1,0 +1,200 @@
+---
+sidebar_position: 1
+---
+
+# Gateway 生命週期
+
+一條 Slack DM 從進到 `pmk gateway` 到落地的整個流程。設計動機請看 [ADR-0006](../adr/0006-pmk-gateway-slack.md)，v0.7.0 的表面合約見 [PRD-2026-0005](../prds/2026-04-27-pmk-gateway-prd.md)。下方流程圖中的編號對應到同名的章節。
+
+## 流程圖
+
+```mermaid
+flowchart TD
+    A([使用者在 Slack DM / @-mention pmk]) --> B{1. 進來分流}
+    B -->|DM| C[2. Per-user / per-thread session]
+    B -->|Channel mention| C
+    C --> D[3. 第一輪載入 PKB seed]
+    D --> E[4. 從 approved atoms 抽 retrieval prefix]
+    E --> F[5. 依 audience 挑 prompt 跑 LLM]
+    F --> G{model 有沒有 emit directive?}
+    G -->|沒有| H([在 thread 回覆])
+    G -->|mra-ask| I[6. 跑 mra ask 子 process]
+    I --> I2[把 mra-result 餵回 LLM synthesise]
+    I2 --> H
+    G -->|escalate| J[7. 在 thread @ IT 同事]
+    J --> K[8. 等 IT 在同 thread 回覆]
+    K --> L[9. LLM extractor 萃出 KnowledgeAtom]
+    L --> M[(.pmk/knowledge/&lt;scope&gt;/&lt;id&gt;.md<br/>status: pending<br/>expiresAt: now + 24h)]
+    M --> N{10. 審核 gate}
+    N -->|24h 後| O[自動 promote → approved]
+    N -->|pmk gateway atoms approve| O
+    N -->|pmk gateway atoms reject| P[刪掉檔案]
+    O --> E
+
+    style M fill:#fff5e6
+    style O fill:#e8f5e8
+    style P fill:#ffe8e8
+```
+
+## 1. 進來分流
+
+`SlackAdapter` 訂兩種 Slack Socket Mode 事件：
+
+- **`message`** — 每條 DM 都觸發（需 `im.history` scope）。handler 會跳過 bot 自己發的訊息與 `cfg.blocklist` 內的人。
+- **`app_mention`** — channel 裡 `@pmk` 才觸發（需 `app_mentions:read` scope）。沒 active case 的 channel mention 會掉到跟 DM 同一條 free-chat 路徑。
+
+兩個 handler 都在 LLM round-trip 開始**之前**先 ack envelope（Slack 會在 ~3s 內重送沒 ack 的事件，比任何 LLM 回覆都快）。Envelope ID 用一個 bounded LRU 去重，所以重送永遠不會觸發同一輪兩次。
+
+## 2. Per-user / per-thread session 隔離
+
+Session 都存在 host 機器上：
+
+```
+~/.pmk/gateway/slack/users/<userId>/session.json                    # 主 DM
+~/.pmk/gateway/slack/users/<userId>/threads/<threadTs>/session.json # thread 內回覆
+~/.pmk/gateway/slack/channels/<channelId>/main.chat-session.json    # channel 主流
+~/.pmk/gateway/slack/channels/<channelId>/threads/<ts>/...          # channel thread
+```
+
+開在 Slack thread 裡的回覆有自己的 session 檔案 — thread A 的 context 永遠不會洩漏到 thread B。Top-level DM 共用一個 "main" session（保留 v0.7.0 layout 的相容性）。
+
+## 3. 第一輪 PKB seed
+
+任何 session 的第一輪，如果 `cfg.defaultIngest` 有設（通常是 `mra:--all`），gateway 會把每個有 PKB 目錄的 repo 的四份 base 文件打包成一段假的 `(user → assistant)` 對話前綴：
+
+```
+[user]      "我先把 workspace 的 PKB context 給你（請當作 ground truth ...）..."
+[assistant] "了解，已載入 workspace PKB context。請繼續。"
+```
+
+這就是為什麼 model 第一輪就能講 *"app/services/sales_budget_performance/ 存在；budget worker chain 會走這條路徑"* — 不需要先跑 retrieval。
+
+## 4. 從 approved atoms 抽 retrieval prefix
+
+每一輪（不只第一輪），`searchAtoms(userText, { limit: 3 })` 找出與當下使用者輸入最相關的 approved atoms。命中的 atoms 以 **ephemeral** 訊息形式 prepend 到這次 LLM call — 不會寫進 `session.messages`，所以舊的 retrieved 答案不會一輪一輪疊上去。
+
+Pending atoms 在這裡刻意看不到。詳見 [Phase 10](#10-審核-gate)。
+
+## 5. 依 audience 挑 prompt
+
+LLM call 的 system prompt 由 `pickGatewayPrompt(audience)` 決定，其中 `audience = pickAudience(cfg, userId)`。三種口吻共用一段 `GATEWAY_TOOLBOX` 後綴，後綴定義 `mra-ask` 與 `escalate` 兩個 directive：
+
+| Audience | 口吻 |
+|---|---|
+| `tech` | 直接引用 `app/models/x.rb`、API endpoint、scope 名稱 |
+| `biz` | 先講業務意義、翻譯 jargon、把 code 問題推給 IT |
+| `exec` | 嚴格三段式 結論 / 影響(含風險) / 建議行動 — 不出現程式碼、API、檔案路徑 |
+
+設定方式：`pmk gateway audience set <userId> <key>` 個別覆蓋；`pmk gateway audience default <key>` 改預設。
+
+## 6. mra-ask round（選用）
+
+當 PKB 摘要不足以回答（具體實作、scope 區塊、ability 規則、確切欄位列表），model 會 emit fenced directive：
+
+````markdown
+```mra-ask
+repo: erp
+question: where is the sales_performances scope defined?
+```
+````
+
+Gateway parse 出來後跑 `mra ask <repo> <question>` 子 process（120s timeout，自 v0.7.3 起對 transient 的 empty-stderr 失敗會 retry 一次），把 stdout 包進 `mra-result` user 訊息再 call 一次 LLM 做 synthesis。失敗時 stderr 會原樣 surface 到 host log 與 LLM 的 apology context（自 v0.7.2），使用者不會看到莫名其妙的 "unknown" 錯誤。
+
+## 7. Escalate directive（選用，從 mra-ask 退一階）
+
+當 PKB 與 mra-ask 都答不出（live ops 狀態、商業決策、未文件化的規則），model emit：
+
+````markdown
+```escalate
+repo: erp
+question: <重新整理過的問題>
+reason: <為什麼 PKB 與 mra-ask 都不夠>
+```
+````
+
+Gateway 透過 `pickEscalationPool(cfg, repo)` 挑一組 IT 聯絡人（repo 特定優先於 default），在同一條 Slack thread `@`-mention 他們，並存一個 `ThreadEscalation` marker：
+
+```
+~/.pmk/gateway/slack/escalations/<channelId>__<threadTs>.json
+```
+
+提問者的 `userId` 也存進去，這樣 absorb 完之後合成的回覆才能 tag 對人。
+
+## 8. 等 IT 回覆
+
+這條 thread 現在處於「pending escalation」狀態。後續任何進到這個 channel-thread 的訊息，`handleMessage` / `handleAppMention` 開頭的 absorb-first hook 會檢查：
+
+1. 這個 `(channelId, threadTs)` 有沒有 pending marker？
+2. 訊息發送者是不是 `marker.mentionedUserIds` 內的人？
+
+兩個都 yes → 就是 IT 同事的回覆 → 走 absorb path。發送者不在名單就維持 pending。（在 channel 場景，IT 同事必須 `@pmk` 才接得到 — 因為我們沒持有 `channels:history` scope；DM 不用這層因為 `im:history` 已經給我們訊息可見性。）
+
+## 9. LLM extractor → KnowledgeAtom
+
+`extractKnowledgeAtom` 跑一次 focused LLM call（120s timeout），用 curator 風格的 system prompt。Input：原始問題 + escalation reason + IT 的 verbatim 回覆。Output：純 JSON `{ question, summary, tags }` — 三個 key、驗證、tags 切到 ≤ 8 個。
+
+結果包成一個 `KnowledgeAtom`：
+
+```yaml
+---
+id: 2026-04-28T0213-5388-如何查詢本月各部門廣告預算分配比例
+createdAt: 1777342416133
+scope: erp
+question: 如何查詢本月各部門廣告預算分配比例？
+tags: [廣告預算, 部門分配, sales_performances, budget_allocation, erp, 財務報表]
+source:
+  threadKey: 'D0B0E9UV52M:1777342320.134509'
+  contributorUserId: U0AVBM41F6Z
+status: pending
+expiresAt: 1777428816133
+summary: '截至 2026-04-28，本月各部門廣告預算分配比例為...'
+---
+
+# 如何查詢本月各部門廣告預算分配比例？
+
+## Answer
+<IT 同事的 verbatim 回覆>
+
+## Summary
+<summary，也在 front-matter>
+```
+
+透過 `saveAtom()` 落到 `~/.pmk/knowledge/<scope>/<slug>.md`，scope 名會被嚴格 sanitise 成 `[a-zA-Z0-9_-]`（v0.7.0 把 path traversal 封掉了）。
+
+Pending marker 在 extraction **之前**就會被清掉 — 兩個 IT 同事連續快速回覆才不會兩個都觸發 extract（v0.7.0 race fix）。
+
+## 10. 審核 gate
+
+這是 v0.7.4 的 TTL hybrid。Atoms 進來時 `status: "pending"`、`expiresAt = now + 24h`。Pending 期間：
+
+- **retrieval 看不到**（`searchAtoms` 過濾掉）— Phase 4 不會撈到
+- **CLI 看得到** — `pmk gateway atoms list --pending`
+
+三條離開路徑：
+
+| 觸發 | 效果 |
+|---|---|
+| 24h 過了；下次 `loadAtoms()` | 自動 promote：重寫檔案 `status: approved`、清掉 `expiresAt`。後續 load 是 idempotent 的。 |
+| `pmk gateway atoms approve <id-prefix>` | 同上，但立即。ID prefix matching：唯一的 prefix 就解析得出 atom。 |
+| `pmk gateway atoms reject <id-prefix>` | 刪掉 `.md` 檔。 |
+
+Promote 完後 atom 對 retrieval 可見。下一個問類似問題的人在 Phase 4 就會被 prepend — loop 收口。
+
+Phase 9 結束後寄給原提問者的合成回覆**不**經過 approval gate（設計如此） — 人問了問題，授權的 IT 同事答了，這個答案應該立刻送到提問者手上，即便 atom 對**未來**查詢還在 pending。只有持久化 retrieval store 才被 gate 住。
+
+## Honest offline UX
+
+跟 directive 流程獨立，但屬於 gateway 生命週期的一部分：
+
+- 一份 heartbeat 檔每 30 秒打卡。下次啟動時若超過 60 秒沒打 → host 之前離線過。
+- 收到 `SIGINT/SIGTERM` 優雅關閉時：bot 會對最近 24h 互動過的 DM 與所有有 active case 的 channel 廣播 `:zzz: pmk gateway 暫離`。
+- 啟動後若偵測到 stale heartbeat：廣播 `:wave: pmk gateway 重新上線（離線約 N 分鐘）`。
+
+預設不附 `caffeinate` / launchd 之類 hack — 接受有界的可用性，換取誠實的透明度。
+
+## 延伸閱讀
+
+- [ADR-0006: pmk gateway — Slack/LINE bot, not SaaS](../adr/0006-pmk-gateway-slack.md)
+- [PRD-2026-0005: pmk gateway v0.7.0 surface](../prds/2026-04-27-pmk-gateway-prd.md)
+- [v0.7.0–v0.7.4 release notes on GitHub](https://github.com/hanfour/pm-workspace-kit/releases)
+- [Changelog](../changelog.md) — release-by-release 摘要

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@docusaurus/core": "3.10.0",
     "@docusaurus/preset-classic": "3.10.0",
+    "@docusaurus/theme-mermaid": "3.10.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
@@ -31,7 +32,11 @@
     "typescript": "~5.6.2"
   },
   "browserslist": {
-    "production": [">0.5%", "not dead", "not op_mini all"],
+    "production": [
+      ">0.5%",
+      "not dead",
+      "not op_mini all"
+    ],
     "development": [
       "last 3 chrome version",
       "last 3 firefox version",

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -84,6 +84,16 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: "category",
+      label: "Gateway (v0.7)",
+      collapsed: false,
+      items: [
+        "gateway/lifecycle",
+        "adr/pmk-gateway-slack",
+        "prds/2026-04-27-pmk-gateway-prd",
+      ],
+    },
+    {
+      type: "category",
       label: "Project Planning",
       collapsed: true,
       items: [
@@ -92,6 +102,7 @@ const sidebars: SidebarsConfig = {
         "plans/2026-04-24-desktop-app-sprint-plan",
       ],
     },
+    "changelog",
   ],
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
       "dependencies": {
         "@docusaurus/core": "3.10.0",
         "@docusaurus/preset-classic": "3.10.0",
+        "@docusaurus/theme-mermaid": "3.10.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
@@ -2352,7 +2353,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4400,6 +4400,34 @@
         "@docusaurus/plugin-content-docs": "*",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-mermaid": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.10.0.tgz",
+      "integrity": "sha512-Y2xrlwhIJ80oOZIO3PXL6A7J869splfcMI87E3NKpYsy3zJxOyV+BP1QMtGi59ajKgU868HPuyyn6J+6BZGOBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.0",
+        "@docusaurus/module-type-aliases": "3.10.0",
+        "@docusaurus/theme-common": "3.10.0",
+        "@docusaurus/types": "3.10.0",
+        "@docusaurus/utils-validation": "3.10.0",
+        "mermaid": ">=11.6.0",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "@mermaid-js/layout-elk": "^0.1.9",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@mermaid-js/layout-elk": {
+          "optional": true
+        }
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {


### PR DESCRIPTION
The v0.7 story has been scattered across PR descriptions, release notes, ADR-0006, and PRD-2026-0005. Hosts trying to understand the *PKB-seed → mra-ask → escalate → absorb → retrieve* loop had to assemble it themselves from 5+ sources. This PR consolidates.

## Three deliverables

### 1. \`apps/docs/docs/gateway/lifecycle.md\` (+ zh-TW mirror)

Single-page walkthrough of the full directive flow, anchored on a Mermaid flowchart. Ten numbered phases match the doc's section headings; each section explains the code that runs plus the file-system / Slack side-effects.

Lives at:
- https://hanfour.github.io/pm-workspace-kit/docs/gateway/lifecycle
- https://hanfour.github.io/pm-workspace-kit/zh-TW/docs/gateway/lifecycle

### 2. \`apps/docs/docs/changelog.md\`

Release-by-release summary covering v0.1 → v0.7.4 in [Keep a Changelog](https://keepachangelog.com/) format. Each release header links to its GitHub release + PR. (Originally targeted at repo root \`CHANGELOG.md\`, moved here so a global pre-tool-use hook in this repo doesn't block creation outside \`docs/\`. Same content; better location for a docs site.)

Lives at https://hanfour.github.io/pm-workspace-kit/docs/changelog

### 3. \`sidebars.ts\` — \"Gateway (v0.7)\" category

New collapsed-open category groups:
- Lifecycle deep-dive (above)
- ADR-0006 (design rationale)
- PRD-2026-0005 (v0.7.0 surface contract)

\`changelog\` also added as a top-level sidebar entry after Project Planning.

## Mermaid enablement

- \`@docusaurus/theme-mermaid@3.10.0\` added to \`apps/docs\` deps (single peer-less package)
- \`markdown.mermaid: true\` + \`themes: [\"@docusaurus/theme-mermaid\"]\` in \`docusaurus.config.ts\`
- One \`flowchart TD\` block in lifecycle.md uses it; everything else stays plain markdown.

## README

Updated to link the new lifecycle page + changelog on GitHub Pages.

## Build

\`npm run build\` green for both locales. Pre-existing LICENSE.txt broken-link warnings unchanged. GitHub Pages workflow [\`deploy.yml\`](https://github.com/hanfour/pm-workspace-kit/blob/main/.github/workflows/deploy.yml) will rebuild + redeploy on merge.