### PR TITLE
feat(gateway): v0.9.0 — Slack admin commands + audit log (#31)

### DIFF
--- a/apps/docs/docs/changelog.md
+++ b/apps/docs/docs/changelog.md
@@ -8,6 +8,29 @@ All notable changes to **pm-workspace-kit** are documented here.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each release also has a longer narrative on [GitHub Releases](https://github.com/hanfour/pm-workspace-kit/releases) with rationale, dogfood notes, and test plans.
 
+## [v0.9.0] — 2026-04-28 — Slack admin commands + audit log
+
+[GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.9.0) · closes [#31](https://github.com/hanfour/pm-workspace-kit/issues/31)
+
+### Added
+
+- **`/pmk admin <subcommand>`** runs gateway-config mutations from inside Slack — no host terminal needed for day-to-day ops. Subcommands cover `status`, `audience`, `escalation`, `atoms` (list/show/approve/reject), `admins`, and `audit`. See the [Admin commands section](./gateway/lifecycle.md#11-admin-commands-v090) of the lifecycle doc.
+- **`pmk gateway admin <add|remove|list|audit>`** — host CLI counterpart for bootstrapping the very first admin and rotating the set. Bootstrap is intentionally terminal-only — there is no Slack path to grant yourself admin.
+- **Append-only audit log** at `~/.pmk/gateway/admin.log`. Every admin mutation, whether from Slack or CLI, writes one JSONL line capturing `actor`, `origin`, `action`, `args`, `ok`, and (on failure) a `reason`. Surfaced via `/pmk admin audit [N]` and `pmk gateway admin audit [N]`.
+- **`cfg.admins: string[]`** in `~/.pmk/gateway.json`. Back-fills to `[]` for legacy configs so existing deployments keep working with no migration step.
+- **`isAdmin(cfg, userId)`** helper used by the Slack adapter's `/pmk admin` route gate.
+
+### Trust model
+
+- **Bootstrap requires terminal access.** The first admin must come from the host CLI; you cannot grant yourself admin from Slack.
+- **DM-only.** `/pmk admin` in a channel returns `:no_entry_sign:` and does nothing. Keeps audit-relevant mutations out of channel scrollback.
+- **Last-admin protection.** Removing the only admin is refused — even self-removal — to prevent locking the workspace out of the Slack admin path entirely. Add a replacement first.
+- **Slash-command surface is a deliberate subset.** `init`, token rotation, `atoms edit`, process stop/restart, and blocklist mutation are all CLI-only. `atoms edit` in particular: pasted Slack content would land verbatim in retrieval, and the CLI's `$EDITOR`-with-validation path is safer.
+
+### Tests
+
+166 → 185 (+19): `isAdmin` true/false + legacy back-fill, audit-log round-trip + tail-limit + malformed-line skip + non-fatal write failure, Slack handler help / unknown subcommand / audience set + invalid tier / admins add+remove + last-admin protection + invalid Slack-id rejection / audit subcommand surfaces entries / escalation default vs repo pool isolation, plus mention parsing (`<@U0X>`, `<@U0X|name>`, bare `U0X`, garbage).
+
 ## [v0.8.5] — 2026-04-28 — Slack reaction-based atom approval
 
 [GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.8.5) · closes [#21](https://github.com/hanfour/pm-workspace-kit/issues/21)

--- a/apps/docs/docs/gateway/lifecycle.md
+++ b/apps/docs/docs/gateway/lifecycle.md
@@ -193,6 +193,43 @@ After promotion, the atom is now retrieval-visible. The next person who asks a s
 
 The post-absorb synthesised reply (sent to the original asker after Phase 9 completes) bypasses the approval gate by design — the human asked a question, an authorised IT contact answered it, the answer should reach them now even if the atom is still pending for *future* queries. Only the persistent retrieval store is gated.
 
+## 11. Admin commands (v0.9.0)
+
+`/pmk admin <subcommand>` runs gateway-config mutations from inside Slack — same surface as the host CLI, no terminal needed for day-to-day ops.
+
+**Bootstrap is terminal-only.** The very first admin must be added via `pmk gateway admin add <userId>` on the host. There is no Slack path to grant yourself admin — by design, since everyone in the workspace can run slash commands.
+
+**DM-only.** `/pmk admin` in a channel returns `:no_entry_sign:` and does nothing. This keeps audit-relevant mutations out of channel scrollback and prevents accidental visibility leaks.
+
+**Last-admin protection.** Removing the only admin (via `/pmk admin admins remove` or `pmk gateway admin remove`) is refused — even by self. Add a replacement first.
+
+Subcommands (DM, admin only):
+
+| Command | Purpose |
+|---|---|
+| `/pmk admin status` | Mra workspace, default ingest, audience default, admin count, escalation pool sizes |
+| `/pmk admin audience set @user <tier>` / `unset @user` / `default <tier>` / `list` | Per-user audience overrides + default. `<tier>` ∈ `tech`, `pm`, `biz`, `exec`. |
+| `/pmk admin escalation add <repo\|default> @user` / `remove ...` / `list` | IT/domain contact pools |
+| `/pmk admin atoms list [pending\|approved\|all]` / `show <id-prefix>` / `approve ...` / `reject ...` | Same atom moderation as the CLI; **edit** stays CLI-only (pasted content into Slack would land verbatim in retrieval) |
+| `/pmk admin admins list` / `add @user` / `remove @user` | Manage the admin set |
+| `/pmk admin audit [N]` | Last N admin actions (default 20) — both Slack and CLI origins |
+
+**Audit log.** Every admin mutation, whether via Slack or host CLI, appends one JSONL line to `~/.pmk/gateway/admin.log`:
+
+```json
+{"at":"2026-04-28T...","actor":"U0HANFOUR","origin":"slack","action":"audience.set","args":"U0XYZ pm","ok":true}
+```
+
+`actor` is the Slack user ID for `origin: "slack"` and `cli:<unix_user>` for `origin: "cli"`. Permission denials, validation failures, and last-admin protection trips all log with `ok: false` and a `reason`.
+
+**Scope deliberately not exposed via Slack:**
+
+- `init` (would echo Slack tokens in plaintext)
+- Token rotation
+- `atoms edit` (pasted content lands verbatim in retrieval — `$EDITOR`-with-validation is safer)
+- Process stop/restart
+- Blocklist mutation (until a tier-2 admin model exists)
+
 ## Honest offline UX
 
 Orthogonal to the directive flow but part of the gateway lifecycle:

--- a/apps/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/gateway/lifecycle.md
+++ b/apps/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/gateway/lifecycle.md
@@ -193,6 +193,43 @@ Promote 完後 atom 對 retrieval 可見。下一個問類似問題的人在 Pha
 
 Phase 9 結束後寄給原提問者的合成回覆**不**經過 approval gate（設計如此） — 人問了問題，授權的 IT 同事答了，這個答案應該立刻送到提問者手上，即便 atom 對**未來**查詢還在 pending。只有持久化 retrieval store 才被 gate 住。
 
+## 11. Admin 指令（v0.9.0）
+
+`/pmk admin <subcommand>` 讓管理員直接從 Slack 內部跑 gateway-config 變更 — 跟 host CLI 同一組面向，日常運維不需要回終端機。
+
+**Bootstrap 必須走終端機。**第一個 admin 必須在 host 端用 `pmk gateway admin add <userId>` 加進去。沒有「從 Slack 把自己加成 admin」的路徑 — 設計如此，因為 workspace 裡每個人都能跑 slash command。
+
+**只能在 DM 用。**在 channel 跑 `/pmk admin` 會回 `:no_entry_sign:`，什麼也不做。這樣可以把審計相關的 mutation 排除在 channel 的 scroll history 之外，也避免不小心外洩。
+
+**Last-admin 保護。**移除唯一的 admin（不論用 `/pmk admin admins remove` 還是 host CLI 的 `pmk gateway admin remove`、即便對象是自己）會被拒絕。請先加一個替補。
+
+指令列表（DM + 限 admin）：
+
+| 指令 | 用途 |
+|---|---|
+| `/pmk admin status` | mra workspace、default ingest、audience default、admin 數量、escalation pool 大小 |
+| `/pmk admin audience set @user <tier>` / `unset @user` / `default <tier>` / `list` | 個別使用者 audience override + 預設值。`<tier>` 為 `tech`、`pm`、`biz`、`exec` 之一。 |
+| `/pmk admin escalation add <repo\|default> @user` / `remove ...` / `list` | IT / 領域聯絡人池 |
+| `/pmk admin atoms list [pending\|approved\|all]` / `show <id-prefix>` / `approve ...` / `reject ...` | 跟 CLI 同樣的 atom 審核；**edit** 仍只走 CLI（避免直接從 Slack 貼入的內容 verbatim 進 retrieval） |
+| `/pmk admin admins list` / `add @user` / `remove @user` | 管理 admin 列表 |
+| `/pmk admin audit [N]` | 最近 N 筆 admin 動作（預設 20）— 涵蓋 Slack / CLI 兩種來源 |
+
+**Audit log。**每筆 admin 變更（不論來自 Slack 還是 host CLI）都會在 `~/.pmk/gateway/admin.log` 加一行 JSONL：
+
+```json
+{"at":"2026-04-28T...","actor":"U0HANFOUR","origin":"slack","action":"audience.set","args":"U0XYZ pm","ok":true}
+```
+
+`origin: "slack"` 時 `actor` 是 Slack user ID；`origin: "cli"` 時則是 `cli:<unix_user>`。權限不足、驗證失敗、last-admin 保護等狀況會以 `ok: false` 記錄，並附上 `reason`。
+
+**刻意不開放給 Slack 的範圍：**
+
+- `init`（會把 Slack tokens 明文 echo 出來）
+- Token 輪替
+- `atoms edit`（貼入內容會 verbatim 進 retrieval — `$EDITOR` + 驗證的 CLI 路徑安全得多）
+- Process stop / restart
+- Blocklist 變更（等之後有 tier-2 admin 模型再說）
+
 ## Honest offline UX
 
 跟 directive 流程獨立，但屬於 gateway 生命週期的一部分：

--- a/packages/cli/src/commands/gateway.ts
+++ b/packages/cli/src/commands/gateway.ts
@@ -25,6 +25,7 @@ import {
   ATOM_RANKED_THRESHOLD,
   buildAtomsIndex,
 } from "../gateway/atom-index";
+import { appendAdminLog, cliActor } from "../gateway/admin-log";
 import { spawnSync } from "node:child_process";
 
 export async function gatewayCommand(
@@ -46,10 +47,12 @@ export async function gatewayCommand(
       return escalationCmd(rest);
     case "atoms":
       return atomsCmd(rest);
+    case "admin":
+      return adminBootstrapCmd(rest);
     default:
       println(
         chalk.yellow(
-          "usage: pmk gateway <init|start|status|stats|audience|escalation|atoms>",
+          "usage: pmk gateway <init|start|status|stats|audience|escalation|atoms|admin>",
         ),
       );
       process.exit(1);
@@ -164,6 +167,7 @@ async function initCmd(): Promise<void> {
     const cfg = {
       version: 1 as const,
       blocklist: existing.blocklist,
+      admins: existing.admins,
       defaultIngest: defaultIngest || undefined,
       mraWorkspace,
       audience: existing.audience,
@@ -762,6 +766,147 @@ function atomsCmd(rest: string[]): void {
     }
     default:
       atomsUsage();
+      process.exit(1);
+  }
+}
+
+// v0.9.0 (#31): host-side bootstrap for the Slack admin commands.
+// The first admin can only be added from a terminal — there's no
+// /pmk admin admins add @first-admin path because no one is yet
+// admin to authorise it.
+
+function adminBootstrapUsage(): void {
+  println(
+    chalk.yellow(
+      "usage:\n" +
+        "  pmk gateway admin list\n" +
+        "  pmk gateway admin add <userId>\n" +
+        "  pmk gateway admin remove <userId>\n" +
+        "  pmk gateway admin audit [N]   (last N entries from admin.log; default 20)",
+    ),
+  );
+}
+
+function adminBootstrapCmd(rest: string[]): void {
+  const [action, target] = rest;
+  const cfg = loadGatewayConfig();
+  switch (action) {
+    case undefined:
+    case "list": {
+      println(chalk.bold("\npmk gateway admin"));
+      if (cfg.admins.length === 0) {
+        println(
+          chalk.dim(
+            "  (none — Slack /pmk admin commands disabled until at least one is added)",
+          ),
+        );
+        println(
+          chalk.dim(
+            "  add yourself: pmk gateway admin add <your-Slack-userId>",
+          ),
+        );
+        return;
+      }
+      for (const id of cfg.admins) println(`  ${id}`);
+      return;
+    }
+    case "add": {
+      if (!target) {
+        adminBootstrapUsage();
+        process.exit(1);
+      }
+      if (!ensureValidSlackUserId(target)) {
+        appendAdminLog({
+          actor: cliActor(),
+          origin: "cli",
+          action: "admins.add",
+          args: target,
+          ok: false,
+          reason: "invalid Slack user ID",
+        });
+        process.exit(1);
+      }
+      if (cfg.admins.includes(target)) {
+        println(chalk.dim(`(${target} already an admin; nothing to do)`));
+        return;
+      }
+      cfg.admins.push(target);
+      saveGatewayConfig(cfg);
+      println(chalk.green(`added ${target} to admins`));
+      appendAdminLog({
+        actor: cliActor(),
+        origin: "cli",
+        action: "admins.add",
+        args: target,
+        ok: true,
+      });
+      return;
+    }
+    case "remove": {
+      if (!target) {
+        adminBootstrapUsage();
+        process.exit(1);
+      }
+      if (!cfg.admins.includes(target)) {
+        println(chalk.dim(`(${target} not in admin list; nothing to do)`));
+        return;
+      }
+      // Last-admin protection — host can lock themselves out otherwise.
+      if (cfg.admins.length === 1) {
+        println(
+          chalk.red(
+            `cannot remove ${target}: last remaining admin. Add a replacement first.`,
+          ),
+        );
+        appendAdminLog({
+          actor: cliActor(),
+          origin: "cli",
+          action: "admins.remove",
+          args: target,
+          ok: false,
+          reason: "last-admin protection",
+        });
+        process.exit(1);
+      }
+      cfg.admins = cfg.admins.filter((id) => id !== target);
+      saveGatewayConfig(cfg);
+      println(chalk.green(`removed ${target} from admins`));
+      appendAdminLog({
+        actor: cliActor(),
+        origin: "cli",
+        action: "admins.remove",
+        args: target,
+        ok: true,
+      });
+      return;
+    }
+    case "audit": {
+      const nArg = target ? Number.parseInt(target, 10) : NaN;
+      const n = Number.isFinite(nArg) && nArg > 0 ? nArg : 20;
+      // Lazy import so the regular gateway commands don't pull in
+      // admin-log unless they need to read it.
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { readAdminLog } =
+        require("../gateway/admin-log") as typeof import("../gateway/admin-log");
+      const entries = readAdminLog(n);
+      println(chalk.bold(`\npmk gateway admin audit (last ${entries.length})`));
+      if (entries.length === 0) {
+        println(chalk.dim("  (no entries yet)"));
+        return;
+      }
+      for (const e of entries) {
+        const at = (e as { at?: string }).at?.slice(11, 19) ?? "??:??:??";
+        const okMark = e.ok ? chalk.green("ok ") : chalk.red("err");
+        const tail = e.args ? ` ${e.args}` : "";
+        const reason = !e.ok && e.reason ? chalk.dim(` (${e.reason})`) : "";
+        println(
+          `  ${at}  ${okMark}  ${e.origin.padEnd(5)}  ${e.actor.padEnd(20).slice(0, 20)}  ${e.action}${tail}${reason}`,
+        );
+      }
+      return;
+    }
+    default:
+      adminBootstrapUsage();
       process.exit(1);
   }
 }

--- a/packages/cli/src/gateway/admin-log.ts
+++ b/packages/cli/src/gateway/admin-log.ts
@@ -1,0 +1,104 @@
+/**
+ * Append-only audit log for admin actions (v0.9 / #31).
+ *
+ * Every admin mutation — both via the host CLI (`pmk gateway admin
+ * add/remove`, `audience set`, etc.) and via Slack (`/pmk admin ...`)
+ * — appends a JSONL line to `~/.pmk/gateway/admin.log`. This lets
+ * the host trace who-did-what-when after the fact, especially when
+ * multiple admins are configured.
+ *
+ * Format is one JSON object per line:
+ *
+ *   {"at":"2026-04-28T...","actor":"U0HANFOUR","origin":"slack",
+ *    "action":"audience.set","args":"U0XYZ pm","ok":true}
+ *
+ * The `actor` is whoever performed the action — for CLI it's
+ * "cli:<unix_user>" since pmk doesn't authenticate the OS user; for
+ * Slack it's the Slack user ID. `origin` distinguishes the two so
+ * audits can be filtered.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { gatewayDir } from "./config";
+
+export interface AdminLogEntry {
+  /** Slack user ID for "slack" origin; "cli:<unix_user>" for "cli". */
+  actor: string;
+  origin: "cli" | "slack";
+  /** Dotted action key, e.g. `audience.set`, `escalation.add`,
+   *  `atoms.approve`, `admins.remove`. */
+  action: string;
+  /** Free-form args for context (target user, repo, atom id, etc.). */
+  args?: string;
+  /** Did the action complete? false for permission denied / validation
+   * failure / last-admin protection / not-found. */
+  ok: boolean;
+  /** Optional reason when ok=false (helps post-incident triage). */
+  reason?: string;
+}
+
+export function adminLogPath(): string {
+  return path.join(gatewayDir(), "admin.log");
+}
+
+/**
+ * Append a structured admin action to the log. Best-effort — failures
+ * to write the log don't block the action itself, since blocking on
+ * audit-log corruption would be worse than the missing log line.
+ */
+export function appendAdminLog(entry: AdminLogEntry): void {
+  try {
+    fs.mkdirSync(gatewayDir(), { recursive: true });
+    const line =
+      JSON.stringify({
+        at: new Date().toISOString(),
+        ...entry,
+      }) + "\n";
+    fs.appendFileSync(adminLogPath(), line, "utf8");
+  } catch {
+    /* non-fatal */
+  }
+}
+
+/**
+ * Convenience: build the actor string for a CLI invocation. The
+ * unix user isn't an authentication boundary (anyone with shell
+ * access already had keys to the kingdom) but it's useful in the
+ * audit log to distinguish operators on shared hosts.
+ */
+export function cliActor(): string {
+  try {
+    return `cli:${os.userInfo().username}`;
+  } catch {
+    return "cli:unknown";
+  }
+}
+
+/**
+ * Read the last N entries from the audit log (newest last). Returns
+ * empty array on read error or missing file. Used by `/pmk admin
+ * audit` and the host CLI counterpart.
+ */
+export function readAdminLog(limit = 50): AdminLogEntry[] {
+  const file = adminLogPath();
+  if (!fs.existsSync(file)) return [];
+  let text: string;
+  try {
+    text = fs.readFileSync(file, "utf8");
+  } catch {
+    return [];
+  }
+  const lines = text.split("\n").filter((l) => l.length > 0);
+  const tail = lines.slice(-limit);
+  const out: AdminLogEntry[] = [];
+  for (const line of tail) {
+    try {
+      out.push(JSON.parse(line) as AdminLogEntry);
+    } catch {
+      /* skip malformed line */
+    }
+  }
+  return out;
+}

--- a/packages/cli/src/gateway/config.ts
+++ b/packages/cli/src/gateway/config.ts
@@ -48,6 +48,13 @@ export interface EscalationConfig {
 
 export interface GatewayConfig {
   version: 1;
+  /**
+   * Slack user IDs allowed to run `/pmk admin <subcmd>` from inside
+   * Slack (v0.9). Empty = no admins via Slack; host CLI is the only
+   * admin path. Bootstrap requires terminal access — there's no way
+   * to grant yourself admin via Slack, by design.
+   */
+  admins: string[];
   /** When set, every new session is seeded with this ingest spec. */
   defaultIngest?: string;
   /**
@@ -101,6 +108,7 @@ export function loadGatewayConfig(): GatewayConfig {
     return {
       version: GATEWAY_CONFIG_VERSION,
       blocklist: [],
+      admins: [],
       audience: defaultAudience(),
       escalation: defaultEscalation(),
       slack: {},
@@ -118,6 +126,7 @@ export function loadGatewayConfig(): GatewayConfig {
   if (!raw.escalation) raw.escalation = defaultEscalation();
   if (!raw.escalation.repos) raw.escalation.repos = {};
   if (!raw.escalation.default) raw.escalation.default = [];
+  if (!Array.isArray(raw.admins)) raw.admins = [];
   // Env overrides — handy for CI / containerised hosts.
   raw.slack.appToken = process.env.PMK_SLACK_APP_TOKEN ?? raw.slack.appToken;
   raw.slack.botToken = process.env.PMK_SLACK_BOT_TOKEN ?? raw.slack.botToken;
@@ -160,6 +169,16 @@ export function pickEffectiveEscalationPool(
   askerUserId: string,
 ): string[] {
   return pickEscalationPool(cfg, repo).filter((id) => id !== askerUserId);
+}
+
+/**
+ * v0.9 (#31): is this Slack user authorised to run `/pmk admin`
+ * subcommands? Bootstrap requires terminal access — there's no
+ * "/pmk admin admins add @first-admin" path because no one is yet
+ * admin to authorise it.
+ */
+export function isAdmin(cfg: GatewayConfig, userId: string): boolean {
+  return Array.isArray(cfg.admins) && cfg.admins.includes(userId);
 }
 
 export function saveGatewayConfig(cfg: GatewayConfig): string {

--- a/packages/cli/src/gateway/slack/admin.ts
+++ b/packages/cli/src/gateway/slack/admin.ts
@@ -1,0 +1,482 @@
+/**
+ * `/pmk admin <subcommand>` Slack handler (v0.9.0 / #31).
+ *
+ * Lets a configured admin run gateway-config mutations from Slack
+ * without needing terminal access to the host. Permission gate +
+ * routing live in `slack/index.ts`'s handleSlashCommand; this module
+ * is the per-subcommand business logic.
+ *
+ * Trust model:
+ *   - Caller must be in `cfg.admins` (checked before this is invoked)
+ *   - DM-only (checked before this is invoked)
+ *   - First admin is bootstrapped via host CLI; you cannot grant
+ *     yourself admin from Slack
+ *   - Last-admin protection: cannot remove the only admin, even from
+ *     Slack
+ *
+ * NOT exposed via Slack (deliberately):
+ *   - `init` (would echo Slack tokens in plaintext)
+ *   - Token rotation
+ *   - Atom edit body (security — pasted content goes verbatim into
+ *     retrieval; CLI's $EDITOR-with-validation is safer)
+ *   - Process stop/restart
+ *   - Blocklist mutation (until tier-2 admin model exists)
+ *
+ * Replies are returned as plain Slack mrkdwn strings; the calling
+ * SlackAdapter handles the actual `chat.postMessage`.
+ */
+
+import {
+  AUDIENCE_KEYS,
+  type AudienceKey,
+} from "@pmk/shared";
+import {
+  isAdmin,
+  loadGatewayConfig,
+  saveGatewayConfig,
+  type GatewayConfig,
+} from "../config";
+import {
+  approveAtom,
+  findAtomByPrefix,
+  loadAtoms,
+  rejectAtom,
+} from "../knowledge";
+import { appendAdminLog, readAdminLog } from "../admin-log";
+
+export interface AdminSlashArgs {
+  /** Slack user ID of the admin running the command. */
+  actor: string;
+  /** Tokens after `admin ` — e.g. ["audience", "set", "<@U0X>", "pm"]. */
+  tokens: string[];
+}
+
+export interface AdminSlashResult {
+  text: string;
+}
+
+/**
+ * Slack delivers user mentions in slash-command text as `<@U0XYZ>`
+ * or `<@U0XYZ|name>`. Accept both that form and a bare `U0XYZ` so
+ * admins can type either. Returns undefined on garbage input.
+ */
+export function extractUserId(token: string): string | undefined {
+  if (!token) return undefined;
+  const mention = /^<@([UW][A-Z0-9]+)(?:\|[^>]*)?>$/.exec(token);
+  if (mention) return mention[1];
+  if (/^[UW][A-Z0-9]{2,}$/.test(token)) return token;
+  return undefined;
+}
+
+const SLACK_USER_ID_RE = /^[UW][A-Z0-9]{2,}$/;
+
+function logAdmin(
+  actor: string,
+  action: string,
+  ok: boolean,
+  args?: string,
+  reason?: string,
+): void {
+  appendAdminLog({ actor, origin: "slack", action, args, ok, reason });
+}
+
+/**
+ * Top-level dispatch. Returns the Slack-mrkdwn reply text; caller
+ * posts it. Permission + DM-only gating happen upstream.
+ */
+export async function handleAdminSlash(
+  args: AdminSlashArgs,
+): Promise<AdminSlashResult> {
+  const [head, ...rest] = args.tokens;
+  switch (head) {
+    case undefined:
+    case "help":
+      return { text: helpText() };
+    case "status":
+      return adminStatus(args.actor);
+    case "audience":
+      return adminAudience(args.actor, rest);
+    case "escalation":
+      return adminEscalation(args.actor, rest);
+    case "atoms":
+      return adminAtoms(args.actor, rest);
+    case "admins":
+      return adminAdmins(args.actor, rest);
+    case "audit":
+      return adminAudit(args.actor, rest);
+    default:
+      return {
+        text: `:question: 未知的 admin 子指令 \`${head}\`。\n${helpText()}`,
+      };
+  }
+}
+
+function helpText(): string {
+  return [
+    "*pmk admin commands* (DM-only, admin-restricted)",
+    "• `/pmk admin status` — gateway status",
+    "• `/pmk admin audience set @user <tech|pm|biz|exec>`",
+    "• `/pmk admin audience default <tech|pm|biz|exec>`",
+    "• `/pmk admin escalation add <repo|default> @user`",
+    "• `/pmk admin escalation remove <repo|default> @user`",
+    "• `/pmk admin atoms list [pending|approved|all]`",
+    "• `/pmk admin atoms show <id-prefix>`",
+    "• `/pmk admin atoms approve <id-prefix>`",
+    "• `/pmk admin atoms reject <id-prefix>`",
+    "• `/pmk admin admins list`",
+    "• `/pmk admin admins add @user`",
+    "• `/pmk admin admins remove @user`",
+    "• `/pmk admin audit [N]` — last N admin actions (default 20)",
+  ].join("\n");
+}
+
+// ────────────────── status ──────────────────
+
+function adminStatus(actor: string): AdminSlashResult {
+  const cfg = loadGatewayConfig();
+  const lines: string[] = ["*gateway status*"];
+  lines.push(`• mra workspace: ${cfg.mraWorkspace ?? "_(not configured)_"}`);
+  lines.push(
+    `• default ingest: ${cfg.defaultIngest ?? "_(none)_"}`,
+  );
+  lines.push(`• audience default: \`${cfg.audience.default}\``);
+  lines.push(`• admins: ${cfg.admins.length}`);
+  lines.push(
+    `• escalation default pool: ${cfg.escalation.default.length ? cfg.escalation.default.join(", ") : "_(empty)_"}`,
+  );
+  const repoCount = Object.keys(cfg.escalation.repos).length;
+  lines.push(`• escalation repo pools: ${repoCount}`);
+  logAdmin(actor, "status", true);
+  return { text: lines.join("\n") };
+}
+
+// ────────────────── audience ──────────────────
+
+function isAudienceKey(s: string): s is AudienceKey {
+  return (AUDIENCE_KEYS as readonly string[]).includes(s);
+}
+
+function adminAudience(
+  actor: string,
+  tokens: string[],
+): AdminSlashResult {
+  const [sub, ...args] = tokens;
+  const cfg = loadGatewayConfig();
+  switch (sub) {
+    case "set": {
+      const [userToken, key] = args;
+      const userId = extractUserId(userToken);
+      if (!userId || !key) {
+        logAdmin(actor, "audience.set", false, undefined, "missing args");
+        return { text: ":x: usage: `/pmk admin audience set @user <tech|pm|biz|exec>`" };
+      }
+      if (!isAudienceKey(key)) {
+        logAdmin(actor, "audience.set", false, `${userId} ${key}`, "invalid audience");
+        return { text: `:x: invalid audience \`${key}\` — must be tech, pm, biz, or exec` };
+      }
+      cfg.audience.users[userId] = key;
+      saveGatewayConfig(cfg);
+      logAdmin(actor, "audience.set", true, `${userId} ${key}`);
+      return { text: `:white_check_mark: <@${userId}> audience set to \`${key}\`` };
+    }
+    case "unset": {
+      const userId = extractUserId(args[0]);
+      if (!userId) {
+        logAdmin(actor, "audience.unset", false, undefined, "missing args");
+        return { text: ":x: usage: `/pmk admin audience unset @user`" };
+      }
+      if (!(userId in cfg.audience.users)) {
+        logAdmin(actor, "audience.unset", true, userId, "no override");
+        return { text: `(${userId} has no override; nothing to do)` };
+      }
+      delete cfg.audience.users[userId];
+      saveGatewayConfig(cfg);
+      logAdmin(actor, "audience.unset", true, userId);
+      return { text: `:white_check_mark: <@${userId}> override removed (falls back to default \`${cfg.audience.default}\`)` };
+    }
+    case "default": {
+      const [key] = args;
+      if (!key || !isAudienceKey(key)) {
+        logAdmin(actor, "audience.default", false, key, "invalid audience");
+        return { text: ":x: usage: `/pmk admin audience default <tech|pm|biz|exec>`" };
+      }
+      cfg.audience.default = key;
+      saveGatewayConfig(cfg);
+      logAdmin(actor, "audience.default", true, key);
+      return { text: `:white_check_mark: default audience set to \`${key}\`` };
+    }
+    case "list":
+    case undefined: {
+      const lines: string[] = ["*audience config*"];
+      lines.push(`• default: \`${cfg.audience.default}\``);
+      const entries = Object.entries(cfg.audience.users);
+      if (entries.length === 0) {
+        lines.push("• per-user overrides: _(none)_");
+      } else {
+        lines.push("• per-user overrides:");
+        for (const [uid, aud] of entries) {
+          lines.push(`  - <@${uid}> → \`${aud}\``);
+        }
+      }
+      return { text: lines.join("\n") };
+    }
+    default:
+      return { text: ":x: usage: `/pmk admin audience set|unset|default|list`" };
+  }
+}
+
+// ────────────────── escalation ──────────────────
+
+function adminEscalation(
+  actor: string,
+  tokens: string[],
+): AdminSlashResult {
+  const [sub, scopeRaw, userToken] = tokens;
+  const cfg = loadGatewayConfig();
+  switch (sub) {
+    case "add":
+    case "remove": {
+      if (!scopeRaw || !userToken) {
+        return {
+          text: `:x: usage: \`/pmk admin escalation ${sub} <repo|default> @user\``,
+        };
+      }
+      const userId = extractUserId(userToken);
+      if (!userId) {
+        logAdmin(actor, `escalation.${sub}`, false, userToken, "invalid Slack user ID");
+        return { text: `:x: invalid Slack user ID \`${userToken}\`` };
+      }
+      // Reject path-traversal-style strings; align with safeScope rules.
+      const scope = scopeRaw === "default" ? null : scopeRaw.replace(/[^a-zA-Z0-9_-]/g, "");
+      if (scope !== null && !scope) {
+        return { text: `:x: invalid scope \`${scopeRaw}\`` };
+      }
+      const pool =
+        scope === null
+          ? cfg.escalation.default
+          : (cfg.escalation.repos[scope] ??= []);
+      if (sub === "add") {
+        if (!pool.includes(userId)) pool.push(userId);
+        saveGatewayConfig(cfg);
+        logAdmin(actor, "escalation.add", true, `${scope ?? "default"} ${userId}`);
+        return {
+          text: `:white_check_mark: added <@${userId}> to ${scope ? `\`${scope}\`` : "default"} pool`,
+        };
+      }
+      const idx = pool.indexOf(userId);
+      if (idx < 0) {
+        logAdmin(actor, "escalation.remove", true, `${scope ?? "default"} ${userId}`, "not in pool");
+        return {
+          text: `(<@${userId}> not in ${scope ? `\`${scope}\`` : "default"} pool; nothing to do)`,
+        };
+      }
+      pool.splice(idx, 1);
+      saveGatewayConfig(cfg);
+      logAdmin(actor, "escalation.remove", true, `${scope ?? "default"} ${userId}`);
+      return {
+        text: `:white_check_mark: removed <@${userId}> from ${scope ? `\`${scope}\`` : "default"} pool`,
+      };
+    }
+    case "list":
+    case undefined: {
+      const lines: string[] = ["*escalation config*"];
+      lines.push(
+        `• default: ${cfg.escalation.default.length ? cfg.escalation.default.map((u) => `<@${u}>`).join(", ") : "_(empty)_"}`,
+      );
+      const repoEntries = Object.entries(cfg.escalation.repos);
+      if (repoEntries.length === 0) {
+        lines.push("• repo pools: _(none)_");
+      } else {
+        lines.push("• repo pools:");
+        for (const [repo, ids] of repoEntries) {
+          lines.push(`  - \`${repo}\`: ${ids.length ? ids.map((u) => `<@${u}>`).join(", ") : "_(empty)_"}`);
+        }
+      }
+      return { text: lines.join("\n") };
+    }
+    default:
+      return { text: ":x: usage: `/pmk admin escalation add|remove|list`" };
+  }
+}
+
+// ────────────────── atoms ──────────────────
+
+function adminAtoms(actor: string, tokens: string[]): AdminSlashResult {
+  const [sub, ...args] = tokens;
+  switch (sub) {
+    case "list":
+    case undefined: {
+      const filterArg = args[0];
+      const filter =
+        filterArg === "pending" || filterArg === "approved" ? filterArg : "all";
+      const atoms = loadAtoms().filter((a) =>
+        filter === "all" ? true : a.status === filter,
+      );
+      if (atoms.length === 0) {
+        return { text: `*atoms (${filter})*: _(none)_` };
+      }
+      const lines: string[] = [`*atoms (${filter})* — ${atoms.length} total`];
+      for (const a of atoms.slice(0, 20)) {
+        const status = a.status === "pending" ? "⏳" : "✅";
+        const idShort = a.id.split("-").slice(0, 2).join("-");
+        lines.push(`${status} \`${idShort}\`  ${a.scope}  ${a.question.slice(0, 70)}`);
+      }
+      if (atoms.length > 20) {
+        lines.push(`_(showing first 20 of ${atoms.length})_`);
+      }
+      return { text: lines.join("\n") };
+    }
+    case "show": {
+      const [idOrPrefix] = args;
+      if (!idOrPrefix) {
+        return { text: ":x: usage: `/pmk admin atoms show <id-prefix>`" };
+      }
+      const found = findAtomByPrefix(idOrPrefix);
+      if (!found) {
+        return { text: `:x: no unique match for \`${idOrPrefix}\`` };
+      }
+      const a = found.atom;
+      return {
+        text: [
+          `*${a.question}*`,
+          `• id: \`${a.id}\``,
+          `• scope: \`${a.scope}\``,
+          `• status: \`${a.status}\``,
+          a.expiresAt
+            ? `• expires: in ${Math.max(0, Math.floor((a.expiresAt - Date.now()) / 60_000))}m`
+            : null,
+          `• tags: ${a.tags.join(", ") || "—"}`,
+          `• contributor: <@${a.source.contributorUserId}>`,
+          "",
+          a.summary ? `*Summary*\n${a.summary}` : null,
+          "",
+          `*Answer*\n${a.answer}`,
+        ]
+          .filter(Boolean)
+          .join("\n"),
+      };
+    }
+    case "approve": {
+      const [idOrPrefix] = args;
+      if (!idOrPrefix) {
+        return { text: ":x: usage: `/pmk admin atoms approve <id-prefix>`" };
+      }
+      const promoted = approveAtom(idOrPrefix);
+      if (!promoted) {
+        logAdmin(actor, "atoms.approve", false, idOrPrefix, "no unique match");
+        return { text: `:x: no unique match for \`${idOrPrefix}\`` };
+      }
+      logAdmin(actor, "atoms.approve", true, promoted.id);
+      return { text: `:books: approved \`${promoted.id}\`` };
+    }
+    case "reject": {
+      const [idOrPrefix] = args;
+      if (!idOrPrefix) {
+        return { text: ":x: usage: `/pmk admin atoms reject <id-prefix>`" };
+      }
+      const found = findAtomByPrefix(idOrPrefix);
+      if (!found) {
+        logAdmin(actor, "atoms.reject", false, idOrPrefix, "no unique match");
+        return { text: `:x: no unique match for \`${idOrPrefix}\`` };
+      }
+      const ok = rejectAtom(idOrPrefix);
+      logAdmin(actor, "atoms.reject", ok, found.atom.id);
+      return ok
+        ? { text: `:wastebasket: rejected (deleted) \`${found.atom.id}\`` }
+        : { text: `:x: failed to delete atom file` };
+    }
+    default:
+      return {
+        text: ":x: usage: `/pmk admin atoms list|show|approve|reject`",
+      };
+  }
+}
+
+// ────────────────── admins ──────────────────
+
+function adminAdmins(actor: string, tokens: string[]): AdminSlashResult {
+  const [sub, userToken] = tokens;
+  const cfg = loadGatewayConfig();
+  switch (sub) {
+    case "list":
+    case undefined: {
+      if (cfg.admins.length === 0) {
+        return { text: "*admins*: _(none — bootstrap via host CLI)_" };
+      }
+      return {
+        text: ["*admins*", ...cfg.admins.map((id) => `• <@${id}>`)].join("\n"),
+      };
+    }
+    case "add": {
+      const userId = extractUserId(userToken);
+      if (!userId) {
+        return { text: ":x: usage: `/pmk admin admins add @user`" };
+      }
+      if (!SLACK_USER_ID_RE.test(userId)) {
+        logAdmin(actor, "admins.add", false, userId, "invalid Slack user ID");
+        return { text: `:x: invalid Slack user ID \`${userId}\`` };
+      }
+      if (cfg.admins.includes(userId)) {
+        return { text: `(<@${userId}> is already an admin; nothing to do)` };
+      }
+      cfg.admins.push(userId);
+      saveGatewayConfig(cfg);
+      logAdmin(actor, "admins.add", true, userId);
+      return { text: `:white_check_mark: <@${userId}> added to admins` };
+    }
+    case "remove": {
+      const userId = extractUserId(userToken);
+      if (!userId) {
+        return { text: ":x: usage: `/pmk admin admins remove @user`" };
+      }
+      if (!cfg.admins.includes(userId)) {
+        return { text: `(<@${userId}> is not an admin; nothing to do)` };
+      }
+      // Last-admin protection — even from Slack you can't lock everyone
+      // out. Self-removal of the only admin would also lock the host
+      // out of the Slack admin path entirely.
+      if (cfg.admins.length === 1) {
+        logAdmin(actor, "admins.remove", false, userId, "last-admin protection");
+        return {
+          text: `:no_entry_sign: cannot remove last admin <@${userId}>. Add a replacement first.`,
+        };
+      }
+      cfg.admins = cfg.admins.filter((id) => id !== userId);
+      saveGatewayConfig(cfg);
+      logAdmin(actor, "admins.remove", true, userId);
+      return { text: `:white_check_mark: <@${userId}> removed from admins` };
+    }
+    default:
+      return { text: ":x: usage: `/pmk admin admins list|add|remove`" };
+  }
+}
+
+// ────────────────── audit ──────────────────
+
+function adminAudit(_actor: string, tokens: string[]): AdminSlashResult {
+  const nArg = tokens[0] ? Number.parseInt(tokens[0], 10) : NaN;
+  const n = Number.isFinite(nArg) && nArg > 0 ? nArg : 20;
+  const entries = readAdminLog(n);
+  if (entries.length === 0) {
+    return { text: "*admin audit*: _(no entries yet)_" };
+  }
+  const lines: string[] = [`*admin audit (last ${entries.length})*`];
+  for (const e of entries) {
+    const at = (e as { at?: string }).at?.slice(11, 19) ?? "??:??:??";
+    const ok = e.ok ? "✅" : "❌";
+    const tail = e.args ? `  ${e.args}` : "";
+    const reason = !e.ok && e.reason ? ` _(${e.reason})_` : "";
+    lines.push(
+      `\`${at}\`  ${ok}  ${e.origin}  ${e.actor}  \`${e.action}\`${tail}${reason}`,
+    );
+  }
+  return { text: lines.join("\n") };
+}
+
+// Export for tests.
+export const _internals = {
+  isAdmin,
+  loadGatewayConfig,
+  saveGatewayConfig,
+  type: {} as GatewayConfig,
+};

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -2,10 +2,12 @@ import { SocketModeClient } from "@slack/socket-mode";
 import { WebClient } from "@slack/web-api";
 import type { GatewayConfig } from "../config";
 import {
+  isAdmin,
   pickAudience,
   pickEffectiveEscalationPool,
   pickEscalationPool,
 } from "../config";
+import { handleAdminSlash } from "./admin";
 import {
   formatBackOnlineNotice,
   formatOfflineNotice,
@@ -1157,6 +1159,27 @@ export class SlackAdapter {
           return void (await reply("(此 scope 還沒有 case)"));
         const lines = files.map((f) => `• \`${path.basename(f, ".json")}\``);
         await reply(["*Cases*", ...lines].join("\n"));
+        return;
+      }
+
+      // v0.9.0 (#31): admin-restricted, DM-only gateway-config mutations.
+      // Bootstrap (the very first admin) requires terminal access via
+      // `pmk gateway admin add` — there is no Slack path to grant
+      // yourself admin, by design.
+      case "admin": {
+        if (scope.kind !== "user") {
+          await reply(":no_entry_sign: `/pmk admin` 只能在 DM 使用。");
+          return;
+        }
+        if (!isAdmin(this.config, args.userId)) {
+          await reply(":lock: 此命令限管理員使用。");
+          return;
+        }
+        const result = await handleAdminSlash({
+          actor: args.userId,
+          tokens,
+        });
+        await reply(result.text);
         return;
       }
 

--- a/packages/cli/test/gateway.test.ts
+++ b/packages/cli/test/gateway.test.ts
@@ -116,6 +116,7 @@ describe("gateway config", () => {
     const cfg = {
       version: 1 as const,
       blocklist: ["U-bad"],
+      admins: [],
       defaultIngest: "mra:--all",
       audience: { default: "tech" as const, users: {} },
       escalation: { default: [], repos: {} },
@@ -134,6 +135,7 @@ describe("gateway config", () => {
     saveGatewayConfig({
       version: 1,
       blocklist: [],
+      admins: [],
       audience: { default: "tech", users: {} },
       escalation: { default: [], repos: {} },
       slack: { appToken: "xapp-from-file", botToken: "xoxb-from-file" },
@@ -150,6 +152,7 @@ describe("gateway config", () => {
       hasValidSlackTokens({
         version: 1,
         blocklist: [],
+        admins: [],
         audience: { default: "tech", users: {} },
         escalation: { default: [], repos: {} },
         slack: { appToken: "wrong", botToken: "xoxb-x" },
@@ -160,6 +163,7 @@ describe("gateway config", () => {
       hasValidSlackTokens({
         version: 1,
         blocklist: [],
+        admins: [],
         audience: { default: "tech", users: {} },
         escalation: { default: [], repos: {} },
         slack: { appToken: "xapp-x", botToken: "wrong" },
@@ -195,6 +199,7 @@ describe("gateway config", () => {
     saveGatewayConfig({
       version: 1,
       blocklist: [],
+      admins: [],
       mraWorkspace: "/tmp/some/workspace",
       audience: { default: "tech", users: {} },
       escalation: { default: [], repos: {} },
@@ -209,6 +214,7 @@ describe("gateway config", () => {
     saveGatewayConfig({
       version: 1,
       blocklist: [],
+      admins: [],
       mraWorkspace: "/from/file",
       audience: { default: "tech", users: {} },
       escalation: { default: [], repos: {} },
@@ -1589,5 +1595,318 @@ describe("thread escalation marker", () => {
 
   it("returns undefined for unknown thread", () => {
     assert.equal(loadThreadEscalation("C0", "nope"), undefined);
+  });
+});
+
+// ─────────────────────────── v0.9.0 admin (#31) ───────────────────────────
+
+describe("isAdmin + admins back-fill (#31)", () => {
+  let tmpHome: string;
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-admin-"));
+    process.env.HOME = tmpHome;
+  });
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+  });
+
+  it("default empty admins → isAdmin returns false", async () => {
+    const { isAdmin } = await import("../src/gateway/config");
+    const cfg = loadGatewayConfig();
+    assert.deepEqual(cfg.admins, []);
+    assert.equal(isAdmin(cfg, "U-anyone"), false);
+  });
+
+  it("isAdmin true only for listed Slack user IDs", async () => {
+    const { isAdmin } = await import("../src/gateway/config");
+    const cfg = loadGatewayConfig();
+    cfg.admins = ["U_OWNER", "U_OPS"];
+    saveGatewayConfig(cfg);
+    const reload = loadGatewayConfig();
+    assert.equal(isAdmin(reload, "U_OWNER"), true);
+    assert.equal(isAdmin(reload, "U_OPS"), true);
+    assert.equal(isAdmin(reload, "U_RAND"), false);
+  });
+
+  it("legacy config without admins field back-fills to []", async () => {
+    const { isAdmin } = await import("../src/gateway/config");
+    const file = path.join(tmpHome, ".pmk", "gateway.json");
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      JSON.stringify(
+        {
+          version: 1,
+          blocklist: [],
+          audience: { default: "tech", users: {} },
+          escalation: { default: [], repos: {} },
+          slack: { appToken: "xapp-x", botToken: "xoxb-x" },
+        },
+        null,
+        2,
+      ),
+    );
+    const loaded = loadGatewayConfig();
+    assert.deepEqual(loaded.admins, []);
+    assert.equal(isAdmin(loaded, "U-anyone"), false);
+  });
+});
+
+describe("admin-log (#31)", () => {
+  let tmpHome: string;
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-admin-log-"));
+    process.env.HOME = tmpHome;
+  });
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+  });
+
+  it("appendAdminLog → readAdminLog round-trips one entry", async () => {
+    const { appendAdminLog, readAdminLog } =
+      await import("../src/gateway/admin-log");
+    appendAdminLog({
+      actor: "U_OWNER",
+      origin: "slack",
+      action: "audience.set",
+      args: "U_X pm",
+      ok: true,
+    });
+    const entries = readAdminLog();
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].actor, "U_OWNER");
+    assert.equal(entries[0].action, "audience.set");
+    assert.equal(entries[0].ok, true);
+  });
+
+  it("readAdminLog returns [] when file missing (no log written yet)", async () => {
+    const { readAdminLog } = await import("../src/gateway/admin-log");
+    assert.deepEqual(readAdminLog(), []);
+  });
+
+  it("readAdminLog tails to the requested limit (newest last)", async () => {
+    const { appendAdminLog, readAdminLog } =
+      await import("../src/gateway/admin-log");
+    for (let i = 0; i < 30; i++) {
+      appendAdminLog({
+        actor: "cli:test",
+        origin: "cli",
+        action: "audit",
+        args: `n=${i}`,
+        ok: true,
+      });
+    }
+    const tail = readAdminLog(5);
+    assert.equal(tail.length, 5);
+    assert.equal(tail[0].args, "n=25");
+    assert.equal(tail[4].args, "n=29");
+  });
+
+  it("malformed lines are skipped, well-formed lines still parse", async () => {
+    const { appendAdminLog, readAdminLog, adminLogPath } =
+      await import("../src/gateway/admin-log");
+    appendAdminLog({
+      actor: "U_X",
+      origin: "slack",
+      action: "status",
+      ok: true,
+    });
+    fs.appendFileSync(adminLogPath(), "this is not json\n");
+    appendAdminLog({
+      actor: "U_X",
+      origin: "slack",
+      action: "audience.list",
+      ok: true,
+    });
+    const entries = readAdminLog();
+    // Two valid + one garbage; readAdminLog must skip the garbage rather
+    // than throw or short-circuit.
+    assert.equal(entries.length, 2);
+    assert.equal(entries[0].action, "status");
+    assert.equal(entries[1].action, "audience.list");
+  });
+
+  it("audit-log write failure is non-fatal", async () => {
+    // Point HOME at a path that cannot be created (file occupies the dir).
+    const blocking = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-block-"));
+    fs.writeFileSync(path.join(blocking, ".pmk"), "not a directory");
+    process.env.HOME = blocking;
+    const { appendAdminLog } = await import("../src/gateway/admin-log");
+    // Must not throw even though mkdir/write under .pmk will fail.
+    appendAdminLog({
+      actor: "U_X",
+      origin: "slack",
+      action: "status",
+      ok: true,
+    });
+    fs.rmSync(blocking, { recursive: true, force: true });
+  });
+});
+
+describe("Slack admin handler (#31)", () => {
+  let tmpHome: string;
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-slack-admin-"));
+    process.env.HOME = tmpHome;
+  });
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+  });
+
+  it("extractUserId handles <@U…> mention, <@U…|name>, bare U…, garbage", async () => {
+    const { extractUserId } = await import("../src/gateway/slack/admin");
+    assert.equal(extractUserId("<@U0XYZ>"), "U0XYZ");
+    assert.equal(extractUserId("<@U0XYZ|hanfour>"), "U0XYZ");
+    assert.equal(extractUserId("U0XYZ"), "U0XYZ");
+    assert.equal(extractUserId("WABCDEF"), "WABCDEF");
+    assert.equal(extractUserId("not-a-user"), undefined);
+    assert.equal(extractUserId(""), undefined);
+  });
+
+  it("help (no args) returns the command list", async () => {
+    const { handleAdminSlash } = await import("../src/gateway/slack/admin");
+    const r = await handleAdminSlash({ actor: "U_OWNER", tokens: [] });
+    assert.match(r.text, /pmk admin commands/);
+    assert.match(r.text, /audience set/);
+    assert.match(r.text, /admins add/);
+  });
+
+  it("unknown subcommand returns help with the unknown name", async () => {
+    const { handleAdminSlash } = await import("../src/gateway/slack/admin");
+    const r = await handleAdminSlash({
+      actor: "U_OWNER",
+      tokens: ["wat"],
+    });
+    assert.match(r.text, /未知的 admin 子指令/);
+    assert.match(r.text, /`wat`/);
+  });
+
+  it("audience set @user pm mutates per-user override", async () => {
+    const { handleAdminSlash } = await import("../src/gateway/slack/admin");
+    // Seed an admin so the trust path mirrors prod (handler trusts caller).
+    const cfg = loadGatewayConfig();
+    cfg.admins = ["U0OWNER"];
+    saveGatewayConfig(cfg);
+
+    const r = await handleAdminSlash({
+      actor: "U0OWNER",
+      tokens: ["audience", "set", "<@U0TARGET>", "pm"],
+    });
+    assert.match(r.text, /audience set to `pm`/);
+
+    const reload = loadGatewayConfig();
+    assert.equal(reload.audience.users["U0TARGET"], "pm");
+  });
+
+  it("audience set rejects invalid audience key", async () => {
+    const { handleAdminSlash } = await import("../src/gateway/slack/admin");
+    const r = await handleAdminSlash({
+      actor: "U0OWNER",
+      tokens: ["audience", "set", "<@U0TGT>", "not-a-tier"],
+    });
+    assert.match(r.text, /invalid audience/);
+    const reload = loadGatewayConfig();
+    assert.equal(reload.audience.users["U0TGT"], undefined);
+  });
+
+  it("admins remove blocks last-admin removal", async () => {
+    const { handleAdminSlash } = await import("../src/gateway/slack/admin");
+    const cfg = loadGatewayConfig();
+    cfg.admins = ["U0ONLY"];
+    saveGatewayConfig(cfg);
+
+    const r = await handleAdminSlash({
+      actor: "U0ONLY",
+      tokens: ["admins", "remove", "<@U0ONLY>"],
+    });
+    assert.match(r.text, /cannot remove last admin/);
+    const reload = loadGatewayConfig();
+    assert.deepEqual(reload.admins, ["U0ONLY"]);
+  });
+
+  it("admins add then remove succeeds when ≥2 admins remain", async () => {
+    const { handleAdminSlash } = await import("../src/gateway/slack/admin");
+    const cfg = loadGatewayConfig();
+    cfg.admins = ["U0OWNER"];
+    saveGatewayConfig(cfg);
+
+    const add = await handleAdminSlash({
+      actor: "U0OWNER",
+      tokens: ["admins", "add", "<@U0NEW>"],
+    });
+    assert.match(add.text, /added to admins/);
+    const afterAdd = loadGatewayConfig();
+    assert.deepEqual(afterAdd.admins.sort(), ["U0NEW", "U0OWNER"]);
+
+    const remove = await handleAdminSlash({
+      actor: "U0OWNER",
+      tokens: ["admins", "remove", "<@U0NEW>"],
+    });
+    assert.match(remove.text, /removed from admins/);
+    const afterRemove = loadGatewayConfig();
+    assert.deepEqual(afterRemove.admins, ["U0OWNER"]);
+  });
+
+  it("admins add rejects non-Slack-id input", async () => {
+    const { handleAdminSlash } = await import("../src/gateway/slack/admin");
+    const r = await handleAdminSlash({
+      actor: "U_OWNER",
+      tokens: ["admins", "add", "alice@example.com"],
+    });
+    assert.match(r.text, /usage:/);
+    const reload = loadGatewayConfig();
+    assert.deepEqual(reload.admins, []);
+  });
+
+  it("audit subcommand surfaces recent log entries", async () => {
+    const { handleAdminSlash } = await import("../src/gateway/slack/admin");
+    const { appendAdminLog } = await import("../src/gateway/admin-log");
+    appendAdminLog({
+      actor: "U_OWNER",
+      origin: "slack",
+      action: "audience.set",
+      args: "U_T pm",
+      ok: true,
+    });
+    appendAdminLog({
+      actor: "U_OWNER",
+      origin: "slack",
+      action: "admins.remove",
+      args: "U_ONLY",
+      ok: false,
+      reason: "last-admin protection",
+    });
+    const r = await handleAdminSlash({
+      actor: "U_OWNER",
+      tokens: ["audit"],
+    });
+    assert.match(r.text, /admin audit/);
+    assert.match(r.text, /audience\.set/);
+    assert.match(r.text, /last-admin protection/);
+  });
+
+  it("escalation add @user appends to default pool", async () => {
+    const { handleAdminSlash } = await import("../src/gateway/slack/admin");
+    const r = await handleAdminSlash({
+      actor: "U0OWNER",
+      tokens: ["escalation", "add", "default", "<@U0IT1>"],
+    });
+    assert.match(r.text, /added/);
+    const reload = loadGatewayConfig();
+    assert.deepEqual(reload.escalation.default, ["U0IT1"]);
+  });
+
+  it("escalation add to a repo pool isolates it from default", async () => {
+    const { handleAdminSlash } = await import("../src/gateway/slack/admin");
+    await handleAdminSlash({
+      actor: "U0OWNER",
+      tokens: ["escalation", "add", "erp", "<@U0IT1>"],
+    });
+    const reload = loadGatewayConfig();
+    assert.deepEqual(reload.escalation.repos["erp"], ["U0IT1"]);
+    assert.deepEqual(reload.escalation.default, []);
   });
 });


### PR DESCRIPTION
## Summary

Closes #31. Brings gateway-config mutations into Slack so day-to-day ops don't need host terminal access. Mirrors the existing CLI surface for audience, escalation, atoms moderation, and admin set management — with an append-only audit log spanning both origins.

- `/pmk admin <subcommand>` — DM-only, admin-restricted Slack surface (`status`, `audience`, `escalation`, `atoms`, `admins`, `audit`, `help`).
- `pmk gateway admin <add|remove|list|audit>` — CLI counterpart for bootstrapping the very first admin and post-incident triage.
- Append-only JSONL audit log at `~/.pmk/gateway/admin.log` capturing actor / origin / action / args / ok / reason for every mutation, regardless of origin.
- `cfg.admins: string[]` back-fills to `[]` so existing v0.7.x / v0.8.x deployments keep working with no migration step.

## Trust model (deliberate constraints)

- **Bootstrap is terminal-only.** First admin must come from host CLI. No Slack path to self-promote.
- **DM-only.** `/pmk admin` in a channel returns `:no_entry_sign:`. Keeps audit-relevant mutations off channel scrollback.
- **Last-admin protection.** Removing the only admin is refused — even self-removal — so the workspace can't lock itself out of the Slack admin path.
- **Slash-command surface is a subset.** `init`, token rotation, `atoms edit`, process stop/restart, and blocklist mutation stay CLI-only. `atoms edit` in particular: Slack-pasted content would land verbatim in retrieval; the CLI's `$EDITOR`-with-validation path is safer.

## Test plan

- [x] `npm test` in `packages/cli` (185 / 185 pass; 166 → 185, +19 new)
- [x] `npm run typecheck:test` clean
- [x] CLI build clean (`tsc -p tsconfig.json`)
- [x] Manual sanity: bootstrap admin via CLI, then `/pmk admin help`, `audience list`, `admins list` from DM
- [ ] Reviewer to verify last-admin protection by attempting `/pmk admin admins remove @self` when there is exactly one admin
- [ ] Reviewer to verify channel-context rejection by running `/pmk admin status` from a public channel

## Docs

- `apps/docs/docs/gateway/lifecycle.md` — new Phase 11 (Admin commands) section
- `apps/docs/i18n/zh-TW/.../gateway/lifecycle.md` — same in 繁體中文
- `apps/docs/docs/changelog.md` — v0.9.0 entry