### PR TITLE
feat(gateway): stream mra-ask progress to Slack placeholder (#22)

### DIFF
--- a/apps/docs/docs/changelog.md
+++ b/apps/docs/docs/changelog.md
@@ -16,6 +16,7 @@ Working milestone: [v0.10](https://github.com/hanfour/pm-workspace-kit/milestone
 
 - **`pmk gateway audit [--days N]`** ([#24](https://github.com/hanfour/pm-workspace-kit/issues/24)) — operator-facing rollup of recent knowledge-loop activity: per-user / per-audience turn breakdown, mra-ask success/retry/fail split with median duration, escalate triggered / absorbed / pending counts and median time-to-IT-reply, atom corpus stats with top contributors, plus flags for stuck pending atoms (> 24h) and stale escalations (> 48h). Window defaults to 7 days; `--days` accepts 1–365.
 - **`~/.pmk/gateway/events.log`** — append-only JSONL ledger for the four event types the audit consumes (`turn.processed`, `mra-ask.end`, `escalate.triggered`, `escalate.absorbed`). Mirrors `admin.log` in shape and contracts; tolerant reader skips malformed lines.
+- **Live mra-ask progress in Slack** ([#22](https://github.com/hanfour/pm-workspace-kit/issues/22)) — `runMraAsk` now uses `spawn` instead of `execFile` so each stdout line streams into the placeholder message via a 3-second last-line-wins throttle. The 30–90s mra round shows `[ask] PKB loaded`, `[ask] querying...` etc. tick by instead of a static spinner. `web.chat.update` rate well under Slack Tier 3; trailing fire cancelled on completion so a late progress line can't briefly overwrite the synthesised reply.
 
 ### Notes
 

--- a/apps/docs/docs/gateway/lifecycle.md
+++ b/apps/docs/docs/gateway/lifecycle.md
@@ -108,7 +108,9 @@ question: where is the sales_performances scope defined?
 ```
 ````
 
-The gateway parses this, runs `mra ask <repo> <question>` as a subprocess (120s timeout, retry-once on transient empty-stderr failures since v0.7.3), wraps the stdout in a `mra-result` user message, and re-calls the LLM for synthesis. Failures are surfaced verbatim — stderr appears in the host log AND in the LLM's apology context (since v0.7.2), so the user never sees a mysterious "unknown" error.
+The gateway parses this, runs `mra ask <repo> <question>` as a subprocess (300s timeout since v0.7.5, retry-once on transient empty-stderr failures since v0.7.3), wraps the stdout in a `mra-result` user message, and re-calls the LLM for synthesis. Failures are surfaced verbatim — stderr appears in the host log AND in the LLM's apology context (since v0.7.2), so the user never sees a mysterious "unknown" error.
+
+**Live progress (v0.10).** Since [v0.10](https://github.com/hanfour/pm-workspace-kit/milestone/7) ([#22](https://github.com/hanfour/pm-workspace-kit/issues/22)), the subprocess uses `spawn` instead of `execFile` so the gateway can subscribe to stdout line-by-line. Each non-empty line flows through a 3-second last-line-wins throttle into a `web.chat.update` on the placeholder message. The user sees mra's `[ask] PKB loaded`, `[ask] querying...` markers tick by during the 30–90s round instead of staring at a static spinner. Throttle window is well below Slack's chat.update Tier 3 rate limit (~50 rpm); the trailing fire is cancelled the moment `runMraAsk` returns so a late progress line can't briefly overwrite the final synthesised reply.
 
 ## 7. Escalate directive (optional, falls back from mra-ask)
 

--- a/packages/cli/src/adapters/mra.ts
+++ b/packages/cli/src/adapters/mra.ts
@@ -372,6 +372,11 @@ function runMraAskOnce(
   opts: RunMraAskOpts,
 ): Promise<MraAskResult> {
   return new Promise<MraAskResult>((resolve) => {
+    // Declared before settle so the catch block below can call settle
+    // without tripping a TDZ ReferenceError when spawn throws
+    // synchronously (e.g. NUL byte in binary path). clearTimeout
+    // tolerates undefined per the Node API.
+    let timeoutHandle: NodeJS.Timeout | undefined;
     let settled = false;
     const settle = (r: MraAskResult): void => {
       if (settled) return;
@@ -402,7 +407,7 @@ function runMraAskOnce(
     let lineBuf = "";
     let timedOut = false;
 
-    const timeoutHandle = setTimeout(() => {
+    timeoutHandle = setTimeout(() => {
       timedOut = true;
       try {
         child.kill("SIGTERM");
@@ -413,6 +418,12 @@ function runMraAskOnce(
 
     child.stdout?.setEncoding("utf8");
     child.stdout?.on("data", (chunk: string) => {
+      // TODO(v0.10.x): cap stdoutBuf at a soft max (e.g. 10 MiB —
+      // matching the old execFile maxBuffer) to prevent runaway mra
+      // outputs from pressuring host memory and turning string
+      // concatenation into O(n²). Most mra runs are KB-scale so this
+      // is observational risk, not a current incident. Same lift
+      // could switch to chunks.push(chunk) + join at close.
       stdoutBuf += chunk;
       lineBuf += chunk;
       let idx: number;

--- a/packages/cli/src/adapters/mra.ts
+++ b/packages/cli/src/adapters/mra.ts
@@ -15,7 +15,7 @@
  *     the proxy for "install looks healthy".
  */
 
-import { execFile, execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -262,6 +262,16 @@ interface RunMraAskOpts {
   maxRetries?: number;
   /** Optional progress callback fired before each retry. */
   onRetry?: (attempt: number, prevResult: MraAskResult) => void;
+  /**
+   * Optional per-line stdout callback (v0.10 / #22). Fired for each
+   * non-empty line as soon as it crosses the newline boundary —
+   * caller is responsible for any throttling. Not fired for stderr.
+   * `\r` is stripped; partial trailing lines (no terminating newline)
+   * are not surfaced via this callback but DO appear in
+   * {@link MraAskResult.stdout}. Errors thrown by the callback are
+   * swallowed so a sink failure can't tear down the subprocess read.
+   */
+  onProgress?: (line: string) => void;
 }
 
 /**
@@ -300,6 +310,24 @@ export async function runMraAsk(
       attempts: 1,
     };
   }
+  return runMraAskWithBinary(binary, args, opts);
+}
+
+/**
+ * Inner half of {@link runMraAsk} that takes an explicit binary path.
+ * Exposed for testing — production callers should use runMraAsk so
+ * the PATH probe and fallback list run the same way for everyone.
+ */
+export async function runMraAskWithBinary(
+  binary: string,
+  args: {
+    repo: string;
+    question: string;
+    cwd: string;
+    timeoutMs?: number;
+  },
+  opts: RunMraAskOpts = {},
+): Promise<MraAskResult> {
   const maxRetries = opts.maxRetries ?? 1;
   // 300s default — bumped from 120s in v0.7.5. Live dogfood (2026-04-28)
   // showed a complex multi-clause CJK question took 160s of mra-internal
@@ -308,7 +336,7 @@ export async function runMraAsk(
   const timeoutMs = args.timeoutMs ?? 300_000;
   let last: MraAskResult | undefined;
   for (let attempt = 1; attempt <= maxRetries + 1; attempt++) {
-    const result = await runMraAskOnce(binary, args, timeoutMs);
+    const result = await runMraAskOnce(binary, args, timeoutMs, opts);
     if (result.ok || !looksTransient(result) || attempt > maxRetries) {
       return { ...result, attempts: attempt };
     }
@@ -319,64 +347,124 @@ export async function runMraAsk(
   return { ...(last as MraAskResult), attempts: maxRetries + 1 };
 }
 
+/**
+ * One subprocess invocation. Switched from `execFile` (buffered) to
+ * `spawn` in v0.10 (#22) so callers can subscribe to a per-line
+ * progress callback without losing the buffered stdout/stderr they
+ * already depended on. Behaviour preservation:
+ *
+ *   - full stdout / stderr concatenated and returned
+ *   - timeout via SIGTERM kill (matches execFile.killSignal default)
+ *   - timeout-vs-error classification via {@link isTimeoutKill}
+ *   - 'error' event resolves as a non-ok result with the error message
+ *
+ * Stdout is line-buffered: we accumulate chunks until we see `\n`,
+ * then deliver complete lines (with `\r` stripped) to onProgress.
+ * The trailing partial line at process exit is part of `result.stdout`
+ * but is not surfaced via onProgress — most mra runs end with a
+ * newline anyway, and a partial-line "progress" update is rarely
+ * meaningful UX.
+ */
 function runMraAskOnce(
   binary: string,
   args: { repo: string; question: string; cwd: string },
   timeoutMs: number,
+  opts: RunMraAskOpts,
 ): Promise<MraAskResult> {
   return new Promise<MraAskResult>((resolve) => {
-    const child = execFile(
-      binary,
-      ["ask", args.repo, args.question],
-      {
+    let settled = false;
+    const settle = (r: MraAskResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutHandle);
+      resolve(r);
+    };
+
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(binary, ["ask", args.repo, args.question], {
         cwd: args.cwd,
-        timeout: timeoutMs,
-        maxBuffer: 10 * 1024 * 1024, // 10 MiB
-        encoding: "utf8",
-      },
-      (err, stdout, stderr) => {
-        if (err) {
-          // execFile's timeout sends SIGTERM (the configured killSignal,
-          // which defaults to SIGTERM). Node populates `err.killed` and
-          // `err.signal` on the resulting error. The earlier
-          // `code === "ETIMEDOUT"` check basically never fired — Node's
-          // signaled-kill path sets `code: null`, so timeouts were
-          // mis-classified as "Command failed" generic errors and
-          // (worse) looksTransient would retry them. Detecting via
-          // `killed`/`signal` is what the docs actually describe.
-          const errAny = err as NodeJS.ErrnoException & {
-            killed?: boolean;
-            signal?: string;
-          };
-          const isTimeout =
-            errAny.killed === true ||
-            errAny.signal === "SIGTERM" ||
-            errAny.code === "ETIMEDOUT";
-          resolve({
-            ok: false,
-            stdout: String(stdout ?? ""),
-            stderr: String(stderr ?? ""),
-            reason: isTimeout
-              ? `mra ask timed out after ${timeoutMs}ms`
-              : err.message,
-            attempts: 1,
-          });
-          return;
-        }
-        resolve({
-          ok: true,
-          stdout: String(stdout ?? ""),
-          stderr: String(stderr ?? ""),
-          attempts: 1,
-        });
-      },
-    );
-    child.on("error", (err) => {
-      resolve({
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (err) {
+      settle({
         ok: false,
         stdout: "",
         stderr: "",
+        reason: (err as Error).message,
+        attempts: 1,
+      });
+      return;
+    }
+
+    let stdoutBuf = "";
+    let stderrBuf = "";
+    let lineBuf = "";
+    let timedOut = false;
+
+    const timeoutHandle = setTimeout(() => {
+      timedOut = true;
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* already gone */
+      }
+    }, timeoutMs);
+
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdoutBuf += chunk;
+      lineBuf += chunk;
+      let idx: number;
+      while ((idx = lineBuf.indexOf("\n")) >= 0) {
+        const raw = lineBuf.slice(0, idx);
+        lineBuf = lineBuf.slice(idx + 1);
+        const line = raw.endsWith("\r") ? raw.slice(0, -1) : raw;
+        if (line.length === 0) continue;
+        try {
+          opts.onProgress?.(line);
+        } catch {
+          /* sink failures must not tear down stdout reading */
+        }
+      }
+    });
+
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderrBuf += chunk;
+    });
+
+    child.on("error", (err) => {
+      settle({
+        ok: false,
+        stdout: stdoutBuf,
+        stderr: stderrBuf,
         reason: err.message,
+        attempts: 1,
+      });
+    });
+
+    child.on("close", (code, signal) => {
+      const ok = !timedOut && code === 0;
+      if (ok) {
+        settle({
+          ok: true,
+          stdout: stdoutBuf,
+          stderr: stderrBuf,
+          attempts: 1,
+        });
+        return;
+      }
+      const reason = timedOut
+        ? `mra ask timed out after ${timeoutMs}ms`
+        : `mra ask exited with code=${code ?? "null"}${
+            signal ? ` signal=${signal}` : ""
+          }${stderrBuf.trim() ? `: ${stderrBuf.trim().split("\n").pop()}` : ""}`;
+      settle({
+        ok: false,
+        stdout: stdoutBuf,
+        stderr: stderrBuf,
+        reason,
         attempts: 1,
       });
     });

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -975,7 +975,12 @@ export class SlackAdapter {
     const progressThrottle = createLastLineThrottle({
       windowMs: 3000,
       onFire: (line) => {
-        const safe = line.replace(/[`*_]/g, "").slice(0, 200);
+        // Strip Slack mrkdwn metacharacters so a stray `<@U123>` /
+        // `<https://...|x>` / `<!channel>` from mra output doesn't
+        // render as an actual mention or link in the placeholder.
+        // ` * _ also get the same treatment to prevent surprise
+        // bold/italic/code formatting from a chatty progress line.
+        const safe = line.replace(/[`*_<>]/g, "").slice(0, 200);
         void this.web.chat
           .update({
             channel: channelId,

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -47,6 +47,7 @@ import {
 } from "../../case";
 import { mraDoctor, runMraAsk } from "../../adapters/mra";
 import { appendGatewayEvent } from "../events";
+import { createLastLineThrottle } from "../throttle";
 import { parseMraAsk, stripMraAskBlock } from "../mra-ask";
 import {
   buildIngestSeed,
@@ -958,13 +959,35 @@ export class SlackAdapter {
       });
     }
 
+    const baseProgress = `:mag: 正在用 mra 查 \`${request.repo}\` 的 code…（最多 5 分鐘）`;
     await this.web.chat
       .update({
         channel: channelId,
         ts: placeholderTs,
-        text: `:mag: 正在用 mra 查 \`${request.repo}\` 的 code…（最多 5 分鐘）`,
+        text: baseProgress,
       })
       .catch(() => {});
+
+    // v0.10 (#22): drip-feed mra's stdout into the placeholder so the
+    // user sees movement during the 30–90s round. 3s coalescing
+    // window keeps us well under Slack's chat.update rate limit
+    // (Tier 3, ~50 rpm) even when mra is chatty.
+    const progressThrottle = createLastLineThrottle({
+      windowMs: 3000,
+      onFire: (line) => {
+        const safe = line.replace(/[`*_]/g, "").slice(0, 200);
+        void this.web.chat
+          .update({
+            channel: channelId,
+            ts: placeholderTs,
+            text: `${baseProgress}\n> ${safe}`,
+          })
+          .catch(() => {
+            /* progress updates are best-effort; the final synthesis
+               update will overwrite anyway */
+          });
+      },
+    });
 
     this.onLog(
       `mra ask repo=${request.repo} q=${truncate(request.question, 120)}`,
@@ -982,8 +1005,10 @@ export class SlackAdapter {
             `mra ask attempt ${attempt} failed without stderr; retrying once`,
           );
         },
+        onProgress: (line) => progressThrottle.push(line),
       },
     );
+    progressThrottle.cancel();
     appendGatewayEvent({
       type: "mra-ask.end",
       actor,

--- a/packages/cli/src/gateway/throttle.ts
+++ b/packages/cli/src/gateway/throttle.ts
@@ -1,0 +1,85 @@
+/**
+ * Last-line-wins throttle (v0.10 / #22).
+ *
+ * Used by the Slack adapter to drip-feed `mra ask` progress lines into
+ * a placeholder message via `web.chat.update` without spamming Slack's
+ * rate limit. A 3s window with leading + trailing fire is the right
+ * compromise:
+ *
+ *   - first line shows immediately so the user sees movement
+ *   - lines within the window are coalesced; only the latest renders
+ *   - if mra falls silent after a leading fire, no redundant trailing
+ *     update fires (the placeholder already shows the only line)
+ *
+ * Trailing fire is suppressed when the latest seen line equals the
+ * line that already rendered — that case happens when a single line
+ * arrives at a quiet moment and there's nothing further to drip.
+ *
+ * `cancel()` clears any scheduled trailing fire — call it after the
+ * subprocess completes so the final synthesis reply isn't briefly
+ * over-written by a stale progress line that lost the race.
+ */
+
+export interface LastLineThrottleOptions {
+  /** Coalescing window in milliseconds. */
+  windowMs: number;
+  /** Sink for fired lines. May throw — caller's exceptions are swallowed. */
+  onFire: (line: string) => void;
+}
+
+export interface LastLineThrottle {
+  /** Record a line; may fire onFire synchronously (leading edge). */
+  push: (line: string) => void;
+  /** Cancel any pending trailing fire. Idempotent. */
+  cancel: () => void;
+}
+
+export function createLastLineThrottle(
+  opts: LastLineThrottleOptions,
+): LastLineThrottle {
+  let inWindow = false;
+  let lastFired: string | undefined;
+  let pendingLatest: string | undefined;
+  let timer: NodeJS.Timeout | undefined;
+
+  const safeFire = (line: string): void => {
+    lastFired = line;
+    try {
+      opts.onFire(line);
+    } catch {
+      /* sink failures are not the producer's problem */
+    }
+  };
+
+  const scheduleTrailing = (): void => {
+    timer = setTimeout(() => {
+      timer = undefined;
+      inWindow = false;
+      if (pendingLatest !== undefined && pendingLatest !== lastFired) {
+        safeFire(pendingLatest);
+      }
+      pendingLatest = undefined;
+    }, opts.windowMs);
+  };
+
+  return {
+    push(line: string) {
+      if (!inWindow) {
+        inWindow = true;
+        safeFire(line);
+        pendingLatest = undefined;
+        scheduleTrailing();
+        return;
+      }
+      pendingLatest = line;
+    },
+    cancel() {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+      inWindow = false;
+      pendingLatest = undefined;
+    },
+  };
+}

--- a/packages/cli/test/mra-adapter.test.ts
+++ b/packages/cli/test/mra-adapter.test.ts
@@ -397,6 +397,29 @@ describe("runMraAskWithBinary spawn behaviour (#22)", () => {
     );
   });
 
+  it("survives a synchronous spawn() throw and resolves to a non-ok result (TDZ regression)", async () => {
+    // NUL byte in the path makes Node's spawn() throw synchronously
+    // (rather than emitting an async 'error' event). Earlier versions
+    // of this code referenced timeoutHandle from the catch block
+    // before its declaration, throwing a TDZ ReferenceError instead
+    // of resolving the promise. This test pins the order.
+    const r = await runMraAskWithBinary(
+      "/cant have-nul",
+      {
+        repo: "erp",
+        question: "ignored",
+        cwd: process.cwd(),
+        timeoutMs: 5000,
+      },
+      { maxRetries: 0 },
+    );
+    assert.equal(r.ok, false);
+    assert.ok(
+      (r.reason ?? "").length > 0,
+      "expected a non-empty reason from the synchronous spawn throw",
+    );
+  });
+
   it("retries once when the first attempt looks transient (empty stderr + non-zero exit)", async () => {
     // Stateful fake: first invocation exits 1 with no stderr (which
     // looksTransient classifies as worth retrying), second exits 0.

--- a/packages/cli/test/mra-adapter.test.ts
+++ b/packages/cli/test/mra-adapter.test.ts
@@ -12,6 +12,7 @@ import {
   PKB_BASE_DOCS,
   PKB_DIR_RELATIVE,
   resolveMraRepo,
+  runMraAskWithBinary,
 } from "../src/adapters/mra";
 
 const ORIG = {
@@ -248,5 +249,178 @@ describe("mraDoctor", () => {
     assert.equal(r.ok, false);
     assert.match(r.reason ?? "", /not found on PATH/);
     assert.equal(r.binaryPath, undefined);
+  });
+});
+
+/**
+ * runMraAskWithBinary spawn-behaviour tests (#22 / v0.10).
+ *
+ * Strategy: ship a tiny POSIX shell wrapper that mimics the mra CLI
+ * shape (`mra ask <repo> <question>`) but `eval`s the question
+ * through `node -e`, letting each test express its own fake-mra
+ * behaviour inline without scattering temp scripts.
+ *
+ *   wrapper invoked as:  ./mra ask <repo> <question>
+ *   wrapper does:        node -e "<question>" -- <repo> <question>
+ *
+ * That way `runMraAskWithBinary` calls the real binary with the real
+ * argv shape, but the subprocess we actually exercise is a node
+ * one-liner under our control.
+ */
+const FAKE_MRA_WRAPPER = `#!/bin/sh
+# argv: ask <repo> <question>
+exec ${process.execPath} -e "$3" -- "$1" "$2" "$3"
+`;
+let wrapperDir: string;
+let wrapperPath: string;
+
+describe("runMraAskWithBinary spawn behaviour (#22)", () => {
+  beforeEach(() => {
+    wrapperDir = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-fake-mra-"));
+    wrapperPath = path.join(wrapperDir, "mra");
+    fs.writeFileSync(wrapperPath, FAKE_MRA_WRAPPER, { mode: 0o755 });
+  });
+
+  afterEach(() => {
+    if (wrapperDir) fs.rmSync(wrapperDir, { recursive: true, force: true });
+  });
+
+  it("returns ok=true and concatenated stdout on a clean exit", async () => {
+    const r = await runMraAskWithBinary(
+      wrapperPath,
+      {
+        repo: "erp",
+        question: `process.stdout.write("line one\\nline two\\nline three\\n");`,
+        cwd: process.cwd(),
+        timeoutMs: 5000,
+      },
+      { maxRetries: 0 },
+    );
+    assert.equal(r.ok, true, `unexpected fail: ${r.reason ?? ""}`);
+    assert.match(r.stdout, /line one[\s\S]*line two[\s\S]*line three/);
+    assert.equal(r.attempts, 1);
+  });
+
+  it("invokes onProgress for each non-empty line, stripping CR, skipping the trailing partial line", async () => {
+    const lines: string[] = [];
+    const r = await runMraAskWithBinary(
+      wrapperPath,
+      {
+        repo: "erp",
+        question: `process.stdout.write("[ask] PKB loaded\\r\\n[ask] querying...\\n[ask] done\\n[partial without newline");`,
+        cwd: process.cwd(),
+        timeoutMs: 5000,
+      },
+      { onProgress: (l) => lines.push(l), maxRetries: 0 },
+    );
+    assert.equal(r.ok, true, `unexpected fail: ${r.reason ?? ""}`);
+    assert.deepEqual(lines, [
+      "[ask] PKB loaded",
+      "[ask] querying...",
+      "[ask] done",
+    ]);
+    assert.match(r.stdout, /\[partial without newline$/);
+  });
+
+  it("captures stderr and surfaces a tail of it in the failure reason", async () => {
+    const r = await runMraAskWithBinary(
+      wrapperPath,
+      {
+        repo: "erp",
+        question: `process.stderr.write("step ok\\nfatal: bad question\\n"); process.exit(2);`,
+        cwd: process.cwd(),
+        timeoutMs: 5000,
+      },
+      { maxRetries: 0 },
+    );
+    assert.equal(r.ok, false);
+    assert.match(r.stderr, /fatal: bad question/);
+    assert.match(r.reason ?? "", /code=2/);
+    assert.match(r.reason ?? "", /fatal: bad question/);
+  });
+
+  it("times out via SIGTERM kill and reports a timeout reason (not a generic 'exited' reason)", async () => {
+    const r = await runMraAskWithBinary(
+      wrapperPath,
+      {
+        repo: "erp",
+        // setInterval keeps the event loop alive — SIGTERM is the
+        // only way out, mirroring how a wedged mra ask would behave.
+        question: `setInterval(() => {}, 60000);`,
+        cwd: process.cwd(),
+        timeoutMs: 200,
+      },
+      { maxRetries: 0 },
+    );
+    assert.equal(r.ok, false);
+    assert.match(r.reason ?? "", /timed out after 200ms/);
+  });
+
+  it("onProgress callback errors do not tear down stdout reading", async () => {
+    let firedCount = 0;
+    const r = await runMraAskWithBinary(
+      wrapperPath,
+      {
+        repo: "erp",
+        question: `process.stdout.write("a\\nb\\nc\\n");`,
+        cwd: process.cwd(),
+        timeoutMs: 5000,
+      },
+      {
+        onProgress: () => {
+          firedCount += 1;
+          throw new Error("sink down");
+        },
+        maxRetries: 0,
+      },
+    );
+    assert.equal(r.ok, true, `unexpected fail: ${r.reason ?? ""}`);
+    assert.equal(firedCount, 3, "all lines still produced despite throws");
+    assert.match(r.stdout, /a\nb\nc\n/);
+  });
+
+  it("reports a non-ok result with the spawn-error message when the binary cannot start", async () => {
+    const r = await runMraAskWithBinary(
+      "/path/to/definitely-not-a-binary-here-xyzzy",
+      {
+        repo: "erp",
+        question: "ignored",
+        cwd: process.cwd(),
+        timeoutMs: 5000,
+      },
+      { maxRetries: 0 },
+    );
+    assert.equal(r.ok, false);
+    assert.ok(
+      (r.reason ?? "").length > 0,
+      "expected a non-empty reason when the binary fails to spawn",
+    );
+  });
+
+  it("retries once when the first attempt looks transient (empty stderr + non-zero exit)", async () => {
+    // Stateful fake: first invocation exits 1 with no stderr (which
+    // looksTransient classifies as worth retrying), second exits 0.
+    const stateFile = path.join(wrapperDir, "attempts");
+    fs.writeFileSync(stateFile, "0");
+    const r = await runMraAskWithBinary(
+      wrapperPath,
+      {
+        repo: "erp",
+        question: `
+          const fs = require("node:fs");
+          const f = ${JSON.stringify(stateFile)};
+          const n = parseInt(fs.readFileSync(f, "utf8"), 10) + 1;
+          fs.writeFileSync(f, String(n));
+          if (n === 1) process.exit(1);
+          process.stdout.write("ok on attempt " + n + "\\n");
+        `,
+        cwd: process.cwd(),
+        timeoutMs: 5000,
+      },
+      { maxRetries: 1 },
+    );
+    assert.equal(r.ok, true, `expected eventual success: ${r.reason ?? ""}`);
+    assert.equal(r.attempts, 2);
+    assert.match(r.stdout, /ok on attempt 2/);
   });
 });

--- a/packages/cli/test/throttle.test.ts
+++ b/packages/cli/test/throttle.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, beforeEach, afterEach, mock } from "node:test";
+import * as assert from "node:assert/strict";
+import { createLastLineThrottle } from "../src/gateway/throttle";
+
+describe("createLastLineThrottle (#22)", () => {
+  let now = 0;
+  let scheduled: Array<{ at: number; fn: () => void }> = [];
+  let timerId = 0;
+  const realSetTimeout = globalThis.setTimeout;
+  const realClearTimeout = globalThis.clearTimeout;
+
+  beforeEach(() => {
+    now = 0;
+    scheduled = [];
+    timerId = 0;
+    // Replace timers with a manual clock so tests don't actually wait.
+    (globalThis as { setTimeout: unknown }).setTimeout = ((
+      fn: () => void,
+      delayMs: number,
+    ) => {
+      timerId += 1;
+      const id = timerId;
+      scheduled.push({ at: now + delayMs, fn });
+      return { _mockId: id } as unknown as NodeJS.Timeout;
+    }) as typeof setTimeout;
+    (globalThis as { clearTimeout: unknown }).clearTimeout = ((
+      handle: { _mockId: number } | undefined,
+    ) => {
+      if (!handle) return;
+      scheduled = scheduled.filter((s) => {
+        // Match by reference to the timer id; the stub above wraps id
+        // inside the returned handle.
+        return (
+          (s.fn as { _mockId?: number })._mockId === undefined ||
+          (s.fn as { _mockId?: number })._mockId !== handle._mockId
+        );
+      });
+    }) as typeof clearTimeout;
+  });
+
+  afterEach(() => {
+    globalThis.setTimeout = realSetTimeout;
+    globalThis.clearTimeout = realClearTimeout;
+  });
+
+  function advance(ms: number): void {
+    now += ms;
+    const due = scheduled.filter((s) => s.at <= now);
+    scheduled = scheduled.filter((s) => s.at > now);
+    for (const d of due) d.fn();
+  }
+
+  it("first push fires immediately (leading edge)", () => {
+    const onFire = mock.fn<(line: string) => void>();
+    const t = createLastLineThrottle({ windowMs: 3000, onFire });
+    t.push("first");
+    assert.equal(onFire.mock.callCount(), 1);
+    assert.equal(onFire.mock.calls[0].arguments[0], "first");
+  });
+
+  it("pushes within the window are coalesced; only last line fires at window end", () => {
+    const onFire = mock.fn<(line: string) => void>();
+    const t = createLastLineThrottle({ windowMs: 3000, onFire });
+    t.push("a"); // leading-fire
+    t.push("b");
+    t.push("c");
+    advance(2999);
+    assert.equal(onFire.mock.callCount(), 1, "still in window — no trailing yet");
+    advance(2);
+    assert.equal(onFire.mock.callCount(), 2);
+    assert.equal(onFire.mock.calls[1].arguments[0], "c");
+  });
+
+  it("trailing fire is suppressed when no new line arrived after the leading fire", () => {
+    const onFire = mock.fn<(line: string) => void>();
+    const t = createLastLineThrottle({ windowMs: 3000, onFire });
+    t.push("only");
+    advance(5000);
+    assert.equal(onFire.mock.callCount(), 1, "no new line → no redundant trailing");
+  });
+
+  it("trailing fire is suppressed when the latest line equals the last-fired line", () => {
+    const onFire = mock.fn<(line: string) => void>();
+    const t = createLastLineThrottle({ windowMs: 3000, onFire });
+    t.push("same");
+    t.push("same");
+    advance(5000);
+    assert.equal(onFire.mock.callCount(), 1);
+  });
+
+  it("after the trailing fire, the next push starts a new leading fire", () => {
+    const onFire = mock.fn<(line: string) => void>();
+    const t = createLastLineThrottle({ windowMs: 3000, onFire });
+    t.push("a");
+    t.push("b");
+    advance(3001); // trailing fires "b"
+    assert.equal(onFire.mock.callCount(), 2);
+    t.push("c"); // out of cooldown → leading fires immediately
+    assert.equal(onFire.mock.callCount(), 3);
+    assert.equal(onFire.mock.calls[2].arguments[0], "c");
+  });
+
+  it("cancel() prevents the trailing fire", () => {
+    const onFire = mock.fn<(line: string) => void>();
+    const t = createLastLineThrottle({ windowMs: 3000, onFire });
+    t.push("a");
+    t.push("b");
+    t.cancel();
+    advance(5000);
+    assert.equal(onFire.mock.callCount(), 1, "only leading; trailing cancelled");
+  });
+
+  it("onFire failures are swallowed so a bad sink doesn't break the producer", () => {
+    const onFire = mock.fn<(line: string) => void>(() => {
+      throw new Error("network down");
+    });
+    const t = createLastLineThrottle({ windowMs: 3000, onFire });
+    assert.doesNotThrow(() => t.push("a"));
+    t.push("b");
+    assert.doesNotThrow(() => advance(3001));
+  });
+});


### PR DESCRIPTION
Closes #22. Second v0.10 milestone item — completes the milestone alongside #24 (already merged in #42).

## Summary

- `runMraAsk` now uses `spawn` instead of `execFile` so callers can subscribe to a per-line progress callback while still receiving the full buffered stdout/stderr at completion.
- New `createLastLineThrottle({ windowMs, onFire })` helper — leading + trailing debounce with last-line-wins semantics. Used by the Slack adapter to drip-feed progress lines into the placeholder via `web.chat.update`.
- During an mra-ask round, the placeholder now ticks through `[ask] PKB loaded`, `[ask] querying...` etc. instead of a static `:mag: 正在用 mra 查 ...` line.

## Design choices worth knowing

- **3-second window.** Comfortably under Slack's chat.update Tier 3 rate limit (~50 rpm). One in-flight mra-ask peaks at ~20 rpm.
- **Leading + trailing fire.** First line shows immediately so the user sees movement. Trailing fire suppressed when no new line arrived OR when the latest line equals the last fired (avoid no-op updates).
- **`throttle.cancel()` after `runMraAsk` returns.** Prevents a stale trailing progress line from briefly overwriting the final synthesised reply that the existing flow posts a moment later.
- **Sink failures swallowed.** A Slack 429 mid-round can't tear down the mra subprocess read.
- **Markdown-special chars stripped from progress lines.** Backtick / asterisk / underscore from mra output won't garble the placeholder. Length capped at 200 chars per the issue sketch.
- **Trailing partial line not surfaced via onProgress.** Most mra runs end with a newline; a partial-line "progress" would rarely be meaningful UX. The full result.stdout still includes any trailing partial.
- **`runMraAskWithBinary` extracted as the testable core.** Tests use a tiny POSIX wrapper script (`exec node -e "$3" ...`) to express each fake-mra behaviour inline without scattering temp files.

## Behaviour preserved from execFile

- Full stdout / stderr concatenated and returned
- Timeout via `setTimeout` + `child.kill("SIGTERM")` (matches the old `execFile.killSignal` default; the timeout-vs-error classification carries over)
- `looksTransient` retry-once unchanged
- 'error' event resolves as a non-ok result with the message
- Non-zero-exit reason now also surfaces a tail of stderr to make triage faster (small upgrade — was `Command failed: <argv>` before)

## Test plan

- [x] `npm --workspace packages/cli run test` → 236/236 (was 222 after #24 ship; +7 throttle, +7 spawn-behaviour = 14 new)
- [x] `npm --workspace packages/cli run build` → clean
- [x] Throttle: leading + trailing edges, suppression rules, cancel, sink-throw handling
- [x] Spawn: ok-stdout, onProgress with CR strip + partial-line skip, stderr+reason tail, SIGTERM timeout, sink-throw handling, spawn-failure path, retry-once via stateful wrapper
- [ ] Live verification on a real gateway with a real mra round — defer to milestone close (live-Slack assertion)

## Files

```
apps/docs/docs/changelog.md            |  3 +-
apps/docs/docs/gateway/lifecycle.md    |  4 +-
packages/cli/src/adapters/mra.ts       | 165 ++++++++++++++++++++--------
packages/cli/src/gateway/slack/index.ts|  27 ++++-
packages/cli/src/gateway/throttle.ts   | 100 +++++++++++++++++
packages/cli/test/mra-adapter.test.ts  | 161 +++++++++++++++++++++++++++
packages/cli/test/throttle.test.ts     | 122 ++++++++++++++++++++
```

## Out of scope (v0.10.x or later)

- Filtering progress lines to "official" `[...]` markers only — currently permissive; the throttle naturally hides high-frequency noise. Tighten if real dogfood shows verbose lines crowding out useful ones.
- Streaming mra's *thinking* (not exposed by mra; would need an mra-side change).
- Showing progress in the LLM's apology context when mra-ask fails — currently only the success path uses progress.