### PR TITLE
feat(cli): atoms search + edit + commander option pass-through (closes #20)

### DIFF
--- a/apps/docs/docs/changelog.md
+++ b/apps/docs/docs/changelog.md
@@ -8,6 +8,24 @@ All notable changes to **pm-workspace-kit** are documented here.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each release also has a longer narrative on [GitHub Releases](https://github.com/hanfour/pm-workspace-kit/releases) with rationale, dogfood notes, and test plans.
 
+## [v0.8.3] — 2026-04-28 — atoms search + edit CLI + commander option pass-through
+
+[GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.8.3) · closes [#20](https://github.com/hanfour/pm-workspace-kit/issues/20)
+
+### Added
+
+- **`pmk gateway atoms search <query> [--scope <name>] [--limit N]`** — wraps `searchAtoms()` for dry-run retrieval ranking. Useful for sanity-checking after a new atom lands ("would this be retrieved when someone asks X?") without DM-ing the bot. Output: rank | id-prefix | scope | tags | question table.
+- **`pmk gateway atoms edit <id-or-prefix>`** — opens the atom's `.md` in `$EDITOR` (fallback `vi`). Post-save validation: re-parses via `gray-matter`, ensures `id` and `createdAt` are unchanged, restores the pre-edit version on parse failure. Tag/summary/answer changes are unrestricted.
+
+### Fixed
+
+- **Commander option pass-through.** Previously `pmk gateway atoms list --pending`, `--scope`, `--limit` etc. were eaten by Commander as unknown root options before reaching the gateway handler. Workaround was `pmk gateway atoms list -- --pending`. Now `--xxx` flags pass through cleanly via `enablePositionalOptions()` + `passThroughOptions()`.
+  - The deprecated `pmk gateway escalation add --default <userId>` form still works (still emits a deprecation warning).
+
+### Tests
+
+158/158 pass (no new — the underlying `searchAtoms` and `findAtomByPrefix` are tested; CLI integration verified via manual smoke).
+
 ## [v0.8.2] — 2026-04-28 — escalate self-tag detection
 
 [GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.8.2) · closes [#30](https://github.com/hanfour/pm-workspace-kit/issues/30)

--- a/packages/cli/src/commands/gateway.ts
+++ b/packages/cli/src/commands/gateway.ts
@@ -18,7 +18,9 @@ import {
   findAtomByPrefix,
   loadAtoms,
   rejectAtom,
+  searchAtoms,
 } from "../gateway/knowledge";
+import { spawnSync } from "node:child_process";
 
 export async function gatewayCommand(
   action: string,
@@ -462,6 +464,8 @@ function atomsUsage(): void {
       "usage:\n" +
         "  pmk gateway atoms list [--all|--pending|--approved] [--scope <name>]\n" +
         "  pmk gateway atoms show <id-or-prefix>\n" +
+        "  pmk gateway atoms search <query> [--scope <name>] [--limit N]\n" +
+        "  pmk gateway atoms edit <id-or-prefix>\n" +
         "  pmk gateway atoms approve <id-or-prefix>\n" +
         "  pmk gateway atoms reject <id-or-prefix>",
     ),
@@ -559,6 +563,134 @@ function atomsCmd(rest: string[]): void {
       }
       println(chalk.bold("Answer"));
       println(found.atom.answer);
+      return;
+    }
+    case "search": {
+      // pmk gateway atoms search <query> [--scope <name>] [--limit N]
+      // Wraps searchAtoms() so the host can dry-run retrieval ranking
+      // without sending a real Slack message — useful after adding a
+      // new atom to verify "would this be retrieved when someone asks
+      // X?" without DM-ing the bot.
+      const scopeIdx = args.indexOf("--scope");
+      const limitIdx = args.indexOf("--limit");
+      const scope = scopeIdx >= 0 ? args[scopeIdx + 1] : undefined;
+      const limitArg =
+        limitIdx >= 0 ? Number.parseInt(args[limitIdx + 1], 10) : NaN;
+      const limit = Number.isFinite(limitArg) && limitArg > 0 ? limitArg : 5;
+      // Reconstruct the query from positional args (everything not a flag).
+      const queryParts: string[] = [];
+      for (let i = 0; i < args.length; i++) {
+        if (args[i] === "--scope" || args[i] === "--limit") {
+          i++; // skip the value too
+          continue;
+        }
+        queryParts.push(args[i]);
+      }
+      const query = queryParts.join(" ").trim();
+      if (!query) {
+        atomsUsage();
+        process.exit(1);
+      }
+      const hits = searchAtoms(query, { scope, limit });
+      println(
+        chalk.bold(
+          `\nsearch results for ${JSON.stringify(query)}${scope ? ` in scope ${scope}` : ""} (top ${limit})`,
+        ),
+      );
+      if (hits.length === 0) {
+        println(
+          chalk.dim(
+            "  (no approved atoms matched — pending atoms are excluded by design)",
+          ),
+        );
+        return;
+      }
+      println(
+        chalk.dim(
+          "  rank  id-prefix             scope       tags                              question",
+        ),
+      );
+      hits.forEach((atom, i) => {
+        const idShort = atom.id
+          .split("-")
+          .slice(0, 2)
+          .join("-")
+          .padEnd(20)
+          .slice(0, 20);
+        const tags = atom.tags.slice(0, 3).join(", ").padEnd(32).slice(0, 32);
+        const q = atom.question.slice(0, 60);
+        println(
+          `  ${String(i + 1).padStart(4)}  ${idShort}  ${atom.scope.padEnd(10).slice(0, 10)}  ${tags}  ${q}`,
+        );
+      });
+      return;
+    }
+    case "edit": {
+      // pmk gateway atoms edit <id-or-prefix> — open the .md file in
+      // $EDITOR (fallback `vi`), validate post-save, atomic replace.
+      const [idOrPrefix] = args;
+      if (!idOrPrefix) {
+        atomsUsage();
+        process.exit(1);
+      }
+      const found = findAtomByPrefix(idOrPrefix);
+      if (!found) {
+        println(
+          chalk.red(
+            `no unique match for '${idOrPrefix}'. Try a longer prefix.`,
+          ),
+        );
+        process.exit(1);
+      }
+      const editor = process.env.EDITOR || process.env.VISUAL || "vi";
+      // Backup the original so we can restore on failure.
+      const originalContent = fs.readFileSync(found.file, "utf8");
+      const backupPath = `${found.file}.editbak`;
+      fs.writeFileSync(backupPath, originalContent, "utf8");
+
+      println(
+        chalk.dim(
+          `opening ${found.file} in ${editor}\n  (post-save: validate front-matter; required fields must keep id/createdAt/question/source)`,
+        ),
+      );
+      const editResult = spawnSync(editor, [found.file], { stdio: "inherit" });
+      if (editResult.status !== 0) {
+        // User aborted ($EDITOR exited non-zero) — leave file alone.
+        fs.unlinkSync(backupPath);
+        println(chalk.dim("(editor exited non-zero; no changes made)"));
+        return;
+      }
+
+      // Re-parse via findAtomByPrefix to validate the post-edit file.
+      const reparsed = findAtomByPrefix(found.atom.id);
+      if (!reparsed) {
+        // Required fields broken; restore.
+        fs.writeFileSync(found.file, originalContent, "utf8");
+        fs.unlinkSync(backupPath);
+        println(
+          chalk.red(
+            "post-edit validation failed (front-matter unparseable or missing required fields). Restored original.",
+          ),
+        );
+        process.exit(1);
+      }
+      // Tag/contributor changes are fine; identity must hold.
+      if (
+        reparsed.atom.id !== found.atom.id ||
+        reparsed.atom.createdAt !== found.atom.createdAt
+      ) {
+        fs.writeFileSync(found.file, originalContent, "utf8");
+        fs.unlinkSync(backupPath);
+        println(
+          chalk.red(
+            "post-edit validation failed (id or createdAt changed). Restored original.",
+          ),
+        );
+        process.exit(1);
+      }
+
+      fs.unlinkSync(backupPath);
+      println(chalk.green(`edited: ${reparsed.atom.id}`));
       return;
     }
     case "approve": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,13 @@ dotenv.config({ quiet: true });
 
 const program = new Command();
 
+// Required for `gateway` subcommand's passThroughOptions — without
+// enablePositionalOptions on the root program, commander throws at
+// init time. This makes commander treat first-positional as the
+// command boundary, so flags after `gateway <action>` go to the
+// subcommand's handler instead of being parsed at root.
+program.enablePositionalOptions();
+
 program
   .name("pmk")
   .description(
@@ -68,8 +75,15 @@ program
 program
   .command("gateway <action> [args...]")
   .description(
-    "Run a Slack/LINE bridge so other PMs and stakeholders can chat with pmk via the messengers they already use. Actions: init / start / status / stats.",
+    "Run a Slack/LINE bridge so other PMs and stakeholders can chat with pmk via the messengers they already use. Actions: init / start / status / stats / audience / escalation / atoms.",
   )
+  // Sub-actions parse their own --flags (--pending, --scope, --limit, etc.).
+  // Without this, commander eats any unknown --xxx option before our handler
+  // sees it, forcing users to type `pmk gateway atoms list -- --pending`.
+  // .allowUnknownOption + .passThroughOptions makes the gateway command
+  // forward all unknown args (flags or positional) verbatim to args[].
+  .allowUnknownOption()
+  .passThroughOptions()
   .action(async (action: string, rest: string[]) => {
     await gatewayCommand(action, rest);
   });


### PR DESCRIPTION
Closes #20.

## What

`pmk gateway atoms search <query> [--scope <name>] [--limit N]` — dry-run retrieval ranking from CLI. Useful after adding a new atom: "would this be retrieved when someone asks X?" without DM-ing the bot.

`pmk gateway atoms edit <id-or-prefix>` — opens the atom's .md in $EDITOR (fallback vi). Post-save validates via gray-matter; restores original on parse failure or identity drift (id/createdAt changed).

## Bonus fix

`enablePositionalOptions()` + `passThroughOptions()` on the gateway command lets all sub-action --flags reach the handler:

- `pmk gateway atoms list --pending` ✅ (previously needed `-- --pending`)
- `pmk gateway atoms search ... --scope erp --limit 5` ✅
- `pmk gateway escalation add --default U0X` ✅ (still works, still deprecated with warning)

## Tests

158/158 pass; manual CLI smoke against the dogfood atom corpus.