### PR TITLE
docs(gateway): document Slack /pmk leading-space workaround (#39)

### DIFF
--- a/apps/docs/docs/gateway/lifecycle.md
+++ b/apps/docs/docs/gateway/lifecycle.md
@@ -197,6 +197,16 @@ The post-absorb synthesised reply (sent to the original asker after Phase 9 comp
 
 `/pmk admin <subcommand>` runs gateway-config mutations from inside Slack — same surface as the host CLI, no terminal needed for day-to-day ops.
 
+:::caution Type a leading space before `/pmk` in Slack
+
+Slack's client treats any message starting with `/` as a slash-command attempt and blocks it via Slackbot ("/pmk 是無效指令"). pmk doesn't currently register `/pmk` as a real Slack slash-command — it's parsed from the message text on the gateway side after the bot receives the `message` / `app_mention` event.
+
+Workaround: type a space before the slash, e.g. ` /pmk admin help` (leading-space). The gateway's `text.trim()` strips the space transparently. Same applies to all the v0.7+ commands (`/pmk open`, `/pmk show`, `/pmk close`, `/pmk cases`, `/pmk help`).
+
+Tracked in [#39](https://github.com/hanfour/pm-workspace-kit/issues/39) — registering `/pmk` as a real Slack slash-command (Socket Mode `slash_commands` event) is on the v0.9.1 plate.
+
+:::
+
 **Bootstrap is terminal-only.** The very first admin must be added via `pmk gateway admin add <userId>` on the host. There is no Slack path to grant yourself admin — by design, since everyone in the workspace can run slash commands.
 
 **DM-only.** `/pmk admin` in a channel returns `:no_entry_sign:` and does nothing. This keeps audit-relevant mutations out of channel scrollback and prevents accidental visibility leaks.

--- a/apps/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/gateway/lifecycle.md
+++ b/apps/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/gateway/lifecycle.md
@@ -197,6 +197,16 @@ Phase 9 結束後寄給原提問者的合成回覆**不**經過 approval gate（
 
 `/pmk admin <subcommand>` 讓管理員直接從 Slack 內部跑 gateway-config 變更 — 跟 host CLI 同一組面向，日常運維不需要回終端機。
 
+:::caution 在 Slack 輸入 `/pmk` 時請加一個 leading space
+
+Slack client 會把所有 `/` 開頭的訊息當成 slash-command 攔下，由 Slackbot 提示「/pmk 是無效指令」。pmk 目前沒有把 `/pmk` 註冊成真正的 Slack slash-command — 是在 bot 收到 `message` / `app_mention` 事件後，從訊息文字解析出來的。
+
+繞過方式：在斜線前打一個空格，例如 ` /pmk admin help`。Gateway 端的 `text.trim()` 會把空格透明地拿掉。所有 v0.7+ 指令（`/pmk open`、`/pmk show`、`/pmk close`、`/pmk cases`、`/pmk help`）都一樣。
+
+追蹤在 [#39](https://github.com/hanfour/pm-workspace-kit/issues/39) — v0.9.1 會把 `/pmk` 註冊成真正的 Slack slash-command（Socket Mode `slash_commands` event）。
+
+:::
+
 **Bootstrap 必須走終端機。**第一個 admin 必須在 host 端用 `pmk gateway admin add <userId>` 加進去。沒有「從 Slack 把自己加成 admin」的路徑 — 設計如此，因為 workspace 裡每個人都能跑 slash command。
 
 **只能在 DM 用。**在 channel 跑 `/pmk admin` 會回 `:no_entry_sign:`，什麼也不做。這樣可以把審計相關的 mutation 排除在 channel 的 scroll history 之外，也避免不小心外洩。


### PR DESCRIPTION
## Summary

Tracks: #39

Real-Slack verification of v0.9.0 surfaced a UX gap: typing \`/pmk admin help\` (or any \`/pmk ...\` form) in Slack triggers Slackbot's "/pmk 是無效指令" intercept. Since pmk doesn't currently register \`/pmk\` as a real Slack slash-command, the message is blocked client-side and never reaches the bot.

The workaround that does work today: type a leading space (\` /pmk admin help\`). The gateway's \`text.trim()\` strips the space transparently and the existing \`text.startsWith(\"/pmk \")\` parser fires.

This PR adds a \`:::caution\` callout inside Phase 11 (Admin commands) of lifecycle.md (EN + zh-TW) explaining:
- Why messages get blocked
- The leading-space workaround
- That all v0.7+ commands are affected (\`/pmk help\`, \`open\`, \`show\`, \`close\`, \`cases\`, \`admin\`)
- A pointer to #39 for the proper fix in v0.9.1

## Test plan

- [x] Diff review — no functional change, doc-only addition
- [x] Issue #39 referenced in callout exists and is open against v0.9.1 milestone
- [x] Same callout text in EN + zh-TW
- [ ] Reviewer to confirm the callout reads naturally in both languages

## Out of scope

The actual fix — registering \`/pmk\` as a Slack slash-command (Socket Mode \`slash_commands\` event handler) — is tracked separately in #39 against v0.9.1.