### PR TITLE
fix(gateway): mra timeout-kill mis-classified as 'Command failed'

### DIFF
--- a/packages/cli/src/adapters/mra.ts
+++ b/packages/cli/src/adapters/mra.ts
@@ -301,7 +301,11 @@ export async function runMraAsk(
     };
   }
   const maxRetries = opts.maxRetries ?? 1;
-  const timeoutMs = args.timeoutMs ?? 120_000;
+  // 300s default — bumped from 120s in v0.7.5. Live dogfood (2026-04-28)
+  // showed a complex multi-clause CJK question took 160s of mra-internal
+  // LLM time, so the v0.7.0 cap of 120s was killing legitimate queries
+  // mid-flight. 300s gives ~2× headroom for the worst we've observed.
+  const timeoutMs = args.timeoutMs ?? 300_000;
   let last: MraAskResult | undefined;
   for (let attempt = 1; attempt <= maxRetries + 1; attempt++) {
     const result = await runMraAskOnce(binary, args, timeoutMs);
@@ -332,12 +336,27 @@ function runMraAskOnce(
       },
       (err, stdout, stderr) => {
         if (err) {
-          const killed = (err as NodeJS.ErrnoException).code === "ETIMEDOUT";
+          // execFile's timeout sends SIGTERM (the configured killSignal,
+          // which defaults to SIGTERM). Node populates `err.killed` and
+          // `err.signal` on the resulting error. The earlier
+          // `code === "ETIMEDOUT"` check basically never fired — Node's
+          // signaled-kill path sets `code: null`, so timeouts were
+          // mis-classified as "Command failed" generic errors and
+          // (worse) looksTransient would retry them. Detecting via
+          // `killed`/`signal` is what the docs actually describe.
+          const errAny = err as NodeJS.ErrnoException & {
+            killed?: boolean;
+            signal?: string;
+          };
+          const isTimeout =
+            errAny.killed === true ||
+            errAny.signal === "SIGTERM" ||
+            errAny.code === "ETIMEDOUT";
           resolve({
             ok: false,
             stdout: String(stdout ?? ""),
             stderr: String(stderr ?? ""),
-            reason: killed
+            reason: isTimeout
               ? `mra ask timed out after ${timeoutMs}ms`
               : err.message,
             attempts: 1,

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -724,7 +724,7 @@ export class SlackAdapter {
       .update({
         channel: channelId,
         ts: placeholderTs,
-        text: `:mag: 正在用 mra 查 \`${request.repo}\` 的 code…（最多 2 分鐘）`,
+        text: `:mag: 正在用 mra 查 \`${request.repo}\` 的 code…（最多 5 分鐘）`,
       })
       .catch(() => {});
 


### PR DESCRIPTION
Dogfood 2026-04-28 (after v0.7.4) hit this: a real escalate query triggered mra-ask, both attempts \"failed\" with no stderr, partial stdout shows mra got to \`[ask] querying: erp\` and stopped.

Manual reproduction of the **same question** completed in **160s** with exit 0 and a perfect 3 KB answer.

## Root cause

\`runMraAsk\`'s \`120s\` timeout killed mra mid-flight via \`SIGTERM\`. The inner timeout-detection check was:

\`\`\`ts
const killed = (err as NodeJS.ErrnoException).code === "ETIMEDOUT";
\`\`\`

But Node's \`execFile\` timeout-kill produces:

| field | value |
|---|---|
| \`err.killed\` | \`true\` |
| \`err.signal\` | \`\"SIGTERM\"\` |
| \`err.code\` | \`null\` ← never \"ETIMEDOUT\" |
| \`err.message\` | \`\"Command failed: <argv>\"\` |

So the \`code === \"ETIMEDOUT\"\` branch never fired. Every timeout was labeled \`Command failed: <argv>\` instead of \`mra ask timed out…\`, which:

1. Confused operators reading the host log (no \"timed out\" line)
2. Lied to the LLM via \`buildMraFailureMessage\` (model said \"no result\" instead of \"timed out\")
3. Tripped \`looksTransient\` → retry-once piled on another 120s of compute against a question that was always going to take 160s+

## Fix

- **Detect signaled-kill via \`err.killed\` / \`err.signal\`** in addition to the original (rare) \`ETIMEDOUT\` code path.
- **Bump default timeout 120s → 300s.** The dogfood case at 160s gives ~2× headroom for plausibly worse questions; the v0.7.0 guess of 120s turned out tight.
- **Slack placeholder copy** \`(最多 2 分鐘)\` → \`(最多 5 分鐘)\` to match new default.

## Verified

Reproduced Node's actual error shape with \`sleep 5\` + \`timeout 500ms\`:

\`\`\`
err.message: Command failed: /bin/sh -c echo started; sleep 5; echo finis
err.killed: true
err.signal: SIGTERM
err.code: null
isTimeout (new check): true
(old check err.code === ETIMEDOUT): false
stdout: \"started\\n\"
\`\`\`

Confirms: old check would miss this; new check catches it.

## Tests

148/148 pass (no new tests — subprocess mocking infra would balloon the change; manual repro covered above).

## Test plan

- [ ] In the live workspace where dogfood failed, restart \`pmk gateway\` and re-ask the same whitelist question
- [ ] Verify gateway log shows \`mra ask succeeded on attempt N\` (no retry needed) OR \`mra ask timed out after 300000ms\` if the question genuinely exceeds 5 min
- [ ] Slack placeholder text now reads \"最多 5 分鐘\"
- [ ] No regression on smaller questions (still answer in 30-60s)