### PR TITLE
feat(gateway): session context-window auto-pruning (closes #18)

### DIFF
--- a/apps/docs/docs/changelog.md
+++ b/apps/docs/docs/changelog.md
@@ -8,6 +8,24 @@ All notable changes to **pm-workspace-kit** are documented here.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each release also has a longer narrative on [GitHub Releases](https://github.com/hanfour/pm-workspace-kit/releases) with rationale, dogfood notes, and test plans.
 
+## [v0.8.1] — 2026-04-28 — session context-window auto-pruning
+
+[GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.8.1) · closes [#18](https://github.com/hanfour/pm-workspace-kit/issues/18)
+
+### Added
+
+- `pruneSessionIfNeeded(session)` in `gateway/messaging.ts` — when a session crosses `MAX_SESSION_TOKENS` (default `60_000`, override via `PMK_MAX_SESSION_TOKENS` env), drops the oldest non-seed turns. Always preserves the PKB seed pair plus the most recent `KEEP_RECENT_TURNS` (default 10) user/assistant pairs; inserts a synthetic `(此處省略 N 輪較舊的對話以節省 context)` marker so the model knows there was earlier history.
+- Idempotent — re-running on an already-pruned session is a no-op until enough new turns push back over cap.
+- Host log line `pruned session: dropped N turn-pair(s); now <tokens> approx tokens` confirms when it fires.
+
+### Why
+
+Until v0.8.1, `UserSession.messages` accumulated forever. Each gateway-DM turn pushes 2 messages (user + assistant), the mra-ask round adds 2 more, the PKB seed adds 2 on first turn. After ~50 turns in a single thread the session approaches the model's context window — slow LLM round-trips, eventual `context_length_exceeded`, linear token-cost growth. v0.8.1 caps that.
+
+### Tests
+
+151 → 156 (+5: under-cap no-op, over-cap pruning preserves seed + tail, idempotent on already-pruned, no-seed branch, single-huge-message edge case).
+
 ## [v0.8.0] — 2026-04-28 — `pm` audience tier
 
 [GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.8.0) · closes [#27](https://github.com/hanfour/pm-workspace-kit/issues/27)

--- a/apps/docs/docs/gateway/lifecycle.md
+++ b/apps/docs/docs/gateway/lifecycle.md
@@ -58,6 +58,15 @@ Sessions are persisted on the host machine:
 
 A reply that lives in a Slack thread gets its own session file — context from thread A never bleeds into thread B. Top-level DMs share one "main" session per user (back-compat with v0.7.0 layout).
 
+**Auto-pruning (v0.8.1)**: when a session's `approxTokens` crosses `MAX_SESSION_TOKENS` (default `60_000`, override via `PMK_MAX_SESSION_TOKENS` env), the oldest non-seed turns are dropped before persisting:
+
+- The PKB seed pair (Phase 3) is always preserved
+- The most recent `KEEP_RECENT_TURNS` (default 10) `(user, assistant)` pairs are always preserved
+- Everything in between is replaced by a synthetic `(此處省略 N 輪較舊的對話以節省 context)` marker so the model knows there was earlier history
+- Idempotent — if no new turns push back over cap, subsequent calls are no-ops
+
+The host log line `pruned session: dropped N turn-pair(s); now <tokens> approx tokens` confirms when it fires.
+
 ## 3. PKB seed on first turn
 
 The very first turn of any session, if `cfg.defaultIngest` is set (typically `mra:--all`), the gateway packages the four base PKB docs of every repo with a PKB directory and prepends them as a synthetic `(user → assistant)` turn pair:

--- a/apps/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/gateway/lifecycle.md
+++ b/apps/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/gateway/lifecycle.md
@@ -58,6 +58,15 @@ Session 都存在 host 機器上：
 
 開在 Slack thread 裡的回覆有自己的 session 檔案 — thread A 的 context 永遠不會洩漏到 thread B。Top-level DM 共用一個 "main" session（保留 v0.7.0 layout 的相容性）。
 
+**自動修剪（v0.8.1）**：當 session 的 `approxTokens` 超過 `MAX_SESSION_TOKENS`（預設 `60_000`，可用 `PMK_MAX_SESSION_TOKENS` env 覆蓋）時，落地之前會把較舊的 turn 砍掉：
+
+- PKB seed pair（Phase 3）一定保留
+- 最近 `KEEP_RECENT_TURNS`（預設 10）對 `(user, assistant)` 一定保留
+- 中間的全部換成一條 `(此處省略 N 輪較舊的對話以節省 context)` 合成 user 訊息，讓 model 知道之前還有歷史
+- Idempotent — 沒有新訊息再次衝過 cap 的話，下次呼叫是 no-op
+
+Host log 出現 `pruned session: dropped N turn-pair(s); now <tokens> approx tokens` 即代表觸發。
+
 ## 3. 第一輪 PKB seed
 
 任何 session 的第一輪，如果 `cfg.defaultIngest` 有設（通常是 `mra:--all`），gateway 會把每個有 PKB 目錄的 repo 的四份 base 文件打包成一段假的 `(user → assistant)` 對話前綴：

--- a/packages/cli/src/gateway/messaging.ts
+++ b/packages/cli/src/gateway/messaging.ts
@@ -4,6 +4,7 @@
  * other adapters (LINE etc.) when those land.
  */
 
+import type { ChatMessage } from "@pmk/shared";
 import {
   listMraWorkspaceReposWithPkb,
   loadPkbBase,
@@ -120,4 +121,138 @@ export function buildMraSuccessMessage(repo: string, stdout: string): string {
     truncate(stdout.trim(), 24_000),
     "```",
   ].join("\n");
+}
+
+// ─────────────────── session pruning (v0.8.1, #18) ──────────────────────
+
+/**
+ * Soft cap for `session.approxTokens` before pruning kicks in. Set to
+ * about 70% of a typical 90k-token gateway-DM context budget — leaves
+ * headroom for system prompt + retrieval prefix + the new user turn
+ * and the model's reply.
+ *
+ * Tunable via `PMK_MAX_SESSION_TOKENS` env var so hosts can override
+ * without rebuilding (e.g. drop to 30k for cheaper Haiku-tier models
+ * or push higher for Opus-tier 200k budgets).
+ */
+export const MAX_SESSION_TOKENS = (() => {
+  const raw = process.env.PMK_MAX_SESSION_TOKENS;
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 60_000;
+})();
+
+/** How many recent (user, assistant) pairs to always keep across a prune. */
+export const KEEP_RECENT_TURNS = 10;
+
+interface SessionLike {
+  messages: ChatMessage[];
+  approxTokens: number;
+}
+
+/**
+ * The PKB seed pair, when present, is always the first two messages
+ * of a session and starts with this exact string (set by
+ * `runFreeChatTurn`). Detecting by content prefix avoids storing a
+ * "this is the seed pair" flag on every session.
+ */
+const PKB_SEED_PREFIX = "我先把 workspace 的 PKB context 給你";
+
+/**
+ * Estimate token count for a message-array using the same ~3.5
+ * chars-per-token heuristic the rest of the gateway uses (matches
+ * `approxTokensFor` in slack/index.ts).
+ */
+function approxTokensFor(messages: ChatMessage[]): number {
+  let total = 0;
+  for (const m of messages) total += m.content.length;
+  return Math.ceil(total / 3.5);
+}
+
+export interface PruneResult {
+  pruned: boolean;
+  /** Number of `(user, assistant)` pairs we dropped. */
+  droppedPairs: number;
+  /** Token tally after pruning (matches `session.approxTokens`). */
+  tokensAfter: number;
+}
+
+/**
+ * If a session is approaching context-window saturation, drop the
+ * oldest non-seed turns to bring it back under cap. Always preserves:
+ *
+ *   1. The PKB seed pair (first two messages, when content matches
+ *      `PKB_SEED_PREFIX`)
+ *   2. The most recent `KEEP_RECENT_TURNS` * 2 messages
+ *
+ * Drops everything in between and inserts a synthetic user marker so
+ * the model knows there was earlier history. Idempotent — running
+ * again on an already-pruned session is a no-op.
+ *
+ * The function MUTATES the passed session and returns a small report
+ * for the caller to log. Caller is responsible for calling
+ * `saveSession()` afterward so the pruned state hits disk.
+ */
+export function pruneSessionIfNeeded(session: SessionLike): PruneResult {
+  if (session.approxTokens <= MAX_SESSION_TOKENS) {
+    return {
+      pruned: false,
+      droppedPairs: 0,
+      tokensAfter: session.approxTokens,
+    };
+  }
+
+  const msgs = session.messages;
+  const hasPkbSeed =
+    msgs.length >= 2 &&
+    msgs[0].role === "user" &&
+    msgs[0].content.startsWith(PKB_SEED_PREFIX) &&
+    msgs[1].role === "assistant";
+
+  // Already-pruned sessions have a marker right after the seed; bail
+  // out to keep this idempotent.
+  const seedEnd = hasPkbSeed ? 2 : 0;
+  if (
+    msgs[seedEnd]?.role === "user" &&
+    msgs[seedEnd]?.content.startsWith("(此處省略") &&
+    msgs.length - seedEnd - 1 <= KEEP_RECENT_TURNS * 2
+  ) {
+    // We've already pruned and not enough new turns have accumulated
+    // to need another pass. Recompute tokens just in case.
+    session.approxTokens = approxTokensFor(msgs);
+    return {
+      pruned: false,
+      droppedPairs: 0,
+      tokensAfter: session.approxTokens,
+    };
+  }
+
+  const keepFromEnd = KEEP_RECENT_TURNS * 2;
+  // Nothing to prune if we're already at/below the keep window after
+  // the seed. (Edge case: a single huge message can put us over cap
+  // without there being anything to drop.)
+  if (msgs.length - seedEnd <= keepFromEnd) {
+    return {
+      pruned: false,
+      droppedPairs: 0,
+      tokensAfter: session.approxTokens,
+    };
+  }
+
+  const seedSlice = hasPkbSeed ? msgs.slice(0, 2) : [];
+  const recent = msgs.slice(-keepFromEnd);
+  const dropped = msgs.length - seedEnd - keepFromEnd;
+  const droppedPairs = Math.floor(dropped / 2);
+
+  const marker: ChatMessage = {
+    role: "user",
+    content: `(此處省略 ${droppedPairs} 輪較舊的對話以節省 context — 完整歷史仍在 host 的 session.json)`,
+  };
+
+  session.messages = [...seedSlice, marker, ...recent];
+  session.approxTokens = approxTokensFor(session.messages);
+  return {
+    pruned: true,
+    droppedPairs,
+    tokensAfter: session.approxTokens,
+  };
 }

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -45,6 +45,7 @@ import {
   buildIngestSeed,
   buildMraFailureMessage,
   buildMraSuccessMessage,
+  pruneSessionIfNeeded,
   truncate,
 } from "../messaging";
 import { parseEscalate, stripEscalateBlock } from "../escalate";
@@ -487,6 +488,17 @@ export class SlackAdapter {
     );
     session.messages.push({ role: "assistant", content: visible });
     session.approxTokens = approxTokensFor(session.messages);
+
+    // v0.8.1: trim long histories before persisting. Idempotent — only
+    // fires when over MAX_SESSION_TOKENS; preserves PKB seed + last
+    // KEEP_RECENT_TURNS pairs; inserts a "(此處省略...)" marker for
+    // the model to see there was earlier history.
+    const pruneReport = pruneSessionIfNeeded(session);
+    if (pruneReport.pruned) {
+      this.onLog(
+        `pruned session: dropped ${pruneReport.droppedPairs} turn-pair(s); now ${pruneReport.tokensAfter} approx tokens`,
+      );
+    }
     saveSession(session);
 
     await this.web.chat.update({

--- a/packages/cli/test/gateway.test.ts
+++ b/packages/cli/test/gateway.test.ts
@@ -41,8 +41,12 @@ import { mraDoctor, runMraAsk } from "../src/adapters/mra";
 import {
   buildMraFailureMessage,
   buildMraSuccessMessage,
+  KEEP_RECENT_TURNS,
+  MAX_SESSION_TOKENS,
+  pruneSessionIfNeeded,
   truncate,
 } from "../src/gateway/messaging";
+import type { ChatMessage } from "@pmk/shared";
 import { pickAudience, pickEscalationPool } from "../src/gateway/config";
 import {
   AUDIENCE_KEYS,
@@ -510,6 +514,132 @@ describe("messaging helpers", () => {
       stderr: "rate limited",
     });
     assert.match(m, /引用上面 stderr 提到的具體原因/);
+  });
+});
+
+describe("pruneSessionIfNeeded (#18)", () => {
+  // Helper to build a session with N (user, assistant) pairs after an
+  // optional PKB seed pair. Each message content is sized to push
+  // approxTokens past MAX_SESSION_TOKENS.
+  function makeSession(opts: {
+    pairs: number;
+    contentSize: number;
+    withSeed: boolean;
+  }) {
+    const messages: ChatMessage[] = [];
+    if (opts.withSeed) {
+      messages.push({
+        role: "user",
+        content: `我先把 workspace 的 PKB context 給你（後續對話請用這些事實作答；缺的就老實說沒有，不要編造）：\n${"#".repeat(2_000)}`,
+      });
+      messages.push({
+        role: "assistant",
+        content: "了解，已載入 workspace PKB context。請繼續。",
+      });
+    }
+    for (let i = 0; i < opts.pairs; i++) {
+      messages.push({
+        role: "user",
+        content: `user turn ${i}: ${"x".repeat(opts.contentSize)}`,
+      });
+      messages.push({
+        role: "assistant",
+        content: `assistant turn ${i}: ${"y".repeat(opts.contentSize)}`,
+      });
+    }
+    const totalChars = messages.reduce((n, m) => n + m.content.length, 0);
+    return {
+      messages,
+      approxTokens: Math.ceil(totalChars / 3.5),
+    };
+  }
+
+  it("no-op when under cap", () => {
+    const session = makeSession({ pairs: 3, contentSize: 100, withSeed: true });
+    const before = session.messages.length;
+    const r = pruneSessionIfNeeded(session);
+    assert.equal(r.pruned, false);
+    assert.equal(session.messages.length, before);
+  });
+
+  it("prunes oldest pairs when over cap, preserves PKB seed + last K pairs", () => {
+    // 60 pairs × 4 000 chars each ≈ 137k tokens — well over the 60k cap.
+    const session = makeSession({
+      pairs: 60,
+      contentSize: 4_000,
+      withSeed: true,
+    });
+    assert.ok(
+      session.approxTokens > MAX_SESSION_TOKENS,
+      "fixture should exceed cap",
+    );
+
+    const r = pruneSessionIfNeeded(session);
+    assert.equal(r.pruned, true);
+    assert.ok(r.droppedPairs > 0);
+
+    // PKB seed retained
+    assert.match(
+      session.messages[0].content,
+      /我先把 workspace 的 PKB context/,
+    );
+    assert.equal(session.messages[1].role, "assistant");
+
+    // Marker inserted right after seed
+    assert.match(session.messages[2].content, /^\(此處省略 \d+ 輪/);
+
+    // Last KEEP_RECENT_TURNS pairs retained at the end
+    const tail = session.messages.slice(-KEEP_RECENT_TURNS * 2);
+    assert.equal(tail.length, KEEP_RECENT_TURNS * 2);
+    assert.match(tail[0].content, /^user turn \d+/);
+
+    // Token tally rebuilt
+    assert.equal(r.tokensAfter, session.approxTokens);
+    assert.ok(r.tokensAfter < MAX_SESSION_TOKENS, "post-prune still over cap");
+  });
+
+  it("idempotent on already-pruned session", () => {
+    const session = makeSession({
+      pairs: 60,
+      contentSize: 4_000,
+      withSeed: true,
+    });
+    pruneSessionIfNeeded(session);
+    const lengthAfterFirstPrune = session.messages.length;
+
+    // Run again immediately — should be a no-op.
+    const second = pruneSessionIfNeeded(session);
+    assert.equal(second.pruned, false);
+    assert.equal(session.messages.length, lengthAfterFirstPrune);
+  });
+
+  it("prunes correctly when there is no PKB seed", () => {
+    const session = makeSession({
+      pairs: 60,
+      contentSize: 4_000,
+      withSeed: false,
+    });
+    assert.ok(session.approxTokens > MAX_SESSION_TOKENS);
+
+    const r = pruneSessionIfNeeded(session);
+    assert.equal(r.pruned, true);
+    // First message is now the marker (no seed to preserve)
+    assert.match(session.messages[0].content, /^\(此處省略 \d+ 輪/);
+    // Last KEEP_RECENT_TURNS pairs retained
+    const tail = session.messages.slice(-KEEP_RECENT_TURNS * 2);
+    assert.equal(tail.length, KEEP_RECENT_TURNS * 2);
+  });
+
+  it("no-op when over cap but message count is small (single huge message)", () => {
+    // Edge case: one absurdly long message can put us over cap with
+    // nothing to prune. Should bail rather than mangle the array.
+    const session: { messages: ChatMessage[]; approxTokens: number } = {
+      messages: [{ role: "user", content: "x".repeat(MAX_SESSION_TOKENS * 4) }],
+      approxTokens: MAX_SESSION_TOKENS + 1_000,
+    };
+    const r = pruneSessionIfNeeded(session);
+    assert.equal(r.pruned, false);
+    assert.equal(session.messages.length, 1);
   });
 });
 


### PR DESCRIPTION
Closes #18.

## Why

\`UserSession.messages\` accumulated forever. After ~50 turns in a single thread the session approaches the model's context window — slow LLM round-trips, eventual \`context_length_exceeded\`, linear token-cost growth.

## What

\`pruneSessionIfNeeded(session)\` runs after the assistant turn is appended and before \`saveSession()\` persists. When \`approxTokens > MAX_SESSION_TOKENS\` (default \`60_000\`, env override \`PMK_MAX_SESSION_TOKENS\`):

- Drops the oldest non-seed turns
- Preserves the PKB seed pair (first two messages, when content starts with \`我先把 workspace 的 PKB context 給你\`)
- Preserves the most recent \`KEEP_RECENT_TURNS\` (default 10) user/assistant pairs
- Inserts a synthetic user marker \`(此處省略 N 輪較舊的對話以節省 context …)\` so the model knows there was earlier history
- Idempotent — second call is a no-op unless new turns push back over cap

Host log on each prune: \`pruned session: dropped N turn-pair(s); now <tokens> approx tokens\`.

## Edge cases handled

- No PKB seed → marker becomes the new first message
- Single huge message that exceeds cap on its own → no-op, can't prune what we shouldn't drop
- Already-pruned session with not-enough-new-turns → no-op (idempotency check)

## Tests

151 → 156 (+5: under-cap no-op, over-cap prune with seed preservation, idempotent on already-pruned, no-seed branch, single-huge-message edge).

## Docs

Phase 2 of \`apps/docs/docs/gateway/lifecycle.md\` (EN + zh-TW) gains an "Auto-pruning (v0.8.1)" subsection describing what's preserved, what's dropped, and what the host log line looks like. Changelog entry under v0.8.1.

## Test plan

- [ ] Drive a long DM (50+ turns); host log shows \`pruned session\` line at some point
- [ ] After pruning, a follow-up turn still works — model sees the \`(此處省略...)\` marker and behaves correctly
- [ ] \`PMK_MAX_SESSION_TOKENS=10000 pmk gateway start\` triggers earlier pruning for testing
- [ ] \`session.json\` on disk reflects pruned state (seed + marker + last 10 pairs)