### PR TITLE
feat(gateway): pmk gateway audit — knowledge-loop telemetry summary (#24)

### DIFF
--- a/apps/docs/docs/changelog.md
+++ b/apps/docs/docs/changelog.md
@@ -8,6 +8,20 @@ All notable changes to **pm-workspace-kit** are documented here.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each release also has a longer narrative on [GitHub Releases](https://github.com/hanfour/pm-workspace-kit/releases) with rationale, dogfood notes, and test plans.
 
+## [Unreleased] — v0.10 (gateway observability + Slack UX)
+
+Working milestone: [v0.10](https://github.com/hanfour/pm-workspace-kit/milestone/7). Items below land on `feat/v0.10-*` branches and roll up at release time.
+
+### Added
+
+- **`pmk gateway audit [--days N]`** ([#24](https://github.com/hanfour/pm-workspace-kit/issues/24)) — operator-facing rollup of recent knowledge-loop activity: per-user / per-audience turn breakdown, mra-ask success/retry/fail split with median duration, escalate triggered / absorbed / pending counts and median time-to-IT-reply, atom corpus stats with top contributors, plus flags for stuck pending atoms (> 24h) and stale escalations (> 48h). Window defaults to 7 days; `--days` accepts 1–365.
+- **`~/.pmk/gateway/events.log`** — append-only JSONL ledger for the four event types the audit consumes (`turn.processed`, `mra-ask.end`, `escalate.triggered`, `escalate.absorbed`). Mirrors `admin.log` in shape and contracts; tolerant reader skips malformed lines.
+
+### Notes
+
+- Audience binding is captured at turn time, so changing `audience default` after the fact does not rewrite the audit's history.
+- Atom corpus stats (`total`, `approved`, `pending`, `topContributors`) are intentionally lifetime, not window-scoped — atoms persist in `~/.pmk/knowledge/` across windows.
+
 ## [v0.9.1] — 2026-04-28 — `/pmk` real Slack slash-command (no leading-space workaround)
 
 [GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.9.1) · closes [#39](https://github.com/hanfour/pm-workspace-kit/issues/39)

--- a/apps/docs/docs/gateway/lifecycle.md
+++ b/apps/docs/docs/gateway/lifecycle.md
@@ -266,7 +266,7 @@ escalate
 
 knowledge atoms
   total:                       42 (38 approved, 4 pending)
-  retrieval injections:        61 (24.7% of turns)
+  retrieval injections:        61 (0.25 atoms/turn)
   median atoms-injected/turn:  1.3
   top contributors:            U_IT1 ×11, U_IT2 ×8, U_IT3 ×5
 

--- a/apps/docs/docs/gateway/lifecycle.md
+++ b/apps/docs/docs/gateway/lifecycle.md
@@ -240,6 +240,52 @@ Subcommands (DM, admin only):
 - Process stop/restart
 - Blocklist mutation (until a tier-2 admin model exists)
 
+## 12. Audit (v0.10)
+
+`pmk gateway audit [--days N]` (default 7) prints a condensed view of the knowledge loop's recent activity. Operator-facing — no Slack surface. Run it on the host to answer "is this thing actually working?" without tailing the freeform `[pmk-gw] ...` log line by line.
+
+```text
+pmk gateway audit (last 7 days)
+
+Conversations
+  total turns:                 247
+  per-user breakdown:          U0X 89, U0Y 41, U0Z 38, U_OTHER ×8 = 79
+  per-audience breakdown:      tech 142, biz 79, exec 26
+
+mra-ask
+  invocations:                 31 (12.5% of turns)
+  successes / retries / fails: 28 / 2 / 1
+  median duration:             42s
+  top repos asked:             erp ×24, oss-ui-v2 ×7
+
+escalate
+  triggered:                   8
+  absorbed (atom landed):      6
+  pending (no reply yet):      2
+  median time-to-IT-reply:     1h 23m
+
+knowledge atoms
+  total:                       42 (38 approved, 4 pending)
+  retrieval injections:        61 (24.7% of turns)
+  median atoms-injected/turn:  1.3
+  top contributors:            U_IT1 ×11, U_IT2 ×8, U_IT3 ×5
+
+flags
+  WARN 2 atoms have been pending > 24h (auto-promote stuck — gateway not restarted?)
+  WARN 1 escalate(s) with no IT reply for > 48h — consider rejecting marker
+```
+
+**Where the data comes from.** Window-scoped numbers (turns, mra-ask, escalate triggered/absorbed) read `~/.pmk/gateway/events.log` — a JSONL ledger the gateway appends to at four points (`turn.processed`, `mra-ask.end`, `escalate.triggered`, `escalate.absorbed`). Atom corpus stats walk `~/.pmk/knowledge/` directly (atoms don't expire from the dir, so windowing "total" would mislead). Pending escalation count walks `~/.pmk/gateway/slack/escalations/`.
+
+**Audience is captured at turn time** so changing `audience default` later doesn't silently rewrite the audit's history.
+
+**Flags surface known anti-patterns:**
+
+- Atoms still pending > 24h — auto-promote should have fired on next `loadAtoms()`. Usually means the gateway hasn't been restarted since the atom landed.
+- Escalations marked pending > 48h — IT never replied; consider `/pmk admin atoms reject` if the question is stale, or ping the contact pool again.
+
+**No Slack surface.** Audit is host-only because the output is too wide for Slack and contains operator-level concerns (corpus health, pending markers) that aren't useful to end users. `/pmk admin audit` covers admin-action history; `pmk gateway audit` covers the knowledge loop.
+
 ## Honest offline UX
 
 Orthogonal to the directive flow but part of the gateway lifecycle:

--- a/packages/cli/src/commands/gateway.ts
+++ b/packages/cli/src/commands/gateway.ts
@@ -26,6 +26,8 @@ import {
   buildAtomsIndex,
 } from "../gateway/atom-index";
 import { appendAdminLog, cliActor } from "../gateway/admin-log";
+import { buildAuditReport } from "../gateway/audit";
+import { formatAuditReport } from "../gateway/audit-format";
 import { spawnSync } from "node:child_process";
 
 export async function gatewayCommand(
@@ -49,14 +51,54 @@ export async function gatewayCommand(
       return atomsCmd(rest);
     case "admin":
       return adminBootstrapCmd(rest);
+    case "audit":
+      return auditCmd(rest);
     default:
       println(
         chalk.yellow(
-          "usage: pmk gateway <init|start|status|stats|audience|escalation|atoms|admin>",
+          "usage: pmk gateway <init|start|status|stats|audience|escalation|atoms|admin|audit>",
         ),
       );
       process.exit(1);
   }
+}
+
+/**
+ * `pmk gateway audit [--days N]` — operator-facing rollup of the
+ * knowledge loop's recent activity. Default window is 7 days.
+ *
+ * The number `--days` cap exists so an operator who types `--days 999`
+ * doesn't accidentally scan years of events for a hosted gateway. 365
+ * is generous; bump if real workloads need it.
+ */
+function auditCmd(rest: string[]): void {
+  const daysIdx = rest.indexOf("--days");
+  let days = 7;
+  if (daysIdx >= 0) {
+    const raw = rest[daysIdx + 1];
+    const parsed = raw === undefined ? NaN : Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      println(
+        chalk.red(
+          `invalid --days '${raw ?? ""}'. Expected a positive integer (e.g. --days 14).`,
+        ),
+      );
+      process.exit(1);
+    }
+    if (parsed > 365) {
+      println(
+        chalk.yellow(
+          `  warning: --days ${parsed} clamped to 365. Open an issue if you need a longer audit window.`,
+        ),
+      );
+      days = 365;
+    } else {
+      days = parsed;
+    }
+  }
+  const report = buildAuditReport({ days });
+  println("");
+  println(formatAuditReport(report));
 }
 
 async function initCmd(): Promise<void> {

--- a/packages/cli/src/gateway/audit-format.ts
+++ b/packages/cli/src/gateway/audit-format.ts
@@ -1,0 +1,170 @@
+/**
+ * Terminal formatter for {@link AuditReport} (v0.10 / #24).
+ *
+ * Pure: takes a report, returns a string. No I/O. The CLI command
+ * does the println. Kept separate from the aggregator so the report
+ * can be rendered as JSON / piped elsewhere later without untangling.
+ */
+import chalk from "chalk";
+import type { AuditReport } from "./audit";
+
+const LABEL_PAD = 30;
+/** How many top entries to show before collapsing the rest into "OTHER". */
+const TOP_N = 3;
+
+export function formatAuditReport(report: AuditReport): string {
+  const lines: string[] = [];
+  lines.push(
+    chalk.bold(`pmk gateway audit (last ${report.windowDays} days)`),
+  );
+  lines.push("");
+
+  // Conversations
+  lines.push(chalk.bold("Conversations"));
+  lines.push(label("total turns:") + report.conversations.totalTurns);
+  lines.push(
+    label("per-user breakdown:") +
+      formatTopWithOther(report.conversations.perUser, "userId", "turns"),
+  );
+  lines.push(
+    label("per-audience breakdown:") +
+      formatList(
+        report.conversations.perAudience,
+        (e) => `${e.audience} ${e.turns}`,
+      ),
+  );
+  lines.push("");
+
+  // mra-ask
+  lines.push(chalk.bold("mra-ask"));
+  lines.push(
+    label("invocations:") +
+      `${report.mraAsk.invocations}${pctOfTurns(
+        report.mraAsk.invocations,
+        report.conversations.totalTurns,
+      )}`,
+  );
+  lines.push(
+    label("successes / retries / fails:") +
+      `${report.mraAsk.successes} / ${report.mraAsk.retries} / ${report.mraAsk.failures}`,
+  );
+  lines.push(
+    label("median duration:") + formatDurationMs(report.mraAsk.medianDurationMs),
+  );
+  lines.push(
+    label("top repos asked:") +
+      formatList(report.mraAsk.topRepos, (e) => `${e.repo} ×${e.count}`),
+  );
+  lines.push("");
+
+  // escalate
+  lines.push(chalk.bold("escalate"));
+  lines.push(label("triggered:") + report.escalate.triggered);
+  lines.push(label("absorbed (atom landed):") + report.escalate.absorbed);
+  lines.push(label("pending (no reply yet):") + report.escalate.pending);
+  lines.push(
+    label("median time-to-IT-reply:") +
+      formatDurationMs(report.escalate.medianTimeToReplyMs),
+  );
+  lines.push("");
+
+  // atoms
+  lines.push(chalk.bold("knowledge atoms"));
+  lines.push(
+    label("total:") +
+      `${report.atoms.total} (${report.atoms.approved} approved, ${report.atoms.pending} pending)`,
+  );
+  lines.push(
+    label("retrieval injections:") +
+      `${report.atoms.retrievalInjections}${pctOfTurns(
+        report.atoms.retrievalInjections,
+        report.conversations.totalTurns,
+      )}`,
+  );
+  lines.push(
+    label("median atoms-injected/turn:") +
+      (report.atoms.medianAtomsInjectedPerTurn === undefined
+        ? "—"
+        : formatDecimal(report.atoms.medianAtomsInjectedPerTurn)),
+  );
+  lines.push(
+    label("top contributors:") +
+      formatList(
+        report.atoms.topContributors,
+        (e) => `${e.userId} ×${e.count}`,
+      ),
+  );
+
+  // flags
+  if (report.flags.length > 0) {
+    lines.push("");
+    lines.push(chalk.bold(chalk.yellow("flags")));
+    for (const f of report.flags) {
+      lines.push("  " + chalk.yellow("WARN ") + f);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Render a duration in human-readable form. Tiers chosen to match
+ * what an operator scans for: seconds for snappy ops, minutes when
+ * latency starts to bite, hours/days for backlog problems.
+ *
+ * Returns "—" for undefined so empty reports don't render "NaNs" or
+ * "0s" (which would falsely imply a measurement happened).
+ */
+export function formatDurationMs(ms: number | undefined): string {
+  if (ms === undefined) return "—";
+  if (!Number.isFinite(ms) || ms < 0) return "—";
+  const totalSec = Math.max(1, Math.round(ms / 1000));
+  if (totalSec < 60) return `${totalSec}s`;
+  const totalMin = Math.round(totalSec / 60);
+  if (totalMin < 60) return `${totalMin}m`;
+  const hours = Math.floor(totalMin / 60);
+  const mins = totalMin % 60;
+  if (hours < 24) return mins === 0 ? `${hours}h` : `${hours}h ${mins}m`;
+  const days = Math.floor(hours / 24);
+  const remHours = hours % 24;
+  return remHours === 0 ? `${days}d` : `${days}d ${remHours}h`;
+}
+
+function label(text: string): string {
+  return "  " + chalk.dim(text.padEnd(LABEL_PAD));
+}
+
+function pctOfTurns(numerator: number, totalTurns: number): string {
+  if (totalTurns === 0) return "";
+  const pct = (numerator / totalTurns) * 100;
+  return ` (${formatDecimal(pct)}% of turns)`;
+}
+
+function formatDecimal(n: number): string {
+  return Number.isInteger(n) ? `${n}.0` : n.toFixed(1);
+}
+
+function formatList<T>(items: T[], render: (item: T) => string): string {
+  if (items.length === 0) return chalk.dim("(none)");
+  return items.map(render).join(", ");
+}
+
+/**
+ * Show the top N entries verbatim, then collapse the rest into a
+ * single "U_OTHER ×<count> = <sumOfTurns>" tail. Mirrors the issue
+ * sketch — the operator wants to see the heavy hitters without losing
+ * the long-tail volume.
+ */
+function formatTopWithOther(
+  items: Array<{ userId: string; turns: number }>,
+  _keyName: "userId",
+  _countName: "turns",
+): string {
+  if (items.length === 0) return chalk.dim("(none)");
+  const head = items.slice(0, TOP_N);
+  const tail = items.slice(TOP_N);
+  const headPart = head.map((e) => `${e.userId} ${e.turns}`).join(", ");
+  if (tail.length === 0) return headPart;
+  const tailSum = tail.reduce((acc, e) => acc + e.turns, 0);
+  return `${headPart}, U_OTHER ×${tail.length} = ${tailSum}`;
+}

--- a/packages/cli/src/gateway/audit-format.ts
+++ b/packages/cli/src/gateway/audit-format.ts
@@ -14,9 +14,7 @@ const TOP_N = 3;
 
 export function formatAuditReport(report: AuditReport): string {
   const lines: string[] = [];
-  lines.push(
-    chalk.bold(`pmk gateway audit (last ${report.windowDays} days)`),
-  );
+  lines.push(chalk.bold(`pmk gateway audit (last ${report.windowDays} days)`));
   lines.push("");
 
   // Conversations
@@ -24,7 +22,7 @@ export function formatAuditReport(report: AuditReport): string {
   lines.push(label("total turns:") + report.conversations.totalTurns);
   lines.push(
     label("per-user breakdown:") +
-      formatTopWithOther(report.conversations.perUser, "userId", "turns"),
+      formatTopWithOther(report.conversations.perUser),
   );
   lines.push(
     label("per-audience breakdown:") +
@@ -49,7 +47,8 @@ export function formatAuditReport(report: AuditReport): string {
       `${report.mraAsk.successes} / ${report.mraAsk.retries} / ${report.mraAsk.failures}`,
   );
   lines.push(
-    label("median duration:") + formatDurationMs(report.mraAsk.medianDurationMs),
+    label("median duration:") +
+      formatDurationMs(report.mraAsk.medianDurationMs),
   );
   lines.push(
     label("top repos asked:") +
@@ -76,7 +75,7 @@ export function formatAuditReport(report: AuditReport): string {
   );
   lines.push(
     label("retrieval injections:") +
-      `${report.atoms.retrievalInjections}${pctOfTurns(
+      `${report.atoms.retrievalInjections}${ratePerTurn(
         report.atoms.retrievalInjections,
         report.conversations.totalTurns,
       )}`,
@@ -100,7 +99,7 @@ export function formatAuditReport(report: AuditReport): string {
     lines.push("");
     lines.push(chalk.bold(chalk.yellow("flags")));
     for (const f of report.flags) {
-      lines.push("  " + chalk.yellow("WARN ") + f);
+      lines.push("  " + chalk.bold(chalk.yellow("WARN")) + " " + f);
     }
   }
 
@@ -140,8 +139,30 @@ function pctOfTurns(numerator: number, totalTurns: number): string {
   return ` (${formatDecimal(pct)}% of turns)`;
 }
 
+/**
+ * Render a per-turn ratio. Used for atomsInjected which can exceed
+ * 1.0 (multiple atoms per turn average), where "% of turns" reads
+ * misleadingly above 100%. "0.25 atoms/turn" / "1.5 atoms/turn"
+ * scale cleanly at any density.
+ */
+function ratePerTurn(numerator: number, totalTurns: number): string {
+  if (totalTurns === 0) return "";
+  const rate = numerator / totalTurns;
+  return ` (${formatRate(rate)} atoms/turn)`;
+}
+
 function formatDecimal(n: number): string {
   return Number.isInteger(n) ? `${n}.0` : n.toFixed(1);
+}
+
+/**
+ * 2 decimals for sub-1 rates so 0.05 / 0.25 don't both collapse to
+ * "0.1"; 1 decimal once the rate is large enough that the second
+ * digit is noise.
+ */
+function formatRate(n: number): string {
+  if (!Number.isFinite(n)) return "—";
+  return n < 1 ? n.toFixed(2) : n.toFixed(1);
 }
 
 function formatList<T>(items: T[], render: (item: T) => string): string {
@@ -157,8 +178,6 @@ function formatList<T>(items: T[], render: (item: T) => string): string {
  */
 function formatTopWithOther(
   items: Array<{ userId: string; turns: number }>,
-  _keyName: "userId",
-  _countName: "turns",
 ): string {
   if (items.length === 0) return chalk.dim("(none)");
   const head = items.slice(0, TOP_N);

--- a/packages/cli/src/gateway/audit.ts
+++ b/packages/cli/src/gateway/audit.ts
@@ -11,11 +11,9 @@
  * lifetime — atoms don't expire from the knowledge dir, so windowing
  * "total atoms" would be misleading.
  */
-import * as fs from "node:fs";
-import * as path from "node:path";
-import { gatewayDir } from "./config";
 import { readGatewayEvents } from "./events";
 import { loadAtoms, ATOM_PENDING_TTL_MS } from "./knowledge";
+import { listPendingEscalations } from "./session-store";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_WINDOW_DAYS = 7;
@@ -101,7 +99,14 @@ export function buildAuditReport(
 
   let escTriggered = 0;
   let escAbsorbed = 0;
-  const triggeredAt = new Map<string, number>();
+  /**
+   * Per-thread FIFO of pending trigger timestamps. Same Slack thread
+   * can be re-escalated (first round ignored, user re-asks, pmk fires
+   * another escalate) — pair the absorption with the OLDEST unmatched
+   * trigger so the median time-to-reply reflects "how long until the
+   * original question got answered" rather than the latest re-poke.
+   */
+  const triggeredAt = new Map<string, number[]>();
   const replyDurations: number[] = [];
 
   for (const e of events) {
@@ -123,13 +128,19 @@ export function buildAuditReport(
         mraDurations.push(e.durationMs);
         bump(mraRepos, e.repo);
         break;
-      case "escalate.triggered":
+      case "escalate.triggered": {
         escTriggered++;
-        triggeredAt.set(escKey(e.channelId, e.threadTs), Date.parse(e.at));
+        const k = escKey(e.channelId, e.threadTs);
+        const queue = triggeredAt.get(k) ?? [];
+        queue.push(Date.parse(e.at));
+        triggeredAt.set(k, queue);
         break;
+      }
       case "escalate.absorbed": {
         escAbsorbed++;
-        const start = triggeredAt.get(escKey(e.channelId, e.threadTs));
+        const k = escKey(e.channelId, e.threadTs);
+        const queue = triggeredAt.get(k);
+        const start = queue?.shift();
         if (start !== undefined) {
           const end = Date.parse(e.at);
           if (Number.isFinite(start) && Number.isFinite(end) && end >= start) {
@@ -141,7 +152,10 @@ export function buildAuditReport(
     }
   }
 
-  const atoms = loadAtoms();
+  // Audit is observational — never trigger TTL auto-promotion as a
+  // side effect of reading. The corpus state we report is exactly
+  // what's on disk at the moment of audit.
+  const atoms = loadAtoms({ promote: false });
   const approvedAtoms = atoms.filter((a) => a.status !== "pending").length;
   const pendingAtoms = atoms.length - approvedAtoms;
   const contributors = new Map<string, number>();
@@ -151,9 +165,7 @@ export function buildAuditReport(
 
   const flags: string[] = [];
   const stuckAtoms = atoms.filter(
-    (a) =>
-      a.status === "pending" &&
-      now - a.createdAt > ATOM_PENDING_FLAG_MS,
+    (a) => a.status === "pending" && now - a.createdAt > ATOM_PENDING_FLAG_MS,
   ).length;
   if (stuckAtoms > 0) {
     flags.push(
@@ -225,7 +237,8 @@ function rank<K extends string, V extends string>(
     });
   }
   out.sort(
-    (a, b) => (b as Record<V, number>)[countName] - (a as Record<V, number>)[countName],
+    (a, b) =>
+      (b as Record<V, number>)[countName] - (a as Record<V, number>)[countName],
   );
   return out;
 }
@@ -241,33 +254,4 @@ function median(samples: number[]): number | undefined {
 
 function escKey(channelId: string, threadTs: string): string {
   return `${channelId}__${threadTs}`;
-}
-
-interface PendingEscalation {
-  channelId: string;
-  threadTs: string;
-  pendingSince: number;
-}
-
-function listPendingEscalations(): PendingEscalation[] {
-  const dir = path.join(gatewayDir(), "slack", "escalations");
-  if (!fs.existsSync(dir)) return [];
-  const out: PendingEscalation[] = [];
-  for (const f of fs.readdirSync(dir)) {
-    if (!f.endsWith(".json")) continue;
-    try {
-      const raw = fs.readFileSync(path.join(dir, f), "utf8");
-      const parsed = JSON.parse(raw) as PendingEscalation;
-      if (
-        typeof parsed.channelId === "string" &&
-        typeof parsed.threadTs === "string" &&
-        typeof parsed.pendingSince === "number"
-      ) {
-        out.push(parsed);
-      }
-    } catch {
-      /* skip corrupt */
-    }
-  }
-  return out;
 }

--- a/packages/cli/src/gateway/audit.ts
+++ b/packages/cli/src/gateway/audit.ts
@@ -1,0 +1,273 @@
+/**
+ * Aggregator for `pmk gateway audit` (v0.10 / #24).
+ *
+ * Reads three sources:
+ *   1. ~/.pmk/gateway/events.log         (turn / mra-ask / escalate.* events)
+ *   2. ~/.pmk/knowledge/<scope>/*.md     (atom corpus, status, contributors)
+ *   3. ~/.pmk/gateway/slack/escalations/ (currently-pending markers)
+ *
+ * Window-scoped numbers (turns, mra-ask, escalate triggered/absorbed)
+ * filter events by `at >= now - days*86400_000`. Atom corpus stats are
+ * lifetime — atoms don't expire from the knowledge dir, so windowing
+ * "total atoms" would be misleading.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { gatewayDir } from "./config";
+import { readGatewayEvents } from "./events";
+import { loadAtoms, ATOM_PENDING_TTL_MS } from "./knowledge";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_WINDOW_DAYS = 7;
+/** Pending atom that has lingered this long → flag (auto-promote stuck). */
+const ATOM_PENDING_FLAG_MS = ATOM_PENDING_TTL_MS;
+/** Pending escalation that has lingered this long → flag (no IT reply). */
+const ESCALATE_STALE_FLAG_MS = 48 * 60 * 60 * 1000;
+
+export interface AuditReport {
+  windowDays: number;
+  windowStartMs: number;
+  windowEndMs: number;
+  conversations: {
+    totalTurns: number;
+    perUser: Array<{ userId: string; turns: number }>;
+    perAudience: Array<{ audience: string; turns: number }>;
+  };
+  mraAsk: {
+    invocations: number;
+    /** ok=true and not retried — the happy path. */
+    successes: number;
+    /** ok=true but retried — succeeded after the v0.7.3 retry-once. */
+    retries: number;
+    /** ok=false — failed even with retry. */
+    failures: number;
+    medianDurationMs: number | undefined;
+    topRepos: Array<{ repo: string; count: number }>;
+  };
+  escalate: {
+    triggered: number;
+    absorbed: number;
+    /** Markers currently on disk under .../escalations/. */
+    pending: number;
+    /** Median (absorbed.at - triggered.at) for paired events in window. */
+    medianTimeToReplyMs: number | undefined;
+  };
+  atoms: {
+    /** Lifetime count, not window-scoped. */
+    total: number;
+    approved: number;
+    pending: number;
+    /** Sum of atomsInjected across in-window turns. */
+    retrievalInjections: number;
+    /** Median atomsInjected per turn, computed over turns where it was > 0. */
+    medianAtomsInjectedPerTurn: number | undefined;
+    /** Lifetime, by source.contributorUserId. */
+    topContributors: Array<{ userId: string; count: number }>;
+  };
+  flags: string[];
+}
+
+export interface BuildAuditReportOptions {
+  /** Lookback window. Falls back to 7 on non-positive / non-finite input. */
+  days?: number;
+  /** Override "now" for tests. Defaults to Date.now(). */
+  nowMs?: number;
+}
+
+export function buildAuditReport(
+  opts: BuildAuditReportOptions = {},
+): AuditReport {
+  const now = opts.nowMs ?? Date.now();
+  const days =
+    Number.isFinite(opts.days) && (opts.days as number) > 0
+      ? Math.floor(opts.days as number)
+      : DEFAULT_WINDOW_DAYS;
+  const sinceMs = now - days * DAY_MS;
+
+  const events = readGatewayEvents({ sinceMs });
+
+  const perUser = new Map<string, number>();
+  const perAudience = new Map<string, number>();
+  let totalTurns = 0;
+  let retrievalInjections = 0;
+  const injectedSamples: number[] = [];
+
+  let mraInvocations = 0;
+  let mraSuccesses = 0;
+  let mraRetries = 0;
+  let mraFailures = 0;
+  const mraDurations: number[] = [];
+  const mraRepos = new Map<string, number>();
+
+  let escTriggered = 0;
+  let escAbsorbed = 0;
+  const triggeredAt = new Map<string, number>();
+  const replyDurations: number[] = [];
+
+  for (const e of events) {
+    switch (e.type) {
+      case "turn.processed":
+        totalTurns++;
+        bump(perUser, e.actor);
+        bump(perAudience, e.audience);
+        if (e.atomsInjected > 0) {
+          retrievalInjections += e.atomsInjected;
+          injectedSamples.push(e.atomsInjected);
+        }
+        break;
+      case "mra-ask.end":
+        mraInvocations++;
+        if (e.ok && !e.retried) mraSuccesses++;
+        else if (e.ok && e.retried) mraRetries++;
+        else mraFailures++;
+        mraDurations.push(e.durationMs);
+        bump(mraRepos, e.repo);
+        break;
+      case "escalate.triggered":
+        escTriggered++;
+        triggeredAt.set(escKey(e.channelId, e.threadTs), Date.parse(e.at));
+        break;
+      case "escalate.absorbed": {
+        escAbsorbed++;
+        const start = triggeredAt.get(escKey(e.channelId, e.threadTs));
+        if (start !== undefined) {
+          const end = Date.parse(e.at);
+          if (Number.isFinite(start) && Number.isFinite(end) && end >= start) {
+            replyDurations.push(end - start);
+          }
+        }
+        break;
+      }
+    }
+  }
+
+  const atoms = loadAtoms();
+  const approvedAtoms = atoms.filter((a) => a.status !== "pending").length;
+  const pendingAtoms = atoms.length - approvedAtoms;
+  const contributors = new Map<string, number>();
+  for (const a of atoms) bump(contributors, a.source.contributorUserId);
+
+  const pendingEscalations = listPendingEscalations();
+
+  const flags: string[] = [];
+  const stuckAtoms = atoms.filter(
+    (a) =>
+      a.status === "pending" &&
+      now - a.createdAt > ATOM_PENDING_FLAG_MS,
+  ).length;
+  if (stuckAtoms > 0) {
+    flags.push(
+      `${stuckAtoms} atom(s) have been pending > 24h (auto-promote stuck — gateway not restarted?)`,
+    );
+  }
+  const staleEscalations = pendingEscalations.filter(
+    (esc) => now - esc.pendingSince > ESCALATE_STALE_FLAG_MS,
+  ).length;
+  if (staleEscalations > 0) {
+    flags.push(
+      `${staleEscalations} escalate(s) with no IT reply for > 48h — consider rejecting marker`,
+    );
+  }
+
+  return {
+    windowDays: days,
+    windowStartMs: sinceMs,
+    windowEndMs: now,
+    conversations: {
+      totalTurns,
+      perUser: rank(perUser, "userId", "turns"),
+      perAudience: rank(perAudience, "audience", "turns"),
+    },
+    mraAsk: {
+      invocations: mraInvocations,
+      successes: mraSuccesses,
+      retries: mraRetries,
+      failures: mraFailures,
+      medianDurationMs: median(mraDurations),
+      topRepos: rank(mraRepos, "repo", "count"),
+    },
+    escalate: {
+      triggered: escTriggered,
+      absorbed: escAbsorbed,
+      pending: pendingEscalations.length,
+      medianTimeToReplyMs: median(replyDurations),
+    },
+    atoms: {
+      total: atoms.length,
+      approved: approvedAtoms,
+      pending: pendingAtoms,
+      retrievalInjections,
+      medianAtomsInjectedPerTurn: median(injectedSamples),
+      topContributors: rank(contributors, "userId", "count"),
+    },
+    flags,
+  };
+}
+
+function bump(map: Map<string, number>, key: string): void {
+  map.set(key, (map.get(key) ?? 0) + 1);
+}
+
+/**
+ * Rank a count map into `[{ <keyName>, <countName> }]` sorted by count
+ * descending. Generic over the field names so callers get a useful
+ * shape without an extra map step.
+ */
+function rank<K extends string, V extends string>(
+  map: Map<string, number>,
+  keyName: K,
+  countName: V,
+): Array<{ [P in K]: string } & { [P in V]: number }> {
+  const out: Array<{ [P in K]: string } & { [P in V]: number }> = [];
+  for (const [k, count] of map) {
+    out.push({ [keyName]: k, [countName]: count } as { [P in K]: string } & {
+      [P in V]: number;
+    });
+  }
+  out.sort(
+    (a, b) => (b as Record<V, number>)[countName] - (a as Record<V, number>)[countName],
+  );
+  return out;
+}
+
+function median(samples: number[]): number | undefined {
+  if (samples.length === 0) return undefined;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+function escKey(channelId: string, threadTs: string): string {
+  return `${channelId}__${threadTs}`;
+}
+
+interface PendingEscalation {
+  channelId: string;
+  threadTs: string;
+  pendingSince: number;
+}
+
+function listPendingEscalations(): PendingEscalation[] {
+  const dir = path.join(gatewayDir(), "slack", "escalations");
+  if (!fs.existsSync(dir)) return [];
+  const out: PendingEscalation[] = [];
+  for (const f of fs.readdirSync(dir)) {
+    if (!f.endsWith(".json")) continue;
+    try {
+      const raw = fs.readFileSync(path.join(dir, f), "utf8");
+      const parsed = JSON.parse(raw) as PendingEscalation;
+      if (
+        typeof parsed.channelId === "string" &&
+        typeof parsed.threadTs === "string" &&
+        typeof parsed.pendingSince === "number"
+      ) {
+        out.push(parsed);
+      }
+    } catch {
+      /* skip corrupt */
+    }
+  }
+  return out;
+}

--- a/packages/cli/src/gateway/events.ts
+++ b/packages/cli/src/gateway/events.ts
@@ -19,7 +19,13 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import type { AudienceKey } from "@pmk/shared";
 import { gatewayDir } from "./config";
+
+// TODO(v0.10.x): events.log grows unbounded. At single-host workloads
+// (~100 events/day) we'd hit ~1MB/year — acceptable for now but the
+// admin.log has the same gap; a single rotation helper covering both
+// is the right shape when we get there.
 
 /**
  * `mra ask` round outcome. `retried=true` means the call succeeded or
@@ -46,7 +52,13 @@ export interface MraAskEndEvent {
 export interface TurnProcessedEvent {
   type: "turn.processed";
   actor: string;
-  audience: string;
+  /**
+   * Tightened to {@link AudienceKey} (rather than `string`) so emitter
+   * sites can't slip in a typo'd tier. The reader still tolerates any
+   * string (legacy events from earlier dev builds aren't rejected) —
+   * only the write boundary is policed.
+   */
+  audience: AudienceKey;
   hadMraAsk: boolean;
   /** Number of approved knowledge atoms injected via retrieval. */
   atomsInjected: number;

--- a/packages/cli/src/gateway/events.ts
+++ b/packages/cli/src/gateway/events.ts
@@ -1,0 +1,164 @@
+/**
+ * Append-only structured event log for the gateway (v0.10 / #24).
+ *
+ * The freeform `[pmk-gw] ...` breadcrumbs printed to stdout are good
+ * for live tailing but lossy and unstructured. `pmk gateway audit`
+ * needs reliable counts of mra-ask outcomes, retrieval injections,
+ * audience splits, and escalation lifetimes — none of which are
+ * recoverable from prose log lines.
+ *
+ * This module mirrors `admin-log.ts` (v0.9 / #31) deliberately:
+ * JSONL, best-effort writes, tolerant reader. Different file
+ * (`events.log` vs `admin.log`) so admin actions stay isolated and
+ * each can be rotated independently.
+ *
+ * Events are domain-shaped, not transport-shaped — the consumer is
+ * the audit aggregator, not Prometheus. A future exporter to OTel /
+ * structured logging is out of scope.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { gatewayDir } from "./config";
+
+/**
+ * `mra ask` round outcome. `retried=true` means the call succeeded or
+ * failed only after the v0.7.3 retry-once kicked in. `durationMs`
+ * covers the full runMraAsk window including any retry, since that is
+ * what the user perceived.
+ */
+export interface MraAskEndEvent {
+  type: "mra-ask.end";
+  /** Slack user ID that triggered the round. */
+  actor: string;
+  repo: string;
+  ok: boolean;
+  retried: boolean;
+  durationMs: number;
+}
+
+/**
+ * One bot reply turn. Audience is captured at turn time so historical
+ * audits are not invalidated by later config changes (the alternative
+ * — re-resolving via `pickAudience(cfg, actor)` at audit time —
+ * silently rewrites history).
+ */
+export interface TurnProcessedEvent {
+  type: "turn.processed";
+  actor: string;
+  audience: string;
+  hadMraAsk: boolean;
+  /** Number of approved knowledge atoms injected via retrieval. */
+  atomsInjected: number;
+}
+
+export interface EscalateTriggeredEvent {
+  type: "escalate.triggered";
+  channelId: string;
+  threadTs: string;
+  scope?: string;
+}
+
+/**
+ * Emitted when an IT contributor reply lands and the absorber writes a
+ * pending atom. `atomId` is omitted if absorption failed to land an
+ * atom (e.g. extractor returned no candidate); the audit treats those
+ * as absorbed-without-atom and surfaces the gap.
+ */
+export interface EscalateAbsorbedEvent {
+  type: "escalate.absorbed";
+  channelId: string;
+  threadTs: string;
+  atomId?: string;
+}
+
+export type GatewayEvent =
+  | MraAskEndEvent
+  | TurnProcessedEvent
+  | EscalateTriggeredEvent
+  | EscalateAbsorbedEvent;
+
+/** What lands on disk: the event plus the ISO timestamp added at append time. */
+export type StoredGatewayEvent = GatewayEvent & { at: string };
+
+const VALID_TYPES: ReadonlySet<string> = new Set([
+  "mra-ask.end",
+  "turn.processed",
+  "escalate.triggered",
+  "escalate.absorbed",
+]);
+
+export function gatewayEventsPath(): string {
+  return path.join(gatewayDir(), "events.log");
+}
+
+/**
+ * Append a structured event. Best-effort — failures to write don't
+ * propagate, since blocking the gateway on a corrupt audit log would
+ * be worse than the missing line. Mirrors {@link appendAdminLog}.
+ */
+export function appendGatewayEvent(event: GatewayEvent): void {
+  try {
+    fs.mkdirSync(gatewayDir(), { recursive: true });
+    const line =
+      JSON.stringify({
+        at: new Date().toISOString(),
+        ...event,
+      }) + "\n";
+    fs.appendFileSync(gatewayEventsPath(), line, "utf8");
+  } catch {
+    /* non-fatal */
+  }
+}
+
+export interface ReadGatewayEventsOptions {
+  /** Only return events with `at` >= this epoch ms. */
+  sinceMs?: number;
+  /** Tail to last N entries (applied after sinceMs). */
+  limit?: number;
+}
+
+/**
+ * Read parsed events. Returns [] on missing file, read error, or all
+ * lines being malformed. Malformed lines are silently skipped so a
+ * single bad write doesn't poison the audit.
+ */
+export function readGatewayEvents(
+  opts: ReadGatewayEventsOptions = {},
+): StoredGatewayEvent[] {
+  const file = gatewayEventsPath();
+  if (!fs.existsSync(file)) return [];
+  let text: string;
+  try {
+    text = fs.readFileSync(file, "utf8");
+  } catch {
+    return [];
+  }
+  const out: StoredGatewayEvent[] = [];
+  for (const line of text.split("\n")) {
+    if (line.length === 0) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!isStoredGatewayEvent(parsed)) continue;
+    if (opts.sinceMs !== undefined) {
+      const t = Date.parse(parsed.at);
+      if (!Number.isFinite(t) || t < opts.sinceMs) continue;
+    }
+    out.push(parsed);
+  }
+  if (opts.limit !== undefined && opts.limit >= 0 && out.length > opts.limit) {
+    return out.slice(out.length - opts.limit);
+  }
+  return out;
+}
+
+function isStoredGatewayEvent(v: unknown): v is StoredGatewayEvent {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  if (typeof o.at !== "string" || typeof o.type !== "string") return false;
+  return VALID_TYPES.has(o.type);
+}

--- a/packages/cli/src/gateway/knowledge.ts
+++ b/packages/cli/src/gateway/knowledge.ts
@@ -247,7 +247,21 @@ export function saveAtom(atom: KnowledgeAtom): string {
  * Load every atom under `~/.pmk/knowledge/`. Returns sorted by
  * createdAt descending. Optionally filter by scope.
  */
-export function loadAtoms(opts: { scope?: string } = {}): KnowledgeAtom[] {
+export function loadAtoms(
+  opts: {
+    scope?: string;
+    /**
+     * When true (default), TTL-expired pending atoms are auto-promoted
+     * AND the file is rewritten to disk. Set to false for read-only
+     * callers (e.g. `pmk gateway audit`) that should not have a write
+     * side-effect just from reading the corpus. With promote=false the
+     * in-memory atom keeps its original `status` / `expiresAt`, so the
+     * audit reflects the true on-disk state at observation time.
+     */
+    promote?: boolean;
+  } = {},
+): KnowledgeAtom[] {
+  const promote = opts.promote ?? true;
   const root = knowledgeRoot();
   if (!fs.existsSync(root)) return [];
   const atoms: KnowledgeAtom[] = [];
@@ -273,6 +287,7 @@ export function loadAtoms(opts: { scope?: string } = {}): KnowledgeAtom[] {
         // Auto-promote pending atoms whose TTL has passed. Rewrite to
         // disk so the side-effect is persistent (next load is a no-op).
         if (
+          promote &&
           atom.status === "pending" &&
           atom.expiresAt !== undefined &&
           atom.expiresAt <= now

--- a/packages/cli/src/gateway/session-store.ts
+++ b/packages/cli/src/gateway/session-store.ts
@@ -314,3 +314,35 @@ export function clearThreadEscalation(
     /* may already be gone */
   }
 }
+
+/**
+ * List every escalation marker currently on disk. A marker existing
+ * means the thread is still waiting for an IT reply (clearThreadEscalation
+ * deletes the file the moment a reply lands and is absorbed). Used by
+ * `pmk gateway audit` to count + flag stale pending escalations.
+ *
+ * Returns parsed markers; corrupt or non-JSON files are skipped.
+ */
+export function listPendingEscalations(): ThreadEscalation[] {
+  const dir = escalationsDir();
+  if (!fs.existsSync(dir)) return [];
+  const out: ThreadEscalation[] = [];
+  for (const f of fs.readdirSync(dir)) {
+    if (!f.endsWith(".json")) continue;
+    try {
+      const parsed = JSON.parse(
+        fs.readFileSync(path.join(dir, f), "utf8"),
+      ) as ThreadEscalation;
+      if (
+        typeof parsed.channelId === "string" &&
+        typeof parsed.threadTs === "string" &&
+        typeof parsed.pendingSince === "number"
+      ) {
+        out.push(parsed);
+      }
+    } catch {
+      /* skip corrupt */
+    }
+  }
+  return out;
+}

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -46,6 +46,7 @@ import {
   stripCaseUpdateBlock,
 } from "../../case";
 import { mraDoctor, runMraAsk } from "../../adapters/mra";
+import { appendGatewayEvent } from "../events";
 import { parseMraAsk, stripMraAskBlock } from "../mra-ask";
 import {
   buildIngestSeed,
@@ -530,6 +531,7 @@ export class SlackAdapter {
         firstResponse: full,
         request: askReq,
         systemPrompt,
+        actor: userId,
       });
     }
 
@@ -565,6 +567,14 @@ export class SlackAdapter {
       );
     }
     saveSession(session);
+
+    appendGatewayEvent({
+      type: "turn.processed",
+      actor: userId,
+      audience,
+      hadMraAsk: askReq !== undefined,
+      atomsInjected: retrieved.length,
+    });
 
     await this.web.chat.update({
       channel: channelId,
@@ -660,6 +670,12 @@ export class SlackAdapter {
       mentionedUserIds: effectivePool,
       askerUserId,
     });
+    appendGatewayEvent({
+      type: "escalate.triggered",
+      channelId,
+      threadTs,
+      scope: request.repo,
+    });
   }
 
   /**
@@ -711,6 +727,12 @@ export class SlackAdapter {
       // First save: atom in pending without approval anchor.
       const file = saveAtom(atom);
       this.onLog(`absorbed knowledge atom (pending) → ${file}`);
+      appendGatewayEvent({
+        type: "escalate.absorbed",
+        channelId,
+        threadTs,
+        atomId: atom.id,
+      });
       const idShort = atom.id.split("-").slice(0, 2).join("-");
       const post = await this.web.chat
         .postMessage({
@@ -900,6 +922,9 @@ export class SlackAdapter {
     firstResponse: string;
     request: { repo: string; question: string };
     systemPrompt: string;
+    /** Slack user ID that triggered this round — recorded in the
+     * audit event so per-user mra-ask cost is attributable. */
+    actor: string;
   }): Promise<string> {
     const {
       channelId,
@@ -909,6 +934,7 @@ export class SlackAdapter {
       firstResponse,
       request,
       systemPrompt,
+      actor,
     } = args;
     const doctor = mraDoctor({ workspace: this.config.mraWorkspace });
     if (!doctor.ok || !doctor.workspace) {
@@ -943,6 +969,7 @@ export class SlackAdapter {
     this.onLog(
       `mra ask repo=${request.repo} q=${truncate(request.question, 120)}`,
     );
+    const mraStartMs = Date.now();
     const result = await runMraAsk(
       {
         repo: request.repo,
@@ -957,6 +984,14 @@ export class SlackAdapter {
         },
       },
     );
+    appendGatewayEvent({
+      type: "mra-ask.end",
+      actor,
+      repo: request.repo,
+      ok: result.ok,
+      retried: result.attempts > 1,
+      durationMs: Date.now() - mraStartMs,
+    });
     if (result.ok && result.attempts > 1) {
       this.onLog(`mra ask succeeded on attempt ${result.attempts}`);
     }

--- a/packages/cli/test/gateway-audit-format.test.ts
+++ b/packages/cli/test/gateway-audit-format.test.ts
@@ -1,0 +1,193 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import {
+  formatAuditReport,
+  formatDurationMs,
+} from "../src/gateway/audit-format";
+import type { AuditReport } from "../src/gateway/audit";
+
+const NOW = Date.parse("2026-04-29T12:00:00.000Z");
+
+function emptyReport(overrides: Partial<AuditReport> = {}): AuditReport {
+  return {
+    windowDays: 7,
+    windowStartMs: NOW - 7 * 86_400_000,
+    windowEndMs: NOW,
+    conversations: { totalTurns: 0, perUser: [], perAudience: [] },
+    mraAsk: {
+      invocations: 0,
+      successes: 0,
+      retries: 0,
+      failures: 0,
+      medianDurationMs: undefined,
+      topRepos: [],
+    },
+    escalate: {
+      triggered: 0,
+      absorbed: 0,
+      pending: 0,
+      medianTimeToReplyMs: undefined,
+    },
+    atoms: {
+      total: 0,
+      approved: 0,
+      pending: 0,
+      retrievalInjections: 0,
+      medianAtomsInjectedPerTurn: undefined,
+      topContributors: [],
+    },
+    flags: [],
+    ...overrides,
+  };
+}
+
+describe("formatDurationMs", () => {
+  it("seconds for sub-minute", () => {
+    assert.equal(formatDurationMs(42_000), "42s");
+    assert.equal(formatDurationMs(900), "1s"); // round up sub-second
+  });
+  it("minutes for sub-hour", () => {
+    assert.equal(formatDurationMs(60_000), "1m");
+    assert.equal(formatDurationMs(83 * 60_000), "1h 23m");
+  });
+  it("hours and minutes for sub-day", () => {
+    assert.equal(formatDurationMs(2 * 60 * 60_000), "2h");
+    assert.equal(formatDurationMs((2 * 60 + 5) * 60_000), "2h 5m");
+  });
+  it("days and hours for >= 24h", () => {
+    assert.equal(formatDurationMs(28 * 60 * 60_000), "1d 4h");
+  });
+  it("undefined renders as a dash", () => {
+    assert.equal(formatDurationMs(undefined), "—");
+  });
+});
+
+describe("formatAuditReport", () => {
+  it("renders the empty case with all zero counts and no flags", () => {
+    const out = stripAnsi(formatAuditReport(emptyReport()));
+    assert.match(out, /pmk gateway audit \(last 7 days\)/);
+    assert.match(out, /total turns:\s+0/);
+    assert.match(out, /invocations:\s+0/);
+    assert.match(out, /total:\s+0 \(0 approved, 0 pending\)/);
+    assert.doesNotMatch(out, /flags/i);
+  });
+
+  it("renders per-user / per-audience breakdowns and clips long per-user lists", () => {
+    const report = emptyReport({
+      conversations: {
+        totalTurns: 247,
+        perUser: [
+          { userId: "U0X", turns: 89 },
+          { userId: "U0Y", turns: 41 },
+          { userId: "U0Z", turns: 38 },
+          { userId: "U0A", turns: 30 },
+          { userId: "U0B", turns: 25 },
+          { userId: "U0C", turns: 24 },
+        ],
+        perAudience: [
+          { audience: "tech", turns: 142 },
+          { audience: "biz", turns: 79 },
+          { audience: "exec", turns: 26 },
+        ],
+      },
+    });
+    const out = stripAnsi(formatAuditReport(report));
+    assert.match(out, /total turns:\s+247/);
+    assert.match(out, /U0X 89/);
+    assert.match(out, /U0Y 41/);
+    assert.match(out, /U0Z 38/);
+    // 4th+ users collapsed: ×3 = 79
+    assert.match(out, /U_OTHER ×3 = 79/);
+    assert.match(out, /tech 142/);
+  });
+
+  it("renders mra-ask with percentage of turns and median duration", () => {
+    const report = emptyReport({
+      conversations: {
+        totalTurns: 100,
+        perUser: [{ userId: "U", turns: 100 }],
+        perAudience: [{ audience: "tech", turns: 100 }],
+      },
+      mraAsk: {
+        invocations: 25,
+        successes: 22,
+        retries: 2,
+        failures: 1,
+        medianDurationMs: 42_000,
+        topRepos: [
+          { repo: "erp", count: 20 },
+          { repo: "oss-ui-v2", count: 5 },
+        ],
+      },
+    });
+    const out = stripAnsi(formatAuditReport(report));
+    assert.match(out, /invocations:\s+25 \(25\.0% of turns\)/);
+    assert.match(out, /successes \/ retries \/ fails:\s+22 \/ 2 \/ 1/);
+    assert.match(out, /median duration:\s+42s/);
+    assert.match(out, /erp ×20.*oss-ui-v2 ×5/);
+  });
+
+  it("renders escalate with paired time-to-reply and pending count", () => {
+    const report = emptyReport({
+      escalate: {
+        triggered: 8,
+        absorbed: 6,
+        pending: 2,
+        medianTimeToReplyMs: 83 * 60_000,
+      },
+    });
+    const out = stripAnsi(formatAuditReport(report));
+    assert.match(out, /triggered:\s+8/);
+    assert.match(out, /absorbed \(atom landed\):\s+6/);
+    assert.match(out, /pending \(no reply yet\):\s+2/);
+    assert.match(out, /median time-to-IT-reply:\s+1h 23m/);
+  });
+
+  it("renders atoms with retrieval injection rate and top contributors", () => {
+    const report = emptyReport({
+      conversations: {
+        totalTurns: 247,
+        perUser: [{ userId: "U", turns: 247 }],
+        perAudience: [{ audience: "tech", turns: 247 }],
+      },
+      atoms: {
+        total: 42,
+        approved: 38,
+        pending: 4,
+        retrievalInjections: 61,
+        medianAtomsInjectedPerTurn: 1.3,
+        topContributors: [
+          { userId: "U_IT1", count: 11 },
+          { userId: "U_IT2", count: 8 },
+          { userId: "U_IT3", count: 5 },
+        ],
+      },
+    });
+    const out = stripAnsi(formatAuditReport(report));
+    assert.match(out, /total:\s+42 \(38 approved, 4 pending\)/);
+    assert.match(out, /retrieval injections:\s+61 \(24\.7% of turns\)/);
+    assert.match(out, /median atoms-injected\/turn:\s+1\.3/);
+    assert.match(out, /U_IT1 ×11.*U_IT2 ×8.*U_IT3 ×5/);
+  });
+
+  it("renders flags section only when there are flags", () => {
+    const report = emptyReport({
+      flags: [
+        "2 atom(s) have been pending > 24h (auto-promote stuck — gateway not restarted?)",
+        "1 escalate(s) with no IT reply for > 48h — consider rejecting marker",
+      ],
+    });
+    const out = stripAnsi(formatAuditReport(report));
+    assert.match(out, /flags/);
+    assert.match(out, /2 atom\(s\) have been pending > 24h/);
+    assert.match(out, /1 escalate\(s\) with no IT reply for > 48h/);
+  });
+});
+
+/**
+ * Strip ANSI colour codes so assertions don't have to care about
+ * chalk's wrapping bytes when running in a colour-capable terminal.
+ */
+function stripAnsi(s: string): string {
+  return s.replace(/\[[0-9;]*m/g, "");
+}

--- a/packages/cli/test/gateway-audit-format.test.ts
+++ b/packages/cli/test/gateway-audit-format.test.ts
@@ -165,7 +165,7 @@ describe("formatAuditReport", () => {
     });
     const out = stripAnsi(formatAuditReport(report));
     assert.match(out, /total:\s+42 \(38 approved, 4 pending\)/);
-    assert.match(out, /retrieval injections:\s+61 \(24\.7% of turns\)/);
+    assert.match(out, /retrieval injections:\s+61 \(0\.25 atoms\/turn\)/);
     assert.match(out, /median atoms-injected\/turn:\s+1\.3/);
     assert.match(out, /U_IT1 ×11.*U_IT2 ×8.*U_IT3 ×5/);
   });

--- a/packages/cli/test/gateway-audit.test.ts
+++ b/packages/cli/test/gateway-audit.test.ts
@@ -241,6 +241,41 @@ describe("gateway audit aggregator (#24)", () => {
     );
   });
 
+  it("re-triggered same thread: absorption pairs FIFO with the oldest unmatched trigger", async () => {
+    // Same Slack thread escalated twice (first round ignored, user
+    // re-asks, pmk re-escalates), then absorbed once. The absorption
+    // should pair with the FIRST trigger so median time-to-reply
+    // reflects "from when the original question was asked".
+    const t1 = new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString(); // 4h ago
+    const t2 = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(); // 1h ago
+    const t3 = new Date().toISOString(); // now
+    seedEvent(tmpHome, t1, {
+      type: "escalate.triggered",
+      channelId: "C0X",
+      threadTs: "999.0",
+    });
+    seedEvent(tmpHome, t2, {
+      type: "escalate.triggered",
+      channelId: "C0X",
+      threadTs: "999.0",
+    });
+    seedEvent(tmpHome, t3, {
+      type: "escalate.absorbed",
+      channelId: "C0X",
+      threadTs: "999.0",
+      atomId: "atom-x",
+    });
+    const { buildAuditReport } = await import("../src/gateway/audit");
+    const r = buildAuditReport({ days: 7 });
+    assert.equal(r.escalate.triggered, 2);
+    assert.equal(r.escalate.absorbed, 1);
+    assert.ok(
+      r.escalate.medianTimeToReplyMs !== undefined &&
+        r.escalate.medianTimeToReplyMs >= 3.5 * 60 * 60 * 1000,
+      `expected pairing with t1 (~4h), got ${r.escalate.medianTimeToReplyMs}ms`,
+    );
+  });
+
   it("counts atoms by status and surfaces top contributors (lifetime, not window)", async () => {
     const now = Date.now();
     // 3 approved by U_IT1, 2 approved by U_IT2, 1 pending by U_IT3
@@ -348,6 +383,32 @@ describe("gateway audit aggregator (#24)", () => {
     assert.equal(r.conversations.totalTurns, 4);
     assert.equal(r.atoms.retrievalInjections, 6);
     assert.equal(r.atoms.medianAtomsInjectedPerTurn, 2);
+  });
+
+  it("does not auto-promote TTL-expired pending atoms (audit is read-only)", async () => {
+    // Pending atom whose expiresAt is already in the past. Without
+    // {promote: false} loadAtoms would silently rewrite it to
+    // approved at the moment of audit. The on-disk file must remain
+    // pending after running the audit.
+    const now = Date.now();
+    seedAtom(tmpHome, "erp", "expired", {
+      id: "expired",
+      createdAt: now - 30 * 60 * 60 * 1000,
+      scope: "erp",
+      question: "expired",
+      tags: [],
+      status: "pending",
+      expiresAt: now - 60 * 60 * 1000, // TTL passed an hour ago
+      source: { threadKey: "C:1", contributorUserId: "U_IT" },
+    });
+    const { buildAuditReport } = await import("../src/gateway/audit");
+    const r = buildAuditReport({ days: 7 });
+    assert.equal(r.atoms.pending, 1, "still pending in the report");
+    assert.equal(r.atoms.approved, 0);
+    // Verify the file on disk wasn't rewritten by the audit.
+    const file = path.join(tmpHome, ".pmk/knowledge/erp/expired.md");
+    const raw = fs.readFileSync(file, "utf8");
+    assert.match(raw, /status: pending/);
   });
 
   it("flags pending atoms older than 24h and pending escalations older than 48h", async () => {

--- a/packages/cli/test/gateway-audit.test.ts
+++ b/packages/cli/test/gateway-audit.test.ts
@@ -1,0 +1,392 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const ORIG_HOME = process.env.HOME;
+
+function seedEvent(homeDir: string, atIso: string, payload: object): void {
+  const dir = path.join(homeDir, ".pmk", "gateway");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.appendFileSync(
+    path.join(dir, "events.log"),
+    JSON.stringify({ at: atIso, ...payload }) + "\n",
+    "utf8",
+  );
+}
+
+function seedAtom(
+  homeDir: string,
+  scope: string,
+  slug: string,
+  frontMatter: Record<string, unknown>,
+  body = "answer body",
+): void {
+  const dir = path.join(homeDir, ".pmk", "knowledge", scope);
+  fs.mkdirSync(dir, { recursive: true });
+  const fm = Object.entries(frontMatter)
+    .map(([k, v]) => `${k}: ${typeof v === "string" ? v : JSON.stringify(v)}`)
+    .join("\n");
+  fs.writeFileSync(
+    path.join(dir, `${slug}.md`),
+    `---\n${fm}\n---\n\n${body}\n`,
+    "utf8",
+  );
+}
+
+function seedEscalation(
+  homeDir: string,
+  channelId: string,
+  threadTs: string,
+  pendingSinceMs: number,
+): void {
+  const dir = path.join(homeDir, ".pmk", "gateway", "slack", "escalations");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, `${channelId}__${threadTs}.json`),
+    JSON.stringify({
+      channelId,
+      threadTs,
+      question: "q",
+      pendingSince: pendingSinceMs,
+      mentionedUserIds: [],
+    }),
+    "utf8",
+  );
+}
+
+describe("gateway audit aggregator (#24)", () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-gw-audit-"));
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+  });
+
+  it("returns an empty-ish report when nothing has been recorded", async () => {
+    const { buildAuditReport } = await import("../src/gateway/audit");
+    const report = buildAuditReport({ days: 7 });
+    assert.equal(report.windowDays, 7);
+    assert.equal(report.conversations.totalTurns, 0);
+    assert.equal(report.conversations.perUser.length, 0);
+    assert.equal(report.conversations.perAudience.length, 0);
+    assert.equal(report.mraAsk.invocations, 0);
+    assert.equal(report.escalate.triggered, 0);
+    assert.equal(report.escalate.pending, 0);
+    assert.equal(report.atoms.total, 0);
+    assert.deepEqual(report.flags, []);
+  });
+
+  it("counts turns per user and per audience from turn.processed events", async () => {
+    const recent = new Date().toISOString();
+    seedEvent(tmpHome, recent, {
+      type: "turn.processed",
+      actor: "U_A",
+      audience: "tech",
+      hadMraAsk: false,
+      atomsInjected: 0,
+    });
+    seedEvent(tmpHome, recent, {
+      type: "turn.processed",
+      actor: "U_A",
+      audience: "tech",
+      hadMraAsk: false,
+      atomsInjected: 1,
+    });
+    seedEvent(tmpHome, recent, {
+      type: "turn.processed",
+      actor: "U_B",
+      audience: "biz",
+      hadMraAsk: false,
+      atomsInjected: 0,
+    });
+    const { buildAuditReport } = await import("../src/gateway/audit");
+    const r = buildAuditReport({ days: 7 });
+    assert.equal(r.conversations.totalTurns, 3);
+    // perUser sorted by count desc
+    assert.deepEqual(r.conversations.perUser, [
+      { userId: "U_A", turns: 2 },
+      { userId: "U_B", turns: 1 },
+    ]);
+    assert.deepEqual(r.conversations.perAudience, [
+      { audience: "tech", turns: 2 },
+      { audience: "biz", turns: 1 },
+    ]);
+    // retrieval injections come from atomsInjected
+    assert.equal(r.atoms.retrievalInjections, 1);
+  });
+
+  it("excludes events older than the window", async () => {
+    const recent = new Date().toISOString();
+    const old = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    seedEvent(tmpHome, old, {
+      type: "turn.processed",
+      actor: "U_OLD",
+      audience: "tech",
+      hadMraAsk: false,
+      atomsInjected: 5,
+    });
+    seedEvent(tmpHome, recent, {
+      type: "turn.processed",
+      actor: "U_NEW",
+      audience: "tech",
+      hadMraAsk: false,
+      atomsInjected: 0,
+    });
+    const { buildAuditReport } = await import("../src/gateway/audit");
+    const r = buildAuditReport({ days: 7 });
+    assert.equal(r.conversations.totalTurns, 1);
+    assert.equal(
+      r.conversations.perUser[0].userId,
+      "U_NEW",
+      "old user should be excluded",
+    );
+    assert.equal(r.atoms.retrievalInjections, 0, "old injections excluded");
+  });
+
+  it("classifies mra-ask outcomes: success / retry-then-success / failure", async () => {
+    const at = new Date().toISOString();
+    // 2 clean successes
+    seedEvent(tmpHome, at, {
+      type: "mra-ask.end",
+      actor: "U_A",
+      repo: "erp",
+      ok: true,
+      retried: false,
+      durationMs: 30_000,
+    });
+    seedEvent(tmpHome, at, {
+      type: "mra-ask.end",
+      actor: "U_A",
+      repo: "erp",
+      ok: true,
+      retried: false,
+      durationMs: 50_000,
+    });
+    // 1 retried success
+    seedEvent(tmpHome, at, {
+      type: "mra-ask.end",
+      actor: "U_B",
+      repo: "oss-ui-v2",
+      ok: true,
+      retried: true,
+      durationMs: 90_000,
+    });
+    // 1 failure
+    seedEvent(tmpHome, at, {
+      type: "mra-ask.end",
+      actor: "U_B",
+      repo: "erp",
+      ok: false,
+      retried: true,
+      durationMs: 70_000,
+    });
+    const { buildAuditReport } = await import("../src/gateway/audit");
+    const r = buildAuditReport({ days: 7 });
+    assert.equal(r.mraAsk.invocations, 4);
+    assert.equal(r.mraAsk.successes, 2);
+    assert.equal(r.mraAsk.retries, 1);
+    assert.equal(r.mraAsk.failures, 1);
+    assert.equal(
+      r.mraAsk.medianDurationMs,
+      60_000,
+      "median of [30k, 50k, 70k, 90k] is (50k+70k)/2 = 60k",
+    );
+    // topRepos sorted desc, ties stable
+    assert.deepEqual(r.mraAsk.topRepos, [
+      { repo: "erp", count: 3 },
+      { repo: "oss-ui-v2", count: 1 },
+    ]);
+  });
+
+  it("pairs escalate.triggered with escalate.absorbed by (channelId, threadTs) for time-to-reply", async () => {
+    const triggeredAt = new Date(Date.now() - 60 * 60 * 1000).toISOString(); // 1h ago
+    const absorbedAt = new Date().toISOString();
+    seedEvent(tmpHome, triggeredAt, {
+      type: "escalate.triggered",
+      channelId: "C0X",
+      threadTs: "100.0",
+      scope: "erp",
+    });
+    seedEvent(tmpHome, absorbedAt, {
+      type: "escalate.absorbed",
+      channelId: "C0X",
+      threadTs: "100.0",
+      atomId: "atom-1",
+    });
+    // an unmatched trigger (no absorb yet)
+    seedEvent(tmpHome, new Date().toISOString(), {
+      type: "escalate.triggered",
+      channelId: "C0X",
+      threadTs: "200.0",
+    });
+    // pending marker on disk
+    seedEscalation(tmpHome, "C0X", "200.0", Date.now());
+    const { buildAuditReport } = await import("../src/gateway/audit");
+    const r = buildAuditReport({ days: 7 });
+    assert.equal(r.escalate.triggered, 2);
+    assert.equal(r.escalate.absorbed, 1);
+    assert.equal(r.escalate.pending, 1);
+    assert.ok(
+      r.escalate.medianTimeToReplyMs !== undefined &&
+        r.escalate.medianTimeToReplyMs >= 50 * 60 * 1000 &&
+        r.escalate.medianTimeToReplyMs <= 70 * 60 * 1000,
+      `expected ~1h, got ${r.escalate.medianTimeToReplyMs}`,
+    );
+  });
+
+  it("counts atoms by status and surfaces top contributors (lifetime, not window)", async () => {
+    const now = Date.now();
+    // 3 approved by U_IT1, 2 approved by U_IT2, 1 pending by U_IT3
+    seedAtom(tmpHome, "erp", "q1", {
+      id: "a1",
+      createdAt: now - 5_000,
+      scope: "erp",
+      question: "q1",
+      tags: [],
+      status: "approved",
+      source: { threadKey: "C:1", contributorUserId: "U_IT1" },
+    });
+    seedAtom(tmpHome, "erp", "q2", {
+      id: "a2",
+      createdAt: now - 4_000,
+      scope: "erp",
+      question: "q2",
+      tags: [],
+      status: "approved",
+      source: { threadKey: "C:2", contributorUserId: "U_IT1" },
+    });
+    seedAtom(tmpHome, "erp", "q3", {
+      id: "a3",
+      createdAt: now - 3_000,
+      scope: "erp",
+      question: "q3",
+      tags: [],
+      status: "approved",
+      source: { threadKey: "C:3", contributorUserId: "U_IT1" },
+    });
+    seedAtom(tmpHome, "general", "q4", {
+      id: "a4",
+      createdAt: now - 2_000,
+      scope: "general",
+      question: "q4",
+      tags: [],
+      status: "approved",
+      source: { threadKey: "C:4", contributorUserId: "U_IT2" },
+    });
+    seedAtom(tmpHome, "general", "q5", {
+      id: "a5",
+      createdAt: now - 1_000,
+      scope: "general",
+      question: "q5",
+      tags: [],
+      status: "approved",
+      source: { threadKey: "C:5", contributorUserId: "U_IT2" },
+    });
+    seedAtom(tmpHome, "erp", "q6", {
+      id: "a6",
+      createdAt: now,
+      scope: "erp",
+      question: "q6",
+      tags: [],
+      status: "pending",
+      expiresAt: now + 24 * 60 * 60 * 1000,
+      source: { threadKey: "C:6", contributorUserId: "U_IT3" },
+    });
+    const { buildAuditReport } = await import("../src/gateway/audit");
+    const r = buildAuditReport({ days: 7 });
+    assert.equal(r.atoms.total, 6);
+    assert.equal(r.atoms.approved, 5);
+    assert.equal(r.atoms.pending, 1);
+    assert.deepEqual(r.atoms.topContributors, [
+      { userId: "U_IT1", count: 3 },
+      { userId: "U_IT2", count: 2 },
+      { userId: "U_IT3", count: 1 },
+    ]);
+  });
+
+  it("median atoms-injected per turn ignores zero-injection turns when computing the rate, but reports it as undefined when no injections happened", async () => {
+    const at = new Date().toISOString();
+    // turns with injections: 1, 2, 3
+    seedEvent(tmpHome, at, {
+      type: "turn.processed",
+      actor: "U",
+      audience: "tech",
+      hadMraAsk: false,
+      atomsInjected: 1,
+    });
+    seedEvent(tmpHome, at, {
+      type: "turn.processed",
+      actor: "U",
+      audience: "tech",
+      hadMraAsk: false,
+      atomsInjected: 2,
+    });
+    seedEvent(tmpHome, at, {
+      type: "turn.processed",
+      actor: "U",
+      audience: "tech",
+      hadMraAsk: false,
+      atomsInjected: 3,
+    });
+    // a no-injection turn — counts toward totalTurns but excluded from median
+    seedEvent(tmpHome, at, {
+      type: "turn.processed",
+      actor: "U",
+      audience: "tech",
+      hadMraAsk: false,
+      atomsInjected: 0,
+    });
+    const { buildAuditReport } = await import("../src/gateway/audit");
+    const r = buildAuditReport({ days: 7 });
+    assert.equal(r.conversations.totalTurns, 4);
+    assert.equal(r.atoms.retrievalInjections, 6);
+    assert.equal(r.atoms.medianAtomsInjectedPerTurn, 2);
+  });
+
+  it("flags pending atoms older than 24h and pending escalations older than 48h", async () => {
+    const now = Date.now();
+    // pending atom created > 24h ago, expiresAt also passed but loadAtoms
+    // would have promoted it. To exercise the flag path we need a
+    // pending-and-still-pending state — simulate the bug by writing a
+    // pending atom with expiresAt > now (auto-promote hasn't fired yet)
+    // but createdAt > 24h ago, which means the gateway should have
+    // restarted by now.
+    seedAtom(tmpHome, "erp", "stuck", {
+      id: "stuck",
+      createdAt: now - 30 * 60 * 60 * 1000, // 30h ago
+      scope: "erp",
+      question: "stuck",
+      tags: [],
+      status: "pending",
+      expiresAt: now + 60 * 60 * 1000, // still pending in the future
+      source: { threadKey: "C:1", contributorUserId: "U_IT" },
+    });
+    // pending escalation > 48h
+    seedEscalation(tmpHome, "C0X", "999.0", now - 50 * 60 * 60 * 1000);
+    const { buildAuditReport } = await import("../src/gateway/audit");
+    const r = buildAuditReport({ days: 7 });
+    assert.ok(
+      r.flags.some((f) => /atom/i.test(f) && /24h/.test(f)),
+      `expected an atom-stuck flag, got: ${JSON.stringify(r.flags)}`,
+    );
+    assert.ok(
+      r.flags.some((f) => /escalate/i.test(f) && /48h/.test(f)),
+      `expected an escalate-stale flag, got: ${JSON.stringify(r.flags)}`,
+    );
+  });
+
+  it("days option must be a positive integer; bad input falls back to 7", async () => {
+    const { buildAuditReport } = await import("../src/gateway/audit");
+    assert.equal(buildAuditReport({ days: 0 }).windowDays, 7);
+    assert.equal(buildAuditReport({ days: -3 }).windowDays, 7);
+    assert.equal(buildAuditReport({ days: NaN }).windowDays, 7);
+    assert.equal(buildAuditReport({ days: 14 }).windowDays, 14);
+  });
+});

--- a/packages/cli/test/gateway-events.test.ts
+++ b/packages/cli/test/gateway-events.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const ORIG_HOME = process.env.HOME;
+
+describe("gateway events log (#24)", () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-gw-events-"));
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+  });
+
+  it("appendGatewayEvent → readGatewayEvents round-trips a turn.processed event", async () => {
+    const { appendGatewayEvent, readGatewayEvents } =
+      await import("../src/gateway/events");
+    appendGatewayEvent({
+      type: "turn.processed",
+      actor: "U_X",
+      audience: "tech",
+      hadMraAsk: false,
+      atomsInjected: 0,
+    });
+    const entries = readGatewayEvents();
+    assert.equal(entries.length, 1);
+    const e = entries[0];
+    assert.equal(e.type, "turn.processed");
+    if (e.type === "turn.processed") {
+      assert.equal(e.actor, "U_X");
+      assert.equal(e.audience, "tech");
+      assert.equal(e.atomsInjected, 0);
+    }
+    assert.ok(typeof e.at === "string" && e.at.length > 0);
+  });
+
+  it("supports all four event types via the discriminated union", async () => {
+    const { appendGatewayEvent, readGatewayEvents } =
+      await import("../src/gateway/events");
+    appendGatewayEvent({
+      type: "mra-ask.end",
+      actor: "U_X",
+      repo: "erp",
+      ok: true,
+      retried: false,
+      durationMs: 42_000,
+    });
+    appendGatewayEvent({
+      type: "turn.processed",
+      actor: "U_X",
+      audience: "biz",
+      hadMraAsk: true,
+      atomsInjected: 2,
+    });
+    appendGatewayEvent({
+      type: "escalate.triggered",
+      channelId: "C0X",
+      threadTs: "1234.5678",
+      scope: "erp",
+    });
+    appendGatewayEvent({
+      type: "escalate.absorbed",
+      channelId: "C0X",
+      threadTs: "1234.5678",
+      atomId: "atom-abc",
+    });
+    const entries = readGatewayEvents();
+    assert.equal(entries.length, 4);
+    assert.deepEqual(
+      entries.map((e) => e.type),
+      [
+        "mra-ask.end",
+        "turn.processed",
+        "escalate.triggered",
+        "escalate.absorbed",
+      ],
+    );
+  });
+
+  it("readGatewayEvents returns [] when file missing", async () => {
+    const { readGatewayEvents } = await import("../src/gateway/events");
+    assert.deepEqual(readGatewayEvents(), []);
+  });
+
+  it("malformed lines are skipped, well-formed lines still parse", async () => {
+    const { appendGatewayEvent, readGatewayEvents, gatewayEventsPath } =
+      await import("../src/gateway/events");
+    appendGatewayEvent({
+      type: "turn.processed",
+      actor: "U_A",
+      audience: "tech",
+      hadMraAsk: false,
+      atomsInjected: 0,
+    });
+    fs.appendFileSync(gatewayEventsPath(), "not json at all\n");
+    appendGatewayEvent({
+      type: "turn.processed",
+      actor: "U_B",
+      audience: "pm",
+      hadMraAsk: false,
+      atomsInjected: 0,
+    });
+    const entries = readGatewayEvents();
+    assert.equal(entries.length, 2);
+    assert.equal(
+      entries[0].type === "turn.processed" && entries[0].actor,
+      "U_A",
+    );
+    assert.equal(
+      entries[1].type === "turn.processed" && entries[1].actor,
+      "U_B",
+    );
+  });
+
+  it("readGatewayEvents filters by sinceMs (inclusive)", async () => {
+    const { appendGatewayEvent, readGatewayEvents, gatewayEventsPath } =
+      await import("../src/gateway/events");
+    // Write events with explicit `at` timestamps by writing raw lines.
+    const old = JSON.stringify({
+      at: "2026-04-20T00:00:00.000Z",
+      type: "turn.processed",
+      actor: "U_OLD",
+      audience: "tech",
+      hadMraAsk: false,
+      atomsInjected: 0,
+    });
+    const recent = JSON.stringify({
+      at: "2026-04-29T00:00:00.000Z",
+      type: "turn.processed",
+      actor: "U_NEW",
+      audience: "tech",
+      hadMraAsk: false,
+      atomsInjected: 0,
+    });
+    fs.mkdirSync(path.dirname(gatewayEventsPath()), { recursive: true });
+    fs.writeFileSync(gatewayEventsPath(), `${old}\n${recent}\n`, "utf8");
+
+    const cutoff = Date.parse("2026-04-25T00:00:00.000Z");
+    const entries = readGatewayEvents({ sinceMs: cutoff });
+    assert.equal(entries.length, 1);
+    assert.equal(
+      entries[0].type === "turn.processed" && entries[0].actor,
+      "U_NEW",
+    );
+    // appendGatewayEvent on top of the seeded file
+    appendGatewayEvent({
+      type: "turn.processed",
+      actor: "U_NOW",
+      audience: "biz",
+      hadMraAsk: false,
+      atomsInjected: 0,
+    });
+    const all = readGatewayEvents();
+    assert.equal(all.length, 3);
+  });
+
+  it("readGatewayEvents tails to limit (newest last)", async () => {
+    const { appendGatewayEvent, readGatewayEvents } =
+      await import("../src/gateway/events");
+    for (let i = 0; i < 30; i++) {
+      appendGatewayEvent({
+        type: "turn.processed",
+        actor: `U_${i}`,
+        audience: "tech",
+        hadMraAsk: false,
+        atomsInjected: 0,
+      });
+    }
+    const tail = readGatewayEvents({ limit: 5 });
+    assert.equal(tail.length, 5);
+    assert.equal(
+      tail[0].type === "turn.processed" && tail[0].actor,
+      "U_25",
+    );
+    assert.equal(
+      tail[4].type === "turn.processed" && tail[4].actor,
+      "U_29",
+    );
+  });
+
+  it("appendGatewayEvent does not throw if the directory is unwritable (best-effort)", async () => {
+    const { appendGatewayEvent } = await import("../src/gateway/events");
+    // Point HOME at a path that contains a regular file where the
+    // gateway dir would go — mkdir will fail. The append must swallow.
+    const blocking = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-block-evt-"));
+    fs.writeFileSync(path.join(blocking, ".pmk"), "not a directory");
+    process.env.HOME = blocking;
+    assert.doesNotThrow(() =>
+      appendGatewayEvent({
+        type: "turn.processed",
+        actor: "U_X",
+        audience: "tech",
+        hadMraAsk: false,
+        atomsInjected: 0,
+      }),
+    );
+    fs.rmSync(blocking, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
Closes #24. First v0.10 milestone item.

## Summary

- New CLI: `pmk gateway audit [--days N]` (default 7, range 1–365) — operator-facing rollup of recent knowledge-loop activity. Per-user / per-audience turn breakdown, mra-ask success/retry/fail split with median duration, escalate triggered/absorbed/pending with median time-to-IT-reply, atom corpus stats with top contributors, plus flags for stuck pending atoms and stale escalations.
- New ledger: `~/.pmk/gateway/events.log` — append-only JSONL for the four event types audit consumes (`turn.processed`, `mra-ask.end`, `escalate.triggered`, `escalate.absorbed`). Mirrors `admin.log` (#31) in shape and contracts.
- Runtime instrumentation in `runFreeChatTurn`, `handleMraAskRound`, `handleEscalation`, `maybeAbsorbEscalationReply` — 4 emission points, no behavioural change to existing flows.

## Design choices worth knowing

- **Audience captured at turn time.** Re-resolving via `pickAudience` at audit time would let later config changes silently rewrite history.
- **Atom stats are lifetime, not window-scoped.** Atoms persist across windows; "total atoms in last 7 days" would mislead operators about corpus size.
- **mra-ask trichotomy:** `successes` = ok && !retried, `retries` = ok && retried, `failures` = !ok. Sum equals invocations.
- **No Slack surface.** Output is wide and operator-level; `/pmk admin audit` already covers admin-action history.
- **Freeform `[pmk-gw]` log is not parsed.** It's prose breadcrumbs; structured ledger is the source of truth for audit.
- **Case-mode channel turns are not instrumented.** Audit's primary target is the knowledge loop, not PM/case workflow.

## Test plan

- [x] `npm --workspace packages/cli run test` → 220/220 (was 193, +27)
- [x] `npm --workspace packages/cli run build` → clean
- [x] Empty-corpus smoke (`HOME=/tmp/empty pmk gateway audit`) renders zeros + `(none)` + `—` placeholders
- [x] Bad-input smoke (`--days abc`, `--days 999` clamped to 365)
- [x] End-to-end smoke with seeded events.log + atoms + escalation marker → all sections numerically correct, 48h-stale escalation flag fires
- [ ] Live verification on a real gateway after a few hours of dogfood — defer to milestone close

## Files

```
apps/docs/docs/changelog.md                    |  14 +
apps/docs/docs/gateway/lifecycle.md            |  46 +++
packages/cli/src/commands/gateway.ts           |  44 ++-
packages/cli/src/gateway/audit-format.ts       | 170 +++++++++++
packages/cli/src/gateway/audit.ts              | 273 +++++++++++++++++
packages/cli/src/gateway/events.ts             | 164 +++++++++++
packages/cli/src/gateway/slack/index.ts        |  35 +++
packages/cli/test/gateway-audit-format.test.ts | 193 ++++++++++++
packages/cli/test/gateway-audit.test.ts        | 392 +++++++++++++++++++++++++
packages/cli/test/gateway-events.test.ts       | 206 +++++++++++++
```

## Out of scope (v0.10.x or later)

- `audit --json` machine-readable output
- Add audience to `UserSession` (currently re-resolved every turn at emission time)
- OTel / Prometheus exporter for events.log
- Instrument case-mode turns