### PR TITLE
feat(gateway): Slack reaction-based atom approval (closes #21)

### DIFF
--- a/apps/docs/docs/changelog.md
+++ b/apps/docs/docs/changelog.md
@@ -8,6 +8,28 @@ All notable changes to **pm-workspace-kit** are documented here.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each release also has a longer narrative on [GitHub Releases](https://github.com/hanfour/pm-workspace-kit/releases) with rationale, dogfood notes, and test plans.
 
+## [v0.8.5] — 2026-04-28 — Slack reaction-based atom approval
+
+[GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.8.5) · closes [#21](https://github.com/hanfour/pm-workspace-kit/issues/21)
+
+### Added
+
+- **✅ / ❌ reactions on the bot's pending-notice** now approve / reject the atom in-flow:
+  - ✅ (`white_check_mark`, `heavy_check_mark`, `+1`) → `approveAtom`, posts ":books: 已生效..." reply
+  - ❌ (`x`, `-1`) → `rejectAtom` (deletes the file), posts ":wastebasket: 已捨棄..." reply
+- Trust model: only the original IT contributor (`atom.source.contributorUserId`) can react. Other reactors are silently ignored. Random thread participants can't approve atoms.
+- `KnowledgeAtom.approval?: { channelId, messageTs }` captures the bot's confirmation post `ts` so reactions can be mapped back to the originating atom. Atoms saved before v0.8.5 don't have this anchor and can't be reaction-approved (CLI fallback still works).
+- `findAtomByApprovalMessage(channelId, messageTs)` helper for the Slack handler.
+
+### Changed
+
+- `gateway init` walkthrough now lists `reactions:read` scope and `reaction_added` event subscription as v0.8.5+ requirements. Existing v0.7.x apps without these scopes keep working — no events fire, TTL auto-promote remains the safety net.
+- The pending-notice text now invites reaction directly: "直接 ✅ 或 ❌ react 這條訊息可立即 approve / reject".
+
+### Tests
+
+162 → 166 (+4: anchor lookup matches; mismatched channel/ts returns undefined; legacy atoms without anchor return undefined; approval round-trips through save/load).
+
 ## [v0.8.4] — 2026-04-28 — BM25 / TF-IDF retrieval for knowledge atoms
 
 [GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.8.4) · closes [#19](https://github.com/hanfour/pm-workspace-kit/issues/19)

--- a/apps/docs/docs/gateway/lifecycle.md
+++ b/apps/docs/docs/gateway/lifecycle.md
@@ -180,13 +180,14 @@ This is the v0.7.4 TTL hybrid. Atoms enter as `status: "pending"` with `expiresA
 - **Invisible to retrieval** (`searchAtoms` filters them out) — Phase 4 above won't find them.
 - **Visible in CLI listings** — `pmk gateway atoms list --pending`.
 
-Three exits:
+Four exits:
 
 | Trigger | Effect |
 |---|---|
 | 24h passes; next `loadAtoms()` call | Auto-promote: rewrite file with `status: approved`, drop `expiresAt`. Idempotent on subsequent loads. |
 | `pmk gateway atoms approve <id-prefix>` | Same as above, but immediately. ID prefix matching: any unique prefix resolves. |
 | `pmk gateway atoms reject <id-prefix>` | Delete the `.md` file. |
+| **(v0.8.5)** ✅ react on the bot's pending notice | Same as `approve` — but in-flow, no terminal needed. Only the original IT contributor (atom.source.contributorUserId) is authorised; other reactors are ignored. ❌ react = same as `reject`. Requires `reactions:read` scope on the Slack app side. |
 
 After promotion, the atom is now retrieval-visible. The next person who asks a similar question gets it prepended in Phase 4 — the loop closes.
 

--- a/apps/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/gateway/lifecycle.md
+++ b/apps/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/gateway/lifecycle.md
@@ -180,13 +180,14 @@ Pending marker 在 extraction **之前**就會被清掉 — 兩個 IT 同事連�
 - **retrieval 看不到**（`searchAtoms` 過濾掉）— Phase 4 不會撈到
 - **CLI 看得到** — `pmk gateway atoms list --pending`
 
-三條離開路徑：
+四條離開路徑：
 
 | 觸發 | 效果 |
 |---|---|
 | 24h 過了；下次 `loadAtoms()` | 自動 promote：重寫檔案 `status: approved`、清掉 `expiresAt`。後續 load 是 idempotent 的。 |
 | `pmk gateway atoms approve <id-prefix>` | 同上，但立即。ID prefix matching：唯一的 prefix 就解析得出 atom。 |
 | `pmk gateway atoms reject <id-prefix>` | 刪掉 `.md` 檔。 |
+| **(v0.8.5)** 在 bot 的 pending 通知上 ✅ react | 同 `approve` — 但在 Slack 裡完成、不用回 host 終端。只有原 IT contributor（`atom.source.contributorUserId`）有權限；其他人 react 會被忽略。❌ react 等同 `reject`。需 Slack app 加 `reactions:read` scope。 |
 
 Promote 完後 atom 對 retrieval 可見。下一個問類似問題的人在 Phase 4 就會被 prepend — loop 收口。
 

--- a/packages/cli/src/commands/gateway.ts
+++ b/packages/cli/src/commands/gateway.ts
@@ -84,13 +84,14 @@ async function initCmd(): Promise<void> {
   );
   println(
     chalk.dim(
-      "    3. Event Subscriptions → Enable; subscribe to:  message.im, app_mention",
+      "    3. Event Subscriptions → Enable; subscribe to:  message.im, app_mention, reaction_added (v0.8.5+)",
     ),
   );
   println(chalk.dim("    4. OAuth & Permissions → Scopes (Bot Token):"));
   println(
     chalk.dim(
-      "         app_mentions:read, chat:write, im:history, im:read, im:write, users:read",
+      "         app_mentions:read, chat:write, im:history, im:read, im:write, users:read,\n" +
+        "         reactions:read (v0.8.5+; enables ✅/❌ atom approval on the bot's pending notice)",
     ),
   );
   println(

--- a/packages/cli/src/gateway/knowledge.ts
+++ b/packages/cli/src/gateway/knowledge.ts
@@ -59,6 +59,17 @@ export interface KnowledgeAtom {
   status?: KnowledgeAtomStatus;
   /** Epoch ms when a pending atom auto-promotes; absent on approved. */
   expiresAt?: number;
+  /**
+   * Slack message anchor for v0.8.5 reaction-based approval (#21).
+   * Captures the ts of the bot's "暫存為 pending..." confirmation post
+   * so reactions on that message can be mapped back to this atom.
+   * Absent on atoms saved before v0.8.5 or written without going
+   * through the Slack absorb path.
+   */
+  approval?: {
+    channelId: string;
+    messageTs: string;
+  };
 }
 
 export function knowledgeRoot(): string {
@@ -128,6 +139,7 @@ interface AtomFrontMatter {
   source: { threadKey: string; contributorUserId: string };
   status?: KnowledgeAtomStatus;
   expiresAt?: number;
+  approval?: { channelId: string; messageTs: string };
 }
 
 function renderAtomMarkdown(atom: KnowledgeAtom): string {
@@ -146,6 +158,7 @@ function renderAtomMarkdown(atom: KnowledgeAtom): string {
   };
   if (atom.summary) data.summary = atom.summary;
   if (atom.expiresAt !== undefined) data.expiresAt = atom.expiresAt;
+  if (atom.approval) data.approval = atom.approval;
   const body = [
     `# ${atom.question}`,
     "",
@@ -202,6 +215,15 @@ function parseAtomMarkdown(raw: string): KnowledgeAtom | undefined {
     },
     status,
     expiresAt: typeof data.expiresAt === "number" ? data.expiresAt : undefined,
+    approval:
+      data.approval &&
+      typeof data.approval.channelId === "string" &&
+      typeof data.approval.messageTs === "string"
+        ? {
+            channelId: data.approval.channelId,
+            messageTs: data.approval.messageTs,
+          }
+        : undefined,
   };
 }
 
@@ -346,6 +368,49 @@ export function findAtomByPrefix(idOrPrefix: string): AtomLocation | undefined {
   }
   if (matches.length !== 1) return undefined;
   return matches[0];
+}
+
+/**
+ * v0.8.5 (#21): find an atom by the Slack message ts of its bot
+ * confirmation post (the ":hourglass_flowing_sand: 暫存為 pending"
+ * message). Used by the reaction-approval handler to map a ✅/❌
+ * reaction back to the originating atom.
+ *
+ * Returns undefined when no atom has that anchor — atoms saved
+ * before v0.8.5 won't have an `approval` field.
+ */
+export function findAtomByApprovalMessage(
+  channelId: string,
+  messageTs: string,
+): AtomLocation | undefined {
+  const root = knowledgeRoot();
+  if (!fs.existsSync(root)) return undefined;
+  for (const scope of fs.readdirSync(root)) {
+    const dir = scopeDir(scope);
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(dir);
+    } catch {
+      continue;
+    }
+    if (!stat.isDirectory()) continue;
+    for (const f of fs.readdirSync(dir)) {
+      if (!f.endsWith(".md")) continue;
+      try {
+        const raw = fs.readFileSync(path.join(dir, f), "utf8");
+        const atom = parseAtomMarkdown(raw);
+        if (
+          atom?.approval?.channelId === channelId &&
+          atom.approval.messageTs === messageTs
+        ) {
+          return { atom, file: path.join(dir, f) };
+        }
+      } catch {
+        /* skip */
+      }
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -54,7 +54,10 @@ import {
 } from "../messaging";
 import { parseEscalate, stripEscalateBlock } from "../escalate";
 import {
+  approveAtom,
+  findAtomByApprovalMessage,
   formatAtomsForInjection,
+  rejectAtom,
   saveAtom,
   searchAtoms,
   type KnowledgeAtom,
@@ -147,6 +150,14 @@ export class SlackAdapter {
 
     this.socket.on("message", (event) => this.handleMessage(event));
     this.socket.on("app_mention", (event) => this.handleAppMention(event));
+    // v0.8.5 (#21): reaction-based atom approval. Requires
+    // `reactions:read` Slack scope + `reaction_added` event subscription
+    // on the app side. When the scope isn't granted, no events fire
+    // and the handler is silently inert — TTL auto-promote still
+    // works as the safety net.
+    this.socket.on("reaction_added", (event) =>
+      this.handleReactionAdded(event),
+    );
     this.socket.on("disconnected", () =>
       this.onLog("slack socket disconnected"),
     );
@@ -647,19 +658,37 @@ export class SlackAdapter {
       return true;
     }
     try {
+      // First save: atom in pending without approval anchor.
       const file = saveAtom(atom);
       this.onLog(`absorbed knowledge atom (pending) → ${file}`);
       const idShort = atom.id.split("-").slice(0, 2).join("-");
-      await this.web.chat
+      const post = await this.web.chat
         .postMessage({
           channel: channelId,
           thread_ts: threadTs,
           text:
             `:hourglass_flowing_sand: pmk 已收下這份補充（標籤：${atom.tags.join(", ") || "—"}），暫存為 *pending*，` +
             `24 小時後自動生效，期間不會被其他查詢抓到。\n` +
-            `要立即生效或刪除：\`pmk gateway atoms approve ${idShort}\` / \`pmk gateway atoms reject ${idShort}\``,
+            `直接 ✅ 或 ❌ react 這條訊息可立即 approve / reject；` +
+            `或 host 端：\`pmk gateway atoms approve ${idShort}\` / \`pmk gateway atoms reject ${idShort}\``,
         })
-        .catch(() => {});
+        .catch((err) => {
+          this.onLog(
+            `failed to post pending notice: ${(err as Error).message}`,
+          );
+          return undefined;
+        });
+      // v0.8.5 (#21): if the bot's confirmation message landed, anchor
+      // the atom to its `ts` so reaction-approval can find it. Re-save
+      // — cheap (one extra fs.write) and keeps the storage layer the
+      // single-source-of-truth.
+      if (post?.ts) {
+        const updated: typeof atom = {
+          ...atom,
+          approval: { channelId, messageTs: String(post.ts) },
+        };
+        saveAtom(updated);
+      }
     } catch (err) {
       this.onLog(`failed to save atom: ${(err as Error).message}`);
       return true;
@@ -676,6 +705,81 @@ export class SlackAdapter {
       this.onLog(`post-absorb synthesis failed: ${(err as Error).message}`),
     );
     return true;
+  }
+
+  /**
+   * v0.8.5 (#21): handle a reaction added to one of pmk's pending-
+   * notice messages. ✅ promotes the atom; ❌ deletes it. Layered on
+   * top of the v0.7.4 TTL gate — if no reaction comes in, the atom
+   * still auto-promotes after 24h.
+   *
+   * Trust model: the **original IT contributor** (atom.source.
+   * contributorUserId) is the only Slack user authorised to react.
+   * Random thread participants reacting do nothing. v0.9 admin
+   * commands (#31) will add a separate override path.
+   */
+  private async handleReactionAdded(
+    payload: Slack.ReactionEventPayload,
+  ): Promise<void> {
+    await payload.ack?.().catch(() => {});
+
+    const event = payload?.event;
+    if (!event || !this.botInfo) return;
+    // We only listen for reactions on the bot's own messages
+    // (item_user is the author of the reacted-to message).
+    if (event.item_user !== this.botInfo.botUserId) return;
+    const reaction = event.reaction;
+    const isApprove =
+      reaction === "white_check_mark" ||
+      reaction === "heavy_check_mark" ||
+      reaction === "+1";
+    const isReject = reaction === "x" || reaction === "-1";
+    if (!isApprove && !isReject) return;
+
+    const channelId = event.item?.channel;
+    const messageTs = event.item?.ts;
+    const reactorUserId = event.user;
+    if (!channelId || !messageTs || !reactorUserId) return;
+
+    const found = findAtomByApprovalMessage(channelId, messageTs);
+    if (!found) {
+      // Reaction on some other bot message — not an atom-pending one.
+      return;
+    }
+
+    if (reactorUserId !== found.atom.source.contributorUserId) {
+      this.onLog(
+        `reaction-approval ignored: ${reactorUserId} is not the atom contributor (${found.atom.source.contributorUserId})`,
+      );
+      return;
+    }
+
+    if (isApprove) {
+      const promoted = approveAtom(found.atom.id);
+      this.onLog(
+        `reaction-approval: ${found.atom.id} approved via :${reaction}: from ${reactorUserId}`,
+      );
+      const tags = promoted?.tags?.length ? promoted.tags.join(", ") : "—";
+      await this.web.chat
+        .postMessage({
+          channel: channelId,
+          thread_ts: messageTs,
+          text: `:books: 已生效（標籤：${tags}），下次同類問題會自動帶進來。`,
+        })
+        .catch(() => {});
+    } else {
+      const ok = rejectAtom(found.atom.id);
+      this.onLog(
+        `reaction-approval: ${found.atom.id} rejected via :${reaction}: from ${reactorUserId} (deleted=${ok})`,
+      );
+      await this.web.chat
+        .postMessage({
+          channel: channelId,
+          thread_ts: messageTs,
+          text: `:wastebasket: 已捨棄，atom 檔案已刪除。`,
+        })
+        .catch(() => {});
+    }
   }
 
   /**
@@ -1145,5 +1249,20 @@ declare namespace Slack {
     retry_num?: number;
     retry_reason?: string;
     event?: AppMentionEvent;
+  }
+  // v0.8.5 (#21) — reactions:read scope on the Slack app side.
+  interface ReactionEvent {
+    type: "reaction_added";
+    user?: string;
+    reaction?: string;
+    item_user?: string;
+    item?: { type: string; channel: string; ts: string };
+  }
+  interface ReactionEventPayload {
+    ack?: (response?: unknown) => Promise<void>;
+    envelope_id: string;
+    retry_num?: number;
+    retry_reason?: string;
+    event?: ReactionEvent;
   }
 }

--- a/packages/cli/test/gateway.test.ts
+++ b/packages/cli/test/gateway.test.ts
@@ -62,6 +62,7 @@ import {
 } from "@pmk/shared";
 import {
   approveAtom,
+  findAtomByApprovalMessage,
   formatAtomsForInjection,
   generateAtomId,
   knowledgeRoot,
@@ -1364,6 +1365,97 @@ describe("atom-index BM25 (#19)", () => {
     // Late-added atom is now retrievable.
     assert.ok(hits.length >= 2);
     assert.ok(hits.some((a) => a.question.includes("Late-added")));
+  });
+});
+
+describe("findAtomByApprovalMessage (#21)", () => {
+  let tmpHome: string;
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-react-approval-"));
+    process.env.HOME = tmpHome;
+  });
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+  });
+
+  it("finds atom by approval anchor (channelId + messageTs)", () => {
+    saveAtom({
+      id: generateAtomId("with anchor"),
+      createdAt: Date.now(),
+      scope: "erp",
+      question: "anchored question?",
+      answer: "anchored answer",
+      summary: "s",
+      tags: ["t"],
+      source: { threadKey: "T1", contributorUserId: "U_IT1" },
+      status: "pending",
+      expiresAt: Date.now() + 60_000,
+      approval: { channelId: "C1", messageTs: "1700000000.123456" },
+    });
+    const found = findAtomByApprovalMessage("C1", "1700000000.123456");
+    assert.ok(found);
+    assert.match(found?.atom.question ?? "", /anchored/);
+  });
+
+  it("returns undefined when no atom matches the anchor", () => {
+    saveAtom({
+      id: generateAtomId("anchor mismatch"),
+      createdAt: Date.now(),
+      scope: "erp",
+      question: "q",
+      answer: "a",
+      summary: "s",
+      tags: ["t"],
+      source: { threadKey: "T1", contributorUserId: "U1" },
+      status: "pending",
+      expiresAt: Date.now() + 60_000,
+      approval: { channelId: "C1", messageTs: "1700000000.111111" },
+    });
+    assert.equal(findAtomByApprovalMessage("C1", "wrong-ts"), undefined);
+    assert.equal(
+      findAtomByApprovalMessage("wrong-channel", "1700000000.111111"),
+      undefined,
+    );
+  });
+
+  it("returns undefined for legacy atoms without approval anchor", () => {
+    // Atom written before v0.8.5 — no `approval` in front-matter.
+    saveAtom({
+      id: generateAtomId("legacy no anchor"),
+      createdAt: Date.now(),
+      scope: "erp",
+      question: "legacy?",
+      answer: "legacy answer",
+      summary: "s",
+      tags: ["t"],
+      source: { threadKey: "T1", contributorUserId: "U1" },
+      status: "approved",
+    });
+    assert.equal(findAtomByApprovalMessage("any-channel", "any-ts"), undefined);
+  });
+
+  it("approval anchor round-trips through save/load", () => {
+    const id = generateAtomId("round trip anchor");
+    saveAtom({
+      id,
+      createdAt: Date.now(),
+      scope: "erp",
+      question: "round trip?",
+      answer: "answer",
+      summary: "s",
+      tags: ["t"],
+      source: { threadKey: "T1", contributorUserId: "U1" },
+      status: "pending",
+      expiresAt: Date.now() + 60_000,
+      approval: { channelId: "C-X", messageTs: "1700000000.999999" },
+    });
+    const atoms = loadAtoms({ scope: "erp" });
+    assert.equal(atoms.length, 1);
+    assert.deepEqual(atoms[0].approval, {
+      channelId: "C-X",
+      messageTs: "1700000000.999999",
+    });
   });
 });
 


### PR DESCRIPTION
Closes #21. Layered on top of the v0.7.4 TTL gate.

## What

✅ / ❌ reaction on the bot's pending-notice message → atom approve / reject in-flow:

- ✅ (`white_check_mark`, `heavy_check_mark`, `+1`) → `approveAtom` + `:books: 已生效...`
- ❌ (`x`, `-1`) → `rejectAtom` + `:wastebasket: 已捨棄...`

Trust model: only the **original IT contributor** (`atom.source.contributorUserId`) can react. Random thread participants ignored. v0.9 admin commands (#31) will add an override path.

## Storage anchor

`KnowledgeAtom.approval?: { channelId, messageTs }` captured at absorb time. After `saveAtom()` and the bot's `:hourglass_flowing_sand:` postMessage lands, we re-save the atom with `post.ts` as the anchor. Atoms saved before v0.8.5 won't have the anchor — CLI `atoms approve` still works regardless.

## Slack scope expansion

`pmk gateway init` walkthrough now lists:
- New scope: `reactions:read`
- New event subscription: `reaction_added`

Apps installed before v0.8.5 keep working — no events fire when scope is missing, TTL auto-promote remains the safety net.

## Tests

162 → 166 (+4: anchor lookup matches; mismatched channel/ts returns undefined; legacy atoms without anchor return undefined; approval field round-trips).

## Test plan

- [ ] Add `reactions:read` to the live Slack app's scopes; reinstall app
- [ ] Add `reaction_added` event subscription
- [ ] Trigger an escalate → IT replies → bot posts pending notice → ✅ react it
- [ ] Verify gateway log: `reaction-approval: <id> approved via :white_check_mark: from <userId>`
- [ ] Atom flips to approved (visible to retrieval); follow-up `:books:` reply lands
- [ ] Random thread participant reacts → ignored (gateway log shows the trust check)
- [ ] ❌ react flow: atom file deleted, `:wastebasket:` reply lands