### PR TITLE
fix(gateway): v0.9.1 — real Slack /pmk slash-command (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ You don't have to take the whole monorepo. Pick the layer that matches your need
 
 Read [Getting Started](https://hanfour.github.io/pm-workspace-kit/docs/getting-started) to set up front-matter on your first PRD; the [Confluence sync guide](https://hanfour.github.io/pm-workspace-kit/docs/guides/confluence-sync) covers the Confluence loop.
 
-## Latest release: v0.9.0 (2026-04-28)
+## Latest release: v0.9.1 (2026-04-28)
 
-The v0.7.x series matured the Slack gateway through real dogfood; v0.8.x built retrieval quality and an in-Slack approval loop on top; v0.9.0 brings the operator surface itself into Slack so day-to-day ops no longer need host terminal access.
+The v0.7.x series matured the Slack gateway through real dogfood; v0.8.x built retrieval quality and an in-Slack approval loop on top; v0.9.0 brought the operator surface into Slack; v0.9.1 closed the last UX gap by registering `/pmk` as a real Slack slash-command (no more leading-space workaround).
 
 | Release | Highlight |
 |---|---|
@@ -122,8 +122,9 @@ The v0.7.x series matured the Slack gateway through real dogfood; v0.8.x built r
 | [`v0.8.4`](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.8.4) | **BM25 / TF-IDF retrieval** for knowledge atoms — corpus-size threshold switches between keyword and BM25 |
 | [`v0.8.5`](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.8.5) | **Slack reaction approval** — ✅ / ❌ on the bot's pending notice approves or rejects in-flow (only the original IT contributor) |
 | [`v0.9.0`](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.9.0) | **`/pmk admin <subcommand>`** — DM-only admin surface for audience / escalation / atoms / admins / audit, with append-only JSONL audit log spanning Slack + CLI origins |
+| [`v0.9.1`](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.9.1) | **`/pmk` real Slack slash-command** — Socket Mode `slash_commands` envelope handler so Slack autocompletes `/pmk` and the leading-space workaround is no longer needed |
 
-The full knowledge loop — *PM asks in Slack → bot tries PKB → escalates to mra-ask → escalates to a human IT contact → absorbs the answer → next person who asks gets the cached answer* — works end-to-end, with retrieval quality improved by BM25 (v0.8.4), in-flow ✅ approval (v0.8.5), and Slack-side admin commands (v0.9.0). Tests: 75 → **185** across the v0.7–v0.9 series. Walk through it phase-by-phase in the [Gateway lifecycle](https://hanfour.github.io/pm-workspace-kit/docs/gateway/lifecycle) deep-dive (now with a Phase 11 covering admin commands), or skim the release-by-release [changelog](https://hanfour.github.io/pm-workspace-kit/docs/changelog).
+The full knowledge loop — *PM asks in Slack → bot tries PKB → escalates to mra-ask → escalates to a human IT contact → absorbs the answer → next person who asks gets the cached answer* — works end-to-end, with retrieval quality improved by BM25 (v0.8.4), in-flow ✅ approval (v0.8.5), Slack-side admin commands (v0.9.0), and a properly-registered `/pmk` slash-command (v0.9.1). Tests: 75 → **193** across the v0.7–v0.9 series. Walk through it phase-by-phase in the [Gateway lifecycle](https://hanfour.github.io/pm-workspace-kit/docs/gateway/lifecycle) deep-dive (now with a Phase 11 covering admin commands), or skim the release-by-release [changelog](https://hanfour.github.io/pm-workspace-kit/docs/changelog).
 
 ## Design principles
 

--- a/apps/docs/docs/changelog.md
+++ b/apps/docs/docs/changelog.md
@@ -8,6 +8,43 @@ All notable changes to **pm-workspace-kit** are documented here.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each release also has a longer narrative on [GitHub Releases](https://github.com/hanfour/pm-workspace-kit/releases) with rationale, dogfood notes, and test plans.
 
+## [v0.9.1] — 2026-04-28 — `/pmk` real Slack slash-command (no leading-space workaround)
+
+[GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.9.1) · closes [#39](https://github.com/hanfour/pm-workspace-kit/issues/39)
+
+### Why
+
+Real-Slack verification of v0.9.0 found that typing `/pmk admin help` in Slack triggered Slackbot's "/pmk 是無效指令" intercept and never reached the bot. Slack's client blocks `/`-prefixed messages whose slash-command isn't registered on the app side. The only way to actually deliver the message was to type a leading space (` /pmk admin help`) so the gateway's existing `message`-event path could pick it up after `text.trim()`. Same gap had existed for every `/pmk` command since v0.7.0 (`help`, `open`, `show`, `close`, `cases`).
+
+### Fixed
+
+- **Real Slack slash-command** — `/pmk` is now registered as a Slack slash-command on the app side; SlackAdapter subscribes to the Socket Mode `slash_commands` envelope (`packages/cli/src/gateway/slack/index.ts`). No more leading-space workaround. Slack autocompletes `/pmk` and the bot replies as a top-level message (slash commands have no anchoring message, so no thread).
+- The legacy ` /pmk ...` text-message path stays in place as a fallback for users who learned the workaround and for deployments where the slash-command isn't registered.
+- Empty body (`/pmk` alone) routes to `help` so first-time users discover the surface.
+
+### Added
+
+- `slashCommandArgsFromBody(body)` — exported pure helper that translates a Slack `slash_commands` envelope body into `handleSlashCommand` args. Lets us unit-test the rest/scope decision without instantiating `SlackAdapter`.
+
+### Changed
+
+- `handleSlashCommand`'s `threadTs` is now optional. Slash-command envelopes have no anchor message, so omitting it is correct; the legacy text-message path still passes a thread_ts.
+- `chat.postMessage` only includes `thread_ts` when defined (was always passing it before, even when undefined).
+
+### Tests
+
+185 → 193 (+8): `slashCommandArgsFromBody` for DM/channel scope split, empty-text fallback to `help`, missing user_id/channel_id returns null, undefined body returns null, DM-only check stays downstream.
+
+### Operator note
+
+Existing v0.9.0 deployments need to (one-time):
+
+1. Register `/pmk` as a Slash Command at `https://api.slack.com/apps/<APP_ID>/slash-commands` (Socket Mode is on, no Request URL needed)
+2. Reinstall the app to add the `commands` scope
+3. Restart `pmk gateway start` with the v0.9.1 binary
+
+Until step 3 is done, the leading-space path is the only one that works. After step 3, both paths work in parallel.
+
 ## [v0.9.0] — 2026-04-28 — Slack admin commands + audit log
 
 [GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.9.0) · closes [#31](https://github.com/hanfour/pm-workspace-kit/issues/31)

--- a/apps/docs/docs/gateway/lifecycle.md
+++ b/apps/docs/docs/gateway/lifecycle.md
@@ -197,13 +197,13 @@ The post-absorb synthesised reply (sent to the original asker after Phase 9 comp
 
 `/pmk admin <subcommand>` runs gateway-config mutations from inside Slack — same surface as the host CLI, no terminal needed for day-to-day ops.
 
-:::caution Type a leading space before `/pmk` in Slack
+:::tip Two ways to invoke (v0.9.1+)
 
-Slack's client treats any message starting with `/` as a slash-command attempt and blocks it via Slackbot ("/pmk 是無效指令"). pmk doesn't currently register `/pmk` as a real Slack slash-command — it's parsed from the message text on the gateway side after the bot receives the `message` / `app_mention` event.
+Since [v0.9.1](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.9.1) ([#39](https://github.com/hanfour/pm-workspace-kit/issues/39)), `/pmk` is registered as a real Slack slash-command. The recommended path is just to type `/pmk admin help` — Slack autocompletes the command and routes a `slash_commands` envelope to the bot. No leading space, no Slackbot warning, no thread.
 
-Workaround: type a space before the slash, e.g. ` /pmk admin help` (leading-space). The gateway's `text.trim()` strips the space transparently. Same applies to all the v0.7+ commands (`/pmk open`, `/pmk show`, `/pmk close`, `/pmk cases`, `/pmk help`).
+The legacy text-message path (` /pmk admin help` with a leading space) still works as a fallback for users who learned the workaround before v0.9.1, and for any future Slack-app deployment where the slash-command isn't registered. The gateway's `handleDmMessage` / `handleChannelMention` path still fires on `text.startsWith("/pmk ")` after `trim()`.
 
-Tracked in [#39](https://github.com/hanfour/pm-workspace-kit/issues/39) — registering `/pmk` as a real Slack slash-command (Socket Mode `slash_commands` event) is on the v0.9.1 plate.
+Affected commands: `/pmk help`, `/pmk open`, `/pmk show`, `/pmk close`, `/pmk cases`, `/pmk admin`.
 
 :::
 

--- a/apps/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/gateway/lifecycle.md
+++ b/apps/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/gateway/lifecycle.md
@@ -197,13 +197,13 @@ Phase 9 結束後寄給原提問者的合成回覆**不**經過 approval gate（
 
 `/pmk admin <subcommand>` 讓管理員直接從 Slack 內部跑 gateway-config 變更 — 跟 host CLI 同一組面向，日常運維不需要回終端機。
 
-:::caution 在 Slack 輸入 `/pmk` 時請加一個 leading space
+:::tip 兩種觸發方式（v0.9.1+）
 
-Slack client 會把所有 `/` 開頭的訊息當成 slash-command 攔下，由 Slackbot 提示「/pmk 是無效指令」。pmk 目前沒有把 `/pmk` 註冊成真正的 Slack slash-command — 是在 bot 收到 `message` / `app_mention` 事件後，從訊息文字解析出來的。
+[v0.9.1](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.9.1)（[#39](https://github.com/hanfour/pm-workspace-kit/issues/39)）開始，`/pmk` 已註冊為正式的 Slack slash-command。建議直接打 `/pmk admin help` — Slack 會自動補完，把 `slash_commands` envelope 直接送給 bot。不用加 leading space、不會被 Slackbot 提示、回應也不開 thread。
 
-繞過方式：在斜線前打一個空格，例如 ` /pmk admin help`。Gateway 端的 `text.trim()` 會把空格透明地拿掉。所有 v0.7+ 指令（`/pmk open`、`/pmk show`、`/pmk close`、`/pmk cases`、`/pmk help`）都一樣。
+舊的 text-message 路徑（` /pmk admin help` 前面加空格）仍保留為 fallback：給已經習慣這種寫法的人用，也給未來部署到沒註冊 slash-command 的 Slack app 時備用。Gateway 端 `handleDmMessage` / `handleChannelMention` 還是會在 `text.trim()` 後比對 `text.startsWith("/pmk ")`。
 
-追蹤在 [#39](https://github.com/hanfour/pm-workspace-kit/issues/39) — v0.9.1 會把 `/pmk` 註冊成真正的 Slack slash-command（Socket Mode `slash_commands` event）。
+涵蓋指令：`/pmk help`、`/pmk open`、`/pmk show`、`/pmk close`、`/pmk cases`、`/pmk admin`。
 
 :::
 

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -80,6 +80,43 @@ interface FreeChatSession {
   approxTokens: number;
 }
 
+export type SlashCommandScope =
+  | { kind: "user"; userId: string }
+  | { kind: "channel"; channelId: string };
+
+export interface SlashCommandArgs {
+  channelId: string;
+  userId: string;
+  rest: string;
+  scope: SlashCommandScope;
+}
+
+/**
+ * v0.9.1 (#39): pure translation of a Slack `slash_commands` envelope
+ * body into the `handleSlashCommand` arg shape. Exported for tests so
+ * the rest/scope decision is verifiable without spinning up a
+ * SlackAdapter (which needs real Slack tokens to construct).
+ *
+ * Returns null when the body lacks the minimum fields the handler
+ * needs — caller should drop the envelope.
+ */
+export function slashCommandArgsFromBody(
+  body: { user_id?: string; channel_id?: string; text?: string } | undefined,
+): SlashCommandArgs | null {
+  if (!body) return null;
+  const userId = body.user_id;
+  const channelId = body.channel_id;
+  if (!userId || !channelId) return null;
+  // Empty body text (user typed just `/pmk`) routes to the help surface
+  // rather than a "未知指令" reply, so first-time users discover the
+  // command list.
+  const rest = (body.text ?? "").trim() || "help";
+  const scope: SlashCommandScope = channelId.startsWith("D")
+    ? { kind: "user", userId }
+    : { kind: "channel", channelId };
+  return { channelId, userId, rest, scope };
+}
+
 /**
  * Cap for `seenEnvelopes`. Slack retries any un-acked event up to 3
  * times within ~30s; 2 000 entries gives a generous window even on
@@ -159,6 +196,17 @@ export class SlackAdapter {
     // works as the safety net.
     this.socket.on("reaction_added", (event) =>
       this.handleReactionAdded(event),
+    );
+    // v0.9.1 (#39): real Slack slash-command path. Requires `/pmk` to
+    // be registered as a Slash Command on the Slack app side
+    // (https://api.slack.com/apps/<id>/slash-commands). Without that
+    // registration Slack's client blocks `/pmk ...` messages with the
+    // "/pmk 是無效指令" warning before they reach the bot. With it,
+    // `slash_commands` envelopes flow here and skip the leading-space
+    // workaround. The legacy ` /pmk ...` text-message path stays in
+    // place as a fallback.
+    this.socket.on("slash_commands", (event) =>
+      this.handleSlashCommandEnvelope(event),
     );
     this.socket.on("disconnected", () =>
       this.onLog("slack socket disconnected"),
@@ -1059,9 +1107,60 @@ export class SlackAdapter {
 
   // ─────────────────────────── slash commands ───────────────────────────
 
+  /**
+   * v0.9.1 (#39): handle real Slack slash-command envelopes (e.g. user
+   * typed `/pmk admin help` in Slack and Slack delivered a
+   * `slash_commands` envelope because we registered `/pmk` on the app
+   * side). Distinct from the legacy text-message path in
+   * `handleDmMessage` / `handleChannelMention` which fires when users
+   * type ` /pmk admin help` (leading space) as a regular message.
+   *
+   * Envelope shape (via @slack/socket-mode):
+   *   payload.body = {
+   *     command: "/pmk",
+   *     text: "admin help",        // args, no /pmk prefix
+   *     user_id, channel_id, response_url, ...
+   *   }
+   *
+   * Slack expects `payload.ack()` within 3 s; we ack immediately and
+   * post the reply via `chat.postMessage` so the user sees a top-level
+   * bot message rather than the auto-disappearing slash-command echo.
+   */
+  private async handleSlashCommandEnvelope(
+    payload: Slack.SlashCommandPayload,
+  ): Promise<void> {
+    await payload.ack?.().catch(() => {});
+
+    const args = slashCommandArgsFromBody(payload?.body);
+    if (!args) return;
+    if (this.config.blocklist.includes(args.userId)) return;
+
+    if (
+      this.seenEnvelopeSet.has(payload.envelope_id) ||
+      (payload.retry_num ?? 0) > 0
+    ) {
+      return;
+    }
+    this.rememberEnvelope(payload.envelope_id);
+
+    try {
+      await this.handleSlashCommand(args);
+    } catch (err) {
+      this.onLog(
+        `error handling slash command from ${args.userId}: ${(err as Error).message}`,
+      );
+    }
+  }
+
   private async handleSlashCommand(args: {
     channelId: string;
-    threadTs: string;
+    /**
+     * v0.9.1 (#39): optional. Omitted when invoked via the real Slack
+     * `slash_commands` envelope, since slash commands have no anchoring
+     * message to thread under. Present when invoked via the legacy
+     * leading-space `/pmk` text-message path (Phase 11 backwards compat).
+     */
+    threadTs?: string;
     userId: string;
     rest: string;
     scope:
@@ -1079,7 +1178,7 @@ export class SlackAdapter {
     const reply = (text: string) =>
       this.web.chat.postMessage({
         channel: channelId,
-        thread_ts: threadTs,
+        ...(threadTs ? { thread_ts: threadTs } : {}),
         text,
       });
 
@@ -1287,5 +1386,23 @@ declare namespace Slack {
     retry_num?: number;
     retry_reason?: string;
     event?: ReactionEvent;
+  }
+  // v0.9.1 (#39) — real Slack slash-command envelopes. Shape per
+  // @slack/socket-mode body.
+  interface SlashCommandBody {
+    command?: string;
+    text?: string;
+    user_id?: string;
+    channel_id?: string;
+    response_url?: string;
+    trigger_id?: string;
+    team_id?: string;
+  }
+  interface SlashCommandPayload {
+    ack?: (response?: unknown) => Promise<void>;
+    envelope_id: string;
+    retry_num?: number;
+    retry_reason?: string;
+    body?: SlashCommandBody;
   }
 }

--- a/packages/cli/test/gateway.test.ts
+++ b/packages/cli/test/gateway.test.ts
@@ -79,6 +79,7 @@ import {
   searchAtomsRanked,
 } from "../src/gateway/atom-index";
 import { extractKnowledgeAtom } from "../src/gateway/extractor";
+import { slashCommandArgsFromBody } from "../src/gateway/slack";
 import type { LlmProvider } from "../src/llm";
 
 const ORIG_HOME = process.env.HOME;
@@ -1908,5 +1909,81 @@ describe("Slack admin handler (#31)", () => {
     const reload = loadGatewayConfig();
     assert.deepEqual(reload.escalation.repos["erp"], ["U0IT1"]);
     assert.deepEqual(reload.escalation.default, []);
+  });
+});
+
+// ─────────────────────── v0.9.1 slash_commands (#39) ────────────────────────
+
+describe("slashCommandArgsFromBody (#39)", () => {
+  it("DM channel id (D…) → user scope, args trimmed", () => {
+    const args = slashCommandArgsFromBody({
+      user_id: "U0OWNER",
+      channel_id: "D0DMCHAN",
+      text: "  admin help  ",
+    });
+    assert.ok(args);
+    assert.equal(args?.userId, "U0OWNER");
+    assert.equal(args?.channelId, "D0DMCHAN");
+    assert.equal(args?.rest, "admin help");
+    assert.deepEqual(args?.scope, { kind: "user", userId: "U0OWNER" });
+  });
+
+  it("non-DM channel (C…) → channel scope", () => {
+    const args = slashCommandArgsFromBody({
+      user_id: "U0HX",
+      channel_id: "C0CHAN",
+      text: "help",
+    });
+    assert.ok(args);
+    assert.deepEqual(args?.scope, { kind: "channel", channelId: "C0CHAN" });
+  });
+
+  it("empty text routes to help (so /pmk alone is discoverable)", () => {
+    const args = slashCommandArgsFromBody({
+      user_id: "U0X",
+      channel_id: "D0X",
+      text: "",
+    });
+    assert.equal(args?.rest, "help");
+  });
+
+  it("missing text field also routes to help", () => {
+    const args = slashCommandArgsFromBody({
+      user_id: "U0X",
+      channel_id: "D0X",
+    });
+    assert.equal(args?.rest, "help");
+  });
+
+  it("missing user_id → null (envelope dropped)", () => {
+    assert.equal(
+      slashCommandArgsFromBody({ channel_id: "D0X", text: "help" }),
+      null,
+    );
+  });
+
+  it("missing channel_id → null (envelope dropped)", () => {
+    assert.equal(
+      slashCommandArgsFromBody({ user_id: "U0X", text: "help" }),
+      null,
+    );
+  });
+
+  it("undefined body → null", () => {
+    assert.equal(slashCommandArgsFromBody(undefined), null);
+  });
+
+  it("DM-only check is downstream — /pmk admin in a channel still reaches the handler with channel scope", () => {
+    // The body→args helper itself doesn't enforce DM-only; the
+    // `case "admin"` branch in handleSlashCommand does. This test
+    // documents that boundary so a future refactor doesn't accidentally
+    // gate at the wrong layer.
+    const args = slashCommandArgsFromBody({
+      user_id: "U0X",
+      channel_id: "C0PUBLIC",
+      text: "admin status",
+    });
+    assert.ok(args);
+    assert.equal(args?.scope.kind, "channel");
   });
 });


### PR DESCRIPTION
## Summary

Closes #39. Real-Slack verification of [v0.9.0](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.9.0) found that typing `/pmk admin help` in Slack got blocked by Slackbot's "/pmk 是無效指令" intercept and never reached the bot. The only working path was a leading space (` /pmk admin help`) — gross UX, and broken since v0.7.0 for every `/pmk` command.

This PR registers `/pmk` as a real Slack slash-command and adds the Socket Mode `slash_commands` envelope handler. Slack now autocompletes `/pmk`, and the legacy text-message path stays as a fallback.

## What changed

- **`packages/cli/src/gateway/slack/index.ts`** — subscribes to `slash_commands` envelope; new `handleSlashCommandEnvelope` method routes to existing `handleSlashCommand`. Adds `slashCommandArgsFromBody(body)` exported pure helper for the body→args translation. `handleSlashCommand`'s `threadTs` is now optional (slash commands have no anchor); `chat.postMessage` only includes `thread_ts` when defined.
- **`apps/docs/docs/gateway/lifecycle.md` + zh-TW** — Phase 11 callout flipped from `:::caution` (workaround required) to `:::tip` (two ways to invoke; legacy stays for back-compat).
- **`apps/docs/docs/changelog.md`** — v0.9.1 entry.
- **`README.md`** — Latest release v0.9.1, table extended, test count 185 → 193.

## Trust model / behavior

- DM-only check for `/pmk admin` stays downstream in `handleSlashCommand` (where it always was). Slash-command envelopes from a channel still reach the handler with `scope: { kind: 'channel' }` and get the existing `:no_entry_sign:` reply.
- Blocklist still enforced before dispatch.
- Envelope dedup (LRU + retry_num check) shared with the message-event path.

## Test plan

- [x] `npm test` green: 185 → **193 / 193** (+8 unit tests for `slashCommandArgsFromBody`)
- [x] `npm run typecheck:test` clean
- [x] CLI build clean
- [x] **Real Slack verification** with v0.9.1 binary running locally:
  - [x] DM `/pmk admin help` (no leading space) — Slack autocompletes `/pmk`, bot replies with full 13-command help list as top-level message (no thread)
  - [x] Channel `/pmk admin status` — bot replies `:no_entry_sign: /pmk admin 只能在 DM 使用` (DM-only check enforced via slash-command path)
  - [x] Legacy ` /pmk admin help` (leading space) still works (back-compat)
  - [x] Offline broadcast on SIGTERM still fires (no regression)

## Operator one-time setup

For existing v0.9.0 deployments to use the new slash-command path:

1. Register `/pmk` at `https://api.slack.com/apps/<APP_ID>/slash-commands` — Socket Mode is on, no Request URL needed
2. Reinstall the app to pick up the `commands` OAuth scope
3. Restart `pmk gateway start` with the v0.9.1 binary

Until step 3 is done, the leading-space path is the only one that works. After step 3, both paths work in parallel — no breaking change.