### PR TITLE
fix(gateway): escalate self-tag detection (closes #30)

### DIFF
--- a/apps/docs/docs/changelog.md
+++ b/apps/docs/docs/changelog.md
@@ -8,6 +8,27 @@ All notable changes to **pm-workspace-kit** are documented here.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each release also has a longer narrative on [GitHub Releases](https://github.com/hanfour/pm-workspace-kit/releases) with rationale, dogfood notes, and test plans.
 
+## [v0.8.2] — 2026-04-28 — escalate self-tag detection
+
+[GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.8.2) · closes [#30](https://github.com/hanfour/pm-workspace-kit/issues/30)
+
+### Fixed
+
+- When a model emits `escalate` but the resolved escalation pool is empty (or contains only the asker themselves), the gateway no longer silently logs and drops the mention. It now posts a visible `:warning:` message in the Slack thread naming the config gap and the exact `pmk gateway escalation add ...` commands to fix it. The pending-escalation marker is also skipped (no point waiting for an absorb that can't happen).
+- The asker is filtered out of the resolved pool before any `@`-mention. Previously, if the only configured contact happened to be the same person who asked the question, the bot would `@`-mention them at themselves.
+
+### Added
+
+- `pickEffectiveEscalationPool(cfg, repo, askerUserId)` helper in `gateway/config.ts` — single-source-of-truth for "which contacts should we @-mention given this asker?". Used by `handleEscalation` and unit-tested in isolation.
+
+### Caught by
+
+2026-04-28 dogfood: real escalate flow on a PM scoping question logged `escalate requested but no contacts configured; skipping mention` while the bot's Slack reply degraded to prose ("建議兩個行動: SQL 查 / 找 AOE/PM 同仁"). The host had no way to tell from Slack that the v0.7 escalate flow was suppressed for a config reason.
+
+### Tests
+
+156 → 158 (+2: pool-with-asker filters self; both-pools-empty stays empty).
+
 ## [v0.8.1] — 2026-04-28 — session context-window auto-pruning
 
 [GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.8.1) · closes [#18](https://github.com/hanfour/pm-workspace-kit/issues/18)

--- a/packages/cli/src/gateway/config.ts
+++ b/packages/cli/src/gateway/config.ts
@@ -147,6 +147,21 @@ export function pickEscalationPool(
   return cfg.escalation?.default ?? [];
 }
 
+/**
+ * Same as `pickEscalationPool` but filters the asker out so the bot
+ * never @-mentions the person who just asked the question. Used by
+ * `handleEscalation` to surface a config gap (#30 v0.8.2): when the
+ * effective pool is empty, the host gets a visible Slack warning
+ * instead of a silent prose-degrade.
+ */
+export function pickEffectiveEscalationPool(
+  cfg: GatewayConfig,
+  repo: string | undefined,
+  askerUserId: string,
+): string[] {
+  return pickEscalationPool(cfg, repo).filter((id) => id !== askerUserId);
+}
+
 export function saveGatewayConfig(cfg: GatewayConfig): string {
   const file = gatewayConfigPath();
   fs.mkdirSync(path.dirname(file), { recursive: true });

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -1,7 +1,11 @@
 import { SocketModeClient } from "@slack/socket-mode";
 import { WebClient } from "@slack/web-api";
 import type { GatewayConfig } from "../config";
-import { pickAudience, pickEscalationPool } from "../config";
+import {
+  pickAudience,
+  pickEffectiveEscalationPool,
+  pickEscalationPool,
+} from "../config";
 import {
   formatBackOnlineNotice,
   formatOfflineNotice,
@@ -524,13 +528,55 @@ export class SlackAdapter {
   }): Promise<void> {
     const { channelId, threadTs, askerUserId, request } = args;
     const pool = pickEscalationPool(this.config, request.repo);
-    if (pool.length === 0) {
+    // v0.8.2 (#30): filter out the asker themselves — @-mentioning the
+    // person who just asked the question is useless and creates the
+    // weird "<@U_asker> 想麻煩你補充..." artefact when the pool only
+    // happens to contain them. Helper lives in config.ts so it's
+    // unit-testable in isolation.
+    const effectivePool = pickEffectiveEscalationPool(
+      this.config,
+      request.repo,
+      askerUserId,
+    );
+
+    if (effectivePool.length === 0) {
+      // Two distinct config gaps land here:
+      //   - pool is genuinely empty (host hasn't run `pmk gateway escalation add`)
+      //   - pool resolves to [askerUserId] only (would tag self)
+      // Pre-v0.8.2 we silently logged + skipped, so the host had no
+      // way to know from the Slack thread that the v0.7 escalate flow
+      // was suppressed for a config reason. Now we post a visible
+      // warning naming the fix.
       this.onLog(
-        `escalate requested (repo=${request.repo ?? "—"}) but no contacts configured; skipping mention`,
+        `escalate requested (repo=${request.repo ?? "—"}) but no usable contacts ` +
+          `(pool=[${pool.join(",")}], asker=${askerUserId}); ` +
+          `posting config-hint instead of @-mention`,
       );
+      const scopeLabel = request.repo ? `\`${request.repo}\`` : "default";
+      await this.web.chat
+        .postMessage({
+          channel: channelId,
+          thread_ts: threadTs,
+          text:
+            `:warning: pmk 想 escalate 這題，但目前 ${scopeLabel} 池沒有設定其他 IT/domain 聯絡人。\n` +
+            `host 端設定方式：\n` +
+            (request.repo
+              ? `\`pmk gateway escalation add ${request.repo} <userId>\`（針對此 repo）\n`
+              : "") +
+            `\`pmk gateway escalation add default <userId>\`（fallback 池）\n` +
+            `bot 仍會用既有 PKB 給出 best-effort 答案；之後設定好 pool 再問同樣問題就會自動 @ 對的人。`,
+        })
+        .catch((err) => {
+          this.onLog(
+            `failed to post escalation config-hint: ${(err as Error).message}`,
+          );
+        });
+      // Deliberately do NOT save the pending marker — there's nobody
+      // to wait for, so an absorb hook would never fire.
       return;
     }
-    const mentions = pool.map((id) => `<@${id}>`).join(" ");
+
+    const mentions = effectivePool.map((id) => `<@${id}>`).join(" ");
     const reasonLine = request.reason ? `\n_原因_：${request.reason}` : "";
     await this.web.chat
       .postMessage({
@@ -550,7 +596,7 @@ export class SlackAdapter {
       scope: request.repo,
       reason: request.reason,
       pendingSince: Date.now(),
-      mentionedUserIds: pool,
+      mentionedUserIds: effectivePool,
       askerUserId,
     });
   }

--- a/packages/cli/test/gateway.test.ts
+++ b/packages/cli/test/gateway.test.ts
@@ -47,7 +47,11 @@ import {
   truncate,
 } from "../src/gateway/messaging";
 import type { ChatMessage } from "@pmk/shared";
-import { pickAudience, pickEscalationPool } from "../src/gateway/config";
+import {
+  pickAudience,
+  pickEffectiveEscalationPool,
+  pickEscalationPool,
+} from "../src/gateway/config";
 import {
   AUDIENCE_KEYS,
   pickGatewayPrompt,
@@ -861,6 +865,42 @@ describe("escalation pool picker", () => {
     assert.deepEqual(pickEscalationPool(reload, "erp"), ["U_ERP1", "U_ERP2"]);
     assert.deepEqual(pickEscalationPool(reload, "unknown-repo"), ["U_DEFAULT"]);
     assert.deepEqual(pickEscalationPool(reload, undefined), ["U_DEFAULT"]);
+  });
+
+  // v0.8.2 (#30) — pickEffectiveEscalationPool drops the asker so we
+  // never @-mention the person who just asked.
+  it("pickEffectiveEscalationPool removes asker from the resolved pool", () => {
+    const cfg = loadGatewayConfig();
+    cfg.escalation.default = ["U_HOST"];
+    cfg.escalation.repos = { erp: ["U_HOST", "U_IT1", "U_IT2"] };
+    saveGatewayConfig(cfg);
+    const reload = loadGatewayConfig();
+    // Asker is in the repo pool — should drop self, keep U_IT1, U_IT2.
+    assert.deepEqual(pickEffectiveEscalationPool(reload, "erp", "U_HOST"), [
+      "U_IT1",
+      "U_IT2",
+    ]);
+    // Asker is the only one in the default pool — effective pool empty.
+    assert.deepEqual(
+      pickEffectiveEscalationPool(reload, "unknown-repo", "U_HOST"),
+      [],
+    );
+    // Asker not in pool at all — pool unchanged.
+    assert.deepEqual(pickEffectiveEscalationPool(reload, "erp", "U_OTHER"), [
+      "U_HOST",
+      "U_IT1",
+      "U_IT2",
+    ]);
+  });
+
+  it("pickEffectiveEscalationPool returns [] when both pool branches are empty", () => {
+    const cfg = loadGatewayConfig();
+    cfg.escalation.default = [];
+    cfg.escalation.repos = {};
+    saveGatewayConfig(cfg);
+    const reload = loadGatewayConfig();
+    assert.deepEqual(pickEffectiveEscalationPool(reload, "erp", "U_X"), []);
+    assert.deepEqual(pickEffectiveEscalationPool(reload, undefined, "U_X"), []);
   });
 });
 


### PR DESCRIPTION
Closes #30.

## Why

Two related defects in the v0.7.0 escalate flow surfaced during 2026-04-28 dogfood:

1. **Silent suppression on empty pool.** \`handleEscalation\` logged \`escalate requested but no contacts configured; skipping mention\` and posted **nothing** to Slack. The bot's reply degraded to prose ("建議兩個行動: SQL 查 / 找 AOE/PM 同仁") which from the host's perspective looked like a deliberate decision rather than a suppressed v0.7 directive. Real config gap, invisible.

2. **Asker would be @-mentioned at themselves.** If the host had only added themselves to the default pool (e.g. during initial bootstrap), the bot would emit \`<@U_asker> 想麻煩你補充, pmk 沒有足夠 context...\` — pointing the asker at themselves. Useless.

## Fix

- New helper \`pickEffectiveEscalationPool(cfg, repo, askerUserId)\` in \`gateway/config.ts\` — \`pickEscalationPool\` plus a self-filter. Single-source-of-truth so SlackAdapter isn't the only place doing the filter.
- \`handleEscalation\` uses the effective pool. When empty (genuinely empty OR was only-asker), posts a visible \`:warning:\` in the Slack thread naming the config gap:

  > :warning: pmk 想 escalate 這題，但目前 \`erp\` 池沒有設定其他 IT/domain 聯絡人。
  > host 端設定方式：
  > \`pmk gateway escalation add erp <userId>\`（針對此 repo）
  > \`pmk gateway escalation add default <userId>\`（fallback 池）
  > bot 仍會用既有 PKB 給出 best-effort 答案；之後設定好 pool 再問同樣問題就會自動 @ 對的人。

- **Skips \`saveThreadEscalation\` when effective pool is empty** — no pending marker, because there's no contributor to wait for.

## Tests

156 → 158 (+2 unit tests on \`pickEffectiveEscalationPool\`):
- Asker in repo pool → dropped, others retained
- Both pool branches empty → \`[]\`
- Asker not in pool → unchanged

Existing \`pickEscalationPool\` tests still cover the un-filtered branch.

## Test plan

- [ ] On the live workspace where pool currently has only the host: trigger an escalate flow, expect the new \`:warning:\` message with the exact \`escalation add\` hint
- [ ] Add a real IT contact (\`pmk gateway escalation add default U0IT1\`) and trigger again; expect the original happy-path \`@\`-mention to U0IT1 (not the host)
- [ ] Verify host log line: \`escalate requested (repo=erp) but no usable contacts (pool=[U_HOST], asker=U_HOST); posting config-hint instead of @-mention\`