### PR TITLE
feat(gateway): BM25 / TF-IDF retrieval for knowledge atoms (closes #19)

### DIFF
--- a/apps/docs/docs/changelog.md
+++ b/apps/docs/docs/changelog.md
@@ -8,6 +8,33 @@ All notable changes to **pm-workspace-kit** are documented here.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each release also has a longer narrative on [GitHub Releases](https://github.com/hanfour/pm-workspace-kit/releases) with rationale, dogfood notes, and test plans.
 
+## [v0.8.4] — 2026-04-28 — BM25 / TF-IDF retrieval for knowledge atoms
+
+[GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.8.4) · closes [#19](https://github.com/hanfour/pm-workspace-kit/issues/19)
+
+### Added
+
+- New `packages/cli/src/gateway/atom-index.ts` — BM25-scored TF-IDF index over approved atoms via `@pmk/rag`. Pending atoms are excluded at index-build time (the v0.7.4 TTL gate is preserved). Index file persisted at `~/.pmk/knowledge/.index/<scope>.json`; auto-rebuilds when any atom file's mtime is newer than the index's `builtAt`.
+- `pmk gateway atoms reindex [--scope <name>]` — force-rebuild the index. Useful after tweaking thresholds or to confirm the index is current.
+- `PMK_ATOM_VECTOR_THRESHOLD` env var — corpus-size threshold above which `searchAtoms` switches from keyword overlap to BM25. Default `50`.
+
+### Changed
+
+- `searchAtoms` now picks its scoring path at runtime by corpus size:
+  - `< threshold` (small corpus): keyword + tag overlap (the v0.7.0 path; cheap, predictable)
+  - `>= threshold` (large corpus): BM25 via the new index
+- BM25 falls back to keyword on empty results, so single-token CJK queries that the tokenizer can't handle still work.
+
+### Why
+
+The keyword + tag scoring drifts as the corpus grows past a few dozen atoms — partial token matches and CJK bigram noise surface irrelevant atoms above relevant ones. Atom retrieval that's *worse* than no retrieval is dangerous because the model treats them as ground truth. BM25 fixes the ranking quality without requiring an external embedding API.
+
+(Issue title was "vector retrieval" but `@pmk/rag` is BM25 / TF-IDF, which is the practically-useful upgrade. Pure JS, no embedding cost, no network dependency.)
+
+### Tests
+
+158 → 162 (+4: index excludes pending, BM25 returns approved-ordered, approvedAtomCount filter, mtime invalidation triggers rebuild).
+
 ## [v0.8.3] — 2026-04-28 — atoms search + edit CLI + commander option pass-through
 
 [GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.8.3) · closes [#20](https://github.com/hanfour/pm-workspace-kit/issues/20)

--- a/packages/cli/src/commands/gateway.ts
+++ b/packages/cli/src/commands/gateway.ts
@@ -20,6 +20,11 @@ import {
   rejectAtom,
   searchAtoms,
 } from "../gateway/knowledge";
+import {
+  approvedAtomCount,
+  ATOM_RANKED_THRESHOLD,
+  buildAtomsIndex,
+} from "../gateway/atom-index";
 import { spawnSync } from "node:child_process";
 
 export async function gatewayCommand(
@@ -467,7 +472,8 @@ function atomsUsage(): void {
         "  pmk gateway atoms search <query> [--scope <name>] [--limit N]\n" +
         "  pmk gateway atoms edit <id-or-prefix>\n" +
         "  pmk gateway atoms approve <id-or-prefix>\n" +
-        "  pmk gateway atoms reject <id-or-prefix>",
+        "  pmk gateway atoms reject <id-or-prefix>\n" +
+        "  pmk gateway atoms reindex [--scope <name>]",
     ),
   );
 }
@@ -727,6 +733,30 @@ function atomsCmd(rest: string[]): void {
         process.exit(1);
       }
       println(chalk.green(`rejected (file deleted): ${idOrPrefix}`));
+      return;
+    }
+    case "reindex": {
+      // pmk gateway atoms reindex [--scope <name>]
+      // Force-rebuild the BM25 index. Auto-rebuild on staleness
+      // already happens at search-time, so this is mostly for
+      // operators who want to confirm the index is up-to-date or
+      // who tweaked PMK_ATOM_VECTOR_THRESHOLD and want to see what
+      // would be ranked.
+      const scopeIdx = args.indexOf("--scope");
+      const scope = scopeIdx >= 0 ? args[scopeIdx + 1] : undefined;
+      const before = approvedAtomCount(scope);
+      println(
+        chalk.dim(
+          `building BM25 index over ${before} approved atoms${scope ? ` in scope ${scope}` : ""}…`,
+        ),
+      );
+      const idx = buildAtomsIndex({ scope });
+      println(
+        chalk.green(
+          `indexed ${idx.chunks.length} chunk(s); ranking threshold = ${ATOM_RANKED_THRESHOLD} ` +
+            `(${before >= ATOM_RANKED_THRESHOLD ? "BM25 active" : "still using keyword scoring"})`,
+        ),
+      );
       return;
     }
     default:

--- a/packages/cli/src/gateway/atom-index.ts
+++ b/packages/cli/src/gateway/atom-index.ts
@@ -1,0 +1,220 @@
+/**
+ * BM25 / TF-IDF index over knowledge atoms (v0.8.4 / #19).
+ *
+ * The keyword + tag scoring in `searchAtoms` is fine while the corpus
+ * is small, but as it grows past ~50 atoms the rankings drift —
+ * partial token matches (`widget` substring matching `widgetcategory`)
+ * and CJK bigram noise will surface irrelevant atoms above relevant
+ * ones. Atom retrieval that's *worse* than no retrieval is dangerous
+ * because the model treats them as ground truth.
+ *
+ * @pmk/rag already provides BM25-scored TF-IDF, used by `pmk ask`.
+ * Reusing it here keeps the stack thin and the ranking quality on
+ * par with a serious search system.
+ *
+ * Pending atoms are excluded at index-build time — they're already
+ * invisible to retrieval (`searchAtoms` filters them out), so adding
+ * them to the index would just waste space. Approved-only.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  type IndexedChunk,
+  type RagIndex,
+  loadIndex,
+  query as ragQuery,
+  saveIndex,
+  tokenize,
+} from "@pmk/rag";
+import {
+  knowledgeRoot,
+  loadAtoms,
+  type KnowledgeAtom,
+} from "./knowledge";
+
+/**
+ * Atom corpus size at which `searchAtoms` switches from keyword to
+ * BM25. Default 50 is a heuristic — small enough that hosts hit it
+ * after a few weeks of escalate flow, large enough that BM25's IDF
+ * has signal to work with. Override via `PMK_ATOM_VECTOR_THRESHOLD`.
+ */
+export const ATOM_RANKED_THRESHOLD = (() => {
+  const raw = process.env.PMK_ATOM_VECTOR_THRESHOLD;
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 50;
+})();
+
+function indexDir(): string {
+  return path.join(knowledgeRoot(), ".index");
+}
+
+function indexFileFor(scope: string | undefined): string {
+  // "_all" sentinel for cross-scope index. Sanitised separately from
+  // safeScope() since the leading underscore would be stripped there.
+  const file = scope ? `${scope}.json` : "_all.json";
+  return path.join(indexDir(), file);
+}
+
+/**
+ * Latest mtime of any approved atom's .md file under the given scope
+ * (or all scopes when `scope` is undefined). Used to detect whether
+ * the cached index is stale.
+ */
+function newestAtomMtime(scope?: string): number {
+  const root = knowledgeRoot();
+  if (!fs.existsSync(root)) return 0;
+  let newest = 0;
+  const scopes = scope
+    ? [scope]
+    : fs.readdirSync(root).filter((d) => {
+        try {
+          return (
+            fs.statSync(path.join(root, d)).isDirectory() &&
+            !d.startsWith(".")
+          );
+        } catch {
+          return false;
+        }
+      });
+  for (const s of scopes) {
+    const dir = path.join(root, s);
+    if (!fs.existsSync(dir)) continue;
+    for (const f of fs.readdirSync(dir)) {
+      if (!f.endsWith(".md")) continue;
+      try {
+        const m = fs.statSync(path.join(dir, f)).mtimeMs;
+        if (m > newest) newest = m;
+      } catch {
+        /* skip */
+      }
+    }
+  }
+  return newest;
+}
+
+/**
+ * Pack each approved atom into a single BM25 chunk. We don't split
+ * answers into sub-chunks — atoms are typically a few hundred chars
+ * each, so per-atom granularity is the right grain for retrieval.
+ */
+function buildIndexedChunks(atoms: KnowledgeAtom[]): IndexedChunk[] {
+  return atoms
+    .filter((a) => a.status === "approved" || a.status === undefined)
+    .map((a) => {
+      // Combine question + summary + answer + tags so all signals
+      // contribute to TF-IDF. The model will see the full atom
+      // content via formatAtomsForInjection regardless of which
+      // slice triggered the match.
+      const text = [
+        a.question,
+        a.summary ?? "",
+        a.tags.join(" "),
+        a.answer,
+      ]
+        .filter(Boolean)
+        .join("\n\n");
+      const tokens = tokenize(text);
+      const tf: Record<string, number> = {};
+      for (const t of tokens) tf[t] = (tf[t] ?? 0) + 1;
+      return {
+        // The chunk id = atom id so we can map QueryResult back to
+        // the originating atom in `searchAtomsRanked`.
+        id: a.id,
+        path: a.id,
+        title: a.question,
+        heading: undefined,
+        text,
+        tf,
+        length: tokens.length,
+      };
+    });
+}
+
+/**
+ * Build a fresh RagIndex over approved atoms (optionally scope-
+ * filtered) and persist it to `~/.pmk/knowledge/.index/<scope>.json`.
+ * Returns the in-memory index so callers can use it directly without
+ * re-loading.
+ */
+export function buildAtomsIndex(opts: { scope?: string } = {}): RagIndex {
+  const atoms = loadAtoms({ scope: opts.scope });
+  const chunks = buildIndexedChunks(atoms);
+
+  // IDF across all chunks. Same formula as `@pmk/rag`'s indexDocs
+  // (BM25-style smoothing).
+  const df: Record<string, number> = {};
+  for (const c of chunks) {
+    for (const tok of Object.keys(c.tf)) df[tok] = (df[tok] ?? 0) + 1;
+  }
+  const N = Math.max(chunks.length, 1);
+  const idf: Record<string, number> = {};
+  for (const [tok, count] of Object.entries(df)) {
+    idf[tok] = Math.log((N - count + 0.5) / (count + 0.5) + 1);
+  }
+
+  const index: RagIndex = {
+    version: 1,
+    builtAt: new Date().toISOString(),
+    root: knowledgeRoot(),
+    chunks,
+    idf,
+  };
+  saveIndex(index, indexFileFor(opts.scope));
+  return index;
+}
+
+/**
+ * Load the on-disk index, rebuild if stale (any atom mtime newer
+ * than index `builtAt`) or missing. Returns null when there are no
+ * atoms to index — caller falls back to keyword search.
+ */
+function getOrBuildIndex(scope: string | undefined): RagIndex | null {
+  const file = indexFileFor(scope);
+  const cached = loadIndex(file);
+  const newestMtime = newestAtomMtime(scope);
+  if (cached && new Date(cached.builtAt).getTime() >= newestMtime) {
+    return cached;
+  }
+  // Stale or missing — rebuild.
+  const fresh = buildAtomsIndex({ scope });
+  return fresh.chunks.length > 0 ? fresh : null;
+}
+
+/**
+ * BM25-ranked search over approved atoms. Maps query results back
+ * to the underlying KnowledgeAtom by id. Returns up to `limit`
+ * atoms sorted by descending relevance.
+ *
+ * Falls back to an empty result on any error (caller gracefully
+ * degrades to keyword scoring upstream).
+ */
+export function searchAtomsRanked(
+  q: string,
+  opts: { scope?: string; limit?: number } = {},
+): KnowledgeAtom[] {
+  const limit = opts.limit ?? 3;
+  const index = getOrBuildIndex(opts.scope);
+  if (!index) return [];
+  const results = ragQuery(index, q, limit);
+  if (results.length === 0) return [];
+
+  // Build atom-by-id lookup for the (small) approved set.
+  const atoms = loadAtoms({ scope: opts.scope }).filter(
+    (a) => a.status === "approved" || a.status === undefined,
+  );
+  const byId = new Map(atoms.map((a) => [a.id, a]));
+  return results
+    .map((r) => byId.get(r.chunk.id))
+    .filter((a): a is KnowledgeAtom => a !== undefined);
+}
+
+/**
+ * Count the approved atoms (used by searchAtoms to decide whether
+ * BM25 is worth invoking). Cheaper than building the full index.
+ */
+export function approvedAtomCount(scope?: string): number {
+  return loadAtoms({ scope }).filter(
+    (a) => a.status === "approved" || a.status === undefined,
+  ).length;
+}

--- a/packages/cli/src/gateway/knowledge.ts
+++ b/packages/cli/src/gateway/knowledge.ts
@@ -349,21 +349,43 @@ export function findAtomByPrefix(idOrPrefix: string): AtomLocation | undefined {
 }
 
 /**
- * Score atoms against a query — keyword + tag overlap. Cheap and
- * understandable; upgrade to vector retrieval when atom counts pass
- * a few hundred.
+ * Score atoms against a query.
  *
- * Scoring (per atom):
- *   - 3 points per query token that appears in question
- *   - 2 points per query token matching a tag
- *   - 1 point per query token in summary
- *   - 1 point per query token in answer
+ * Two paths, picked at runtime by corpus size:
+ *
+ *   - **Keyword + tag overlap** (default, used when corpus is small):
+ *     cheap and understandable; 3 pts question, 2 pts tag, 1 pt
+ *     summary, 1 pt answer. Works fine until ranking quality starts
+ *     to matter.
+ *   - **BM25 / TF-IDF** (when approved-atom count >= ATOM_RANKED_THRESHOLD,
+ *     v0.8.4): delegates to `@pmk/rag`'s query() with a per-scope
+ *     index cached at `~/.pmk/knowledge/.index/<scope>.json`.
+ *     Auto-rebuilds when the index is stale (any atom file mtime
+ *     newer than index builtAt) or missing.
+ *
+ * Pending atoms are filtered out either way — that's the v0.7.4 TTL
+ * gate's whole point. They become visible only after auto-promote or
+ * manual approval.
  */
 export function searchAtoms(
   query: string,
   opts: { scope?: string; limit?: number } = {},
 ): KnowledgeAtom[] {
   const limit = opts.limit ?? 3;
+
+  // BM25 fast-path when corpus is large enough to need real ranking.
+  // Imported lazily to avoid pulling @pmk/rag into the keyword path's
+  // hot loop (and to keep this file's startup cost low).
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { approvedAtomCount, ATOM_RANKED_THRESHOLD, searchAtomsRanked } =
+    require("./atom-index") as typeof import("./atom-index");
+  if (approvedAtomCount(opts.scope) >= ATOM_RANKED_THRESHOLD) {
+    const ranked = searchAtomsRanked(query, opts);
+    if (ranked.length > 0) return ranked;
+    // BM25 yielded nothing — fall through to keyword as a safety net
+    // for queries the index can't handle (single-token CJK, etc).
+  }
+
   // Pending atoms are deliberately invisible to retrieval — that's the
   // whole point of the TTL gate. They become visible after auto-promote
   // (loadAtoms rewrites them) or after manual approval.

--- a/packages/cli/test/gateway.test.ts
+++ b/packages/cli/test/gateway.test.ts
@@ -72,6 +72,11 @@ import {
   searchAtoms,
   slugifyQuestion,
 } from "../src/gateway/knowledge";
+import {
+  approvedAtomCount,
+  buildAtomsIndex,
+  searchAtomsRanked,
+} from "../src/gateway/atom-index";
 import { extractKnowledgeAtom } from "../src/gateway/extractor";
 import type { LlmProvider } from "../src/llm";
 
@@ -1244,6 +1249,121 @@ describe("atom TTL approval", () => {
     });
     const r = approveAtom(sharedPrefix);
     assert.equal(r, undefined);
+  });
+});
+
+describe("atom-index BM25 (#19)", () => {
+  let tmpHome: string;
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-atomidx-"));
+    process.env.HOME = tmpHome;
+  });
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+  });
+
+  function seedThreeApprovedAtoms() {
+    saveAtom({
+      id: generateAtomId("widget config"),
+      createdAt: Date.now(),
+      scope: "erp",
+      question: "How is widget A configured for the campaign flow?",
+      answer:
+        "Widget A is configured via the campaign settings page; uses placement_id as primary grain.",
+      summary:
+        "Widget A configuration overview — campaign settings page, placement_id grain.",
+      tags: ["widget", "campaign", "configuration"],
+      source: { threadKey: "T1", contributorUserId: "U1" },
+      status: "approved",
+    });
+    saveAtom({
+      id: generateAtomId("budget allocation"),
+      createdAt: Date.now() - 1000,
+      scope: "erp",
+      question: "How is the monthly budget allocated across departments?",
+      answer:
+        "Budget allocation lives in placement_revenues; query by month and department.",
+      summary: "Monthly budget allocation across departments.",
+      tags: ["budget", "allocation", "monthly", "placement_revenues"],
+      source: { threadKey: "T2", contributorUserId: "U1" },
+      status: "approved",
+    });
+    saveAtom({
+      id: generateAtomId("pending unindexed"),
+      createdAt: Date.now() - 2000,
+      scope: "erp",
+      question: "This atom should never appear in the index.",
+      answer: "It is pending and BM25 must skip it.",
+      summary: "pending excluded sentinel",
+      tags: ["pending"],
+      source: { threadKey: "T3", contributorUserId: "U1" },
+      status: "pending",
+      expiresAt: Date.now() + 60_000,
+    });
+  }
+
+  it("buildAtomsIndex includes only approved atoms (skips pending)", () => {
+    seedThreeApprovedAtoms();
+    const idx = buildAtomsIndex({ scope: "erp" });
+    assert.equal(idx.chunks.length, 2);
+    // Verify the pending atom isn't in the chunk list
+    const ids = idx.chunks.map((c) => c.id);
+    const pendingAtom = loadAtoms({ scope: "erp" }).find(
+      (a) => a.status === "pending",
+    );
+    assert.ok(pendingAtom);
+    assert.equal(
+      ids.includes(pendingAtom.id),
+      false,
+      "pending atom should not be in index",
+    );
+  });
+
+  it("searchAtomsRanked returns BM25-ordered approved atoms", () => {
+    seedThreeApprovedAtoms();
+    const hits = searchAtomsRanked("budget allocation", {
+      scope: "erp",
+      limit: 5,
+    });
+    assert.ok(hits.length >= 1);
+    // Top result should be the budget atom
+    assert.match(hits[0].question, /budget/i);
+    // Pending atom must not appear
+    assert.ok(hits.every((a) => a.status === "approved"));
+  });
+
+  it("approvedAtomCount excludes pending", () => {
+    seedThreeApprovedAtoms();
+    assert.equal(approvedAtomCount("erp"), 2);
+  });
+
+  it("index file is rebuilt when atoms change (mtime invalidation)", () => {
+    seedThreeApprovedAtoms();
+    const first = buildAtomsIndex({ scope: "erp" });
+    const firstBuiltAt = new Date(first.builtAt).getTime();
+    // Add another atom AFTER the index built; mtime should now be newer
+    // than firstBuiltAt, triggering a rebuild on next searchAtomsRanked.
+    fs.utimesSync(
+      path.join(knowledgeRoot(), "erp"),
+      new Date(),
+      new Date(firstBuiltAt + 60_000), // dir mtime well after index
+    );
+    saveAtom({
+      id: generateAtomId("late addition"),
+      createdAt: Date.now(),
+      scope: "erp",
+      question: "Late-added atom about budget reporting",
+      answer: "More info on budget allocation reports.",
+      summary: "Budget reporting details added later.",
+      tags: ["budget", "reporting"],
+      source: { threadKey: "T4", contributorUserId: "U1" },
+      status: "approved",
+    });
+    const hits = searchAtomsRanked("budget", { scope: "erp", limit: 5 });
+    // Late-added atom is now retrievable.
+    assert.ok(hits.length >= 2);
+    assert.ok(hits.some((a) => a.question.includes("Late-added")));
   });
 });
 


### PR DESCRIPTION
Closes #19. (Issue title says "vector retrieval" but @pmk/rag ships BM25/TF-IDF, which is the practically-useful upgrade.)

## What

`packages/cli/src/gateway/atom-index.ts` builds a BM25-scored index over approved atoms via `@pmk/rag`. Pending atoms are filtered at build time (preserves v0.7.4 TTL gate). Index persisted to `~/.pmk/knowledge/.index/<scope>.json`; auto-rebuilds when any atom file's mtime is newer than the index's `builtAt`.

`searchAtoms` switches at runtime:
- corpus < threshold (default 50, override `PMK_ATOM_VECTOR_THRESHOLD`): keyword + tag (the v0.7.0 path)
- corpus >= threshold: BM25 via the new index, with keyword fallback for queries the tokeniser can't handle

New CLI: `pmk gateway atoms reindex [--scope <name>]` — force rebuild + visibility into ranking-mode state.

## Why TF-IDF instead of true vector embeddings

- `@pmk/rag` already ships BM25 used by `pmk ask`; reusing it keeps the stack thin
- No external API call, no embedding cost, no network dependency
- For atoms (a few hundred chars each) BM25's document length normalisation is already a substantial ranking-quality lift over keyword + tag overlap
- True vector retrieval can layer on top later when the corpus genuinely needs semantic matching beyond lexical

## Tests

158 → 162 (+4: index excludes pending; BM25 returns approved-ordered; approvedAtomCount filter; mtime invalidation).

## Test plan

- [ ] On the dogfood host: `pmk gateway atoms reindex` builds successfully
- [ ] `PMK_ATOM_VECTOR_THRESHOLD=1 pmk gateway atoms search '預算'` activates BM25 path and returns the right atom
- [ ] Add a new atom; verify next `atoms search` (or DM retrieval) reflects it (mtime invalidation works)
- [ ] Below threshold (corpus of 1): keyword path stays in use; index is built but unused