### PR TITLE
docs(gateway): bump lifecycle "See also" range to v0.7.0–v0.9.0

### DIFF
--- a/apps/docs/docs/gateway/lifecycle.md
+++ b/apps/docs/docs/gateway/lifecycle.md
@@ -244,5 +244,5 @@ No `caffeinate` / launchd hacks ship by default — accepting bounded availabili
 
 - [ADR-0006: pmk gateway — Slack/LINE bot, not SaaS](../adr/0006-pmk-gateway-slack.md)
 - [PRD-2026-0005: pmk gateway v0.7.0 surface](../prds/2026-04-27-pmk-gateway-prd.md)
-- [v0.7.0–v0.7.4 release notes on GitHub](https://github.com/hanfour/pm-workspace-kit/releases)
+- [v0.7.0–v0.9.0 release notes on GitHub](https://github.com/hanfour/pm-workspace-kit/releases)
 - [Changelog](../changelog.md) — release-by-release summary

--- a/apps/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/gateway/lifecycle.md
+++ b/apps/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/gateway/lifecycle.md
@@ -244,5 +244,5 @@ Phase 9 結束後寄給原提問者的合成回覆**不**經過 approval gate（
 
 - [ADR-0006: pmk gateway — Slack/LINE bot, not SaaS](../adr/0006-pmk-gateway-slack.md)
 - [PRD-2026-0005: pmk gateway v0.7.0 surface](../prds/2026-04-27-pmk-gateway-prd.md)
-- [v0.7.0–v0.7.4 release notes on GitHub](https://github.com/hanfour/pm-workspace-kit/releases)
+- [v0.7.0–v0.9.0 release notes on GitHub](https://github.com/hanfour/pm-workspace-kit/releases)
 - [Changelog](../changelog.md) — release-by-release 摘要


### PR DESCRIPTION
Trailing footnote nit found during the v0.9.0 verification pass. The lifecycle page's *See also* still pointed at "v0.7.0–v0.7.4 release notes" — pre-existing since v0.7.4. Bumps it to cover the actual shipped range (now through v0.9.0). Same string in EN + zh-TW.

Two-line change, no functional impact.