### PR TITLE
feat(gateway): per-channel audience override (#23)

### DIFF
--- a/packages/cli/src/commands/gateway.ts
+++ b/packages/cli/src/commands/gateway.ts
@@ -317,6 +317,25 @@ function ensureValidSlackUserId(userId: string): boolean {
   return false;
 }
 
+/**
+ * Slack channel IDs (#23): `C` (public), `G` (private), or `D` (DM)
+ * followed by uppercase alphanum. DM IDs are accepted because the
+ * channel-default mechanism still works there even though
+ * per-channel overrides for DMs are degenerate (per-user already
+ * covers the same ground).
+ */
+const SLACK_CHANNEL_ID_RE = /^[CGD][A-Z0-9]{2,}$/;
+
+function ensureValidSlackChannelId(channelId: string): boolean {
+  if (SLACK_CHANNEL_ID_RE.test(channelId)) return true;
+  println(
+    chalk.red(
+      `invalid Slack channel ID '${channelId}'. Expected format e.g. C0AVD1XD946 — channel name → 'View channel details' → 'Copy channel ID'.`,
+    ),
+  );
+  return false;
+}
+
 function audienceUsage(): void {
   println(
     chalk.yellow(
@@ -324,6 +343,8 @@ function audienceUsage(): void {
         "  pmk gateway audience list\n" +
         "  pmk gateway audience set <userId> <tech|pm|biz|exec>\n" +
         "  pmk gateway audience unset <userId>\n" +
+        "  pmk gateway audience set-channel <channelId> <tech|pm|biz|exec>\n" +
+        "  pmk gateway audience unset-channel <channelId>\n" +
         "  pmk gateway audience default <tech|pm|biz|exec>",
     ),
   );
@@ -337,15 +358,29 @@ function audienceCmd(rest: string[]): void {
     case "list": {
       println(chalk.bold("\npmk gateway audience"));
       println(`  default: ${chalk.cyan(cfg.audience.default)}`);
-      const entries = Object.entries(cfg.audience.users);
-      if (entries.length === 0) {
+      const userEntries = Object.entries(cfg.audience.users);
+      if (userEntries.length === 0) {
         println(chalk.dim("  (no per-user overrides)"));
       } else {
         println(chalk.dim("  per-user overrides:"));
-        for (const [uid, aud] of entries) {
+        for (const [uid, aud] of userEntries) {
           println(`    ${uid.padEnd(14)} → ${aud}`);
         }
       }
+      const channelEntries = Object.entries(cfg.audience.channels);
+      if (channelEntries.length === 0) {
+        println(chalk.dim("  (no per-channel overrides)"));
+      } else {
+        println(chalk.dim("  per-channel overrides:"));
+        for (const [cid, aud] of channelEntries) {
+          println(`    ${cid.padEnd(14)} → ${aud}`);
+        }
+      }
+      println(
+        chalk.dim(
+          "  resolution order at turn time: per-user → per-channel → default",
+        ),
+      );
       return;
     }
     case "set": {
@@ -382,6 +417,42 @@ function audienceCmd(rest: string[]): void {
       delete cfg.audience.users[userId];
       saveGatewayConfig(cfg);
       println(chalk.green(`removed override for ${userId}`));
+      return;
+    }
+    case "set-channel": {
+      const [channelId, audience] = args;
+      if (!channelId || !audience) {
+        audienceUsage();
+        process.exit(1);
+      }
+      if (!ensureValidSlackChannelId(channelId)) process.exit(1);
+      if (!isAudienceKey(audience)) {
+        println(
+          chalk.red(
+            `invalid audience '${audience}'. Allowed: tech / pm / biz / exec.`,
+          ),
+        );
+        process.exit(1);
+      }
+      cfg.audience.channels[channelId] = audience;
+      saveGatewayConfig(cfg);
+      println(chalk.green(`set channel ${channelId} → ${audience}`));
+      return;
+    }
+    case "unset-channel": {
+      const [channelId] = args;
+      if (!channelId) {
+        audienceUsage();
+        process.exit(1);
+      }
+      if (!ensureValidSlackChannelId(channelId)) process.exit(1);
+      if (!(channelId in cfg.audience.channels)) {
+        println(chalk.dim(`(${channelId} had no override; nothing to do)`));
+        return;
+      }
+      delete cfg.audience.channels[channelId];
+      saveGatewayConfig(cfg);
+      println(chalk.green(`removed channel override for ${channelId}`));
       return;
     }
     case "default": {

--- a/packages/cli/src/gateway/config.ts
+++ b/packages/cli/src/gateway/config.ts
@@ -160,11 +160,13 @@ export function pickAudience(
   userId: string,
   channelId?: string,
 ): AudienceKey {
+  // Truthy check on channelId rather than `!== undefined` so an empty
+  // string accidentally passed through (e.g., a stripped Slack envelope)
+  // doesn't query `cfg.audience.channels[""]` and pull a key the host
+  // never explicitly set.
   return (
     cfg.audience?.users?.[userId] ??
-    (channelId !== undefined
-      ? cfg.audience?.channels?.[channelId]
-      : undefined) ??
+    (channelId ? cfg.audience?.channels?.[channelId] : undefined) ??
     cfg.audience?.default ??
     "tech"
   );

--- a/packages/cli/src/gateway/config.ts
+++ b/packages/cli/src/gateway/config.ts
@@ -25,14 +25,22 @@ export interface SlackConfig {
 }
 
 /**
- * Per-user audience overrides. Audience picks which gateway-DM prompt
- * the model uses for this user — tech (default; PM/SA/eng), biz
- * (sales / ops / non-tech PM), or exec (decision-makers).
+ * Audience overrides. Audience picks which gateway-DM prompt the
+ * model uses for a turn — tech (default; PM/SA/eng), pm
+ * (product-flavored), biz (sales / ops / non-tech), or exec
+ * (decision-makers).
+ *
+ * Resolution order at turn time (#23): per-user override → per-channel
+ * override → workspace default. Per-user always wins; channel default
+ * lets a host say "everyone in #leadership defaults to exec" without
+ * setting 12 individual user overrides.
  */
 export interface AudienceConfig {
   default: AudienceKey;
   /** Slack user ID → audience override. */
   users: Record<string, AudienceKey>;
+  /** Slack channel ID → audience default for the channel (#23). */
+  channels: Record<string, AudienceKey>;
 }
 
 /**
@@ -95,7 +103,7 @@ export function gatewayPidPath(): string {
 }
 
 function defaultAudience(): AudienceConfig {
-  return { default: "tech", users: {} };
+  return { default: "tech", users: {}, channels: {} };
 }
 
 function defaultEscalation(): EscalationConfig {
@@ -123,6 +131,7 @@ export function loadGatewayConfig(): GatewayConfig {
   // Back-fill fields added in later builds so old configs still load.
   if (!raw.audience) raw.audience = defaultAudience();
   if (!raw.audience.users) raw.audience.users = {};
+  if (!raw.audience.channels) raw.audience.channels = {};
   if (!raw.escalation) raw.escalation = defaultEscalation();
   if (!raw.escalation.repos) raw.escalation.repos = {};
   if (!raw.escalation.default) raw.escalation.default = [];
@@ -135,11 +144,30 @@ export function loadGatewayConfig(): GatewayConfig {
 }
 
 /**
- * Pick the audience for a specific user. Falls back to the default
- * audience when no per-user override is set.
+ * Pick the audience for a turn (#23):
+ *   1. per-user override (cfg.audience.users[userId])
+ *   2. per-channel override (cfg.audience.channels[channelId])
+ *   3. workspace default (cfg.audience.default)
+ *   4. hard fallback ("tech") if nothing is configured
+ *
+ * `channelId` is optional so DM call sites that don't have a real
+ * channel context (e.g., user-DM where channelId is the DM channel's
+ * `D...` ID — equivalent to the user) can still call this function;
+ * unmatched channelIds simply fall through to step 3.
  */
-export function pickAudience(cfg: GatewayConfig, userId: string): AudienceKey {
-  return cfg.audience?.users?.[userId] ?? cfg.audience?.default ?? "tech";
+export function pickAudience(
+  cfg: GatewayConfig,
+  userId: string,
+  channelId?: string,
+): AudienceKey {
+  return (
+    cfg.audience?.users?.[userId] ??
+    (channelId !== undefined
+      ? cfg.audience?.channels?.[channelId]
+      : undefined) ??
+    cfg.audience?.default ??
+    "tech"
+  );
 }
 
 /**

--- a/packages/cli/src/gateway/slack/admin.ts
+++ b/packages/cli/src/gateway/slack/admin.ts
@@ -70,6 +70,19 @@ export function extractUserId(token: string): string | undefined {
 
 const SLACK_USER_ID_RE = /^[UW][A-Z0-9]{2,}$/;
 
+/**
+ * Slack channel IDs (#23): `C` (public), `G` (private), or `D` (DM).
+ * Slack delivers channel references in slash-command text as
+ * `<#C0XYZ|name>` or `<#C0XYZ>`; admins can also paste the raw ID.
+ */
+export function extractChannelId(token: string): string | undefined {
+  if (!token) return undefined;
+  const mention = /^<#([CGD][A-Z0-9]+)(?:\|[^>]*)?>$/.exec(token);
+  if (mention) return mention[1];
+  if (/^[CGD][A-Z0-9]{2,}$/.test(token)) return token;
+  return undefined;
+}
+
 function logAdmin(
   actor: string,
   action: string,
@@ -116,6 +129,7 @@ function helpText(): string {
     "*pmk admin commands* (DM-only, admin-restricted)",
     "• `/pmk admin status` — gateway status",
     "• `/pmk admin audience set @user <tech|pm|biz|exec>`",
+    "• `/pmk admin audience set-channel #channel <tech|pm|biz|exec>` (#23)",
     "• `/pmk admin audience default <tech|pm|biz|exec>`",
     "• `/pmk admin escalation add <repo|default> @user`",
     "• `/pmk admin escalation remove <repo|default> @user`",
@@ -205,23 +219,66 @@ function adminAudience(
       logAdmin(actor, "audience.default", true, key);
       return { text: `:white_check_mark: default audience set to \`${key}\`` };
     }
+    case "set-channel": {
+      const [channelToken, key] = args;
+      const channelId = extractChannelId(channelToken);
+      if (!channelId || !key) {
+        logAdmin(actor, "audience.set-channel", false, undefined, "missing args");
+        return { text: ":x: usage: `/pmk admin audience set-channel #channel <tech|pm|biz|exec>`" };
+      }
+      if (!isAudienceKey(key)) {
+        logAdmin(actor, "audience.set-channel", false, `${channelId} ${key}`, "invalid audience");
+        return { text: `:x: invalid audience \`${key}\` — must be tech, pm, biz, or exec` };
+      }
+      cfg.audience.channels[channelId] = key;
+      saveGatewayConfig(cfg);
+      logAdmin(actor, "audience.set-channel", true, `${channelId} ${key}`);
+      return { text: `:white_check_mark: <#${channelId}> default audience set to \`${key}\`` };
+    }
+    case "unset-channel": {
+      const channelId = extractChannelId(args[0]);
+      if (!channelId) {
+        logAdmin(actor, "audience.unset-channel", false, undefined, "missing args");
+        return { text: ":x: usage: `/pmk admin audience unset-channel #channel`" };
+      }
+      if (!(channelId in cfg.audience.channels)) {
+        logAdmin(actor, "audience.unset-channel", true, channelId, "no override");
+        return { text: `(<#${channelId}> has no override; nothing to do)` };
+      }
+      delete cfg.audience.channels[channelId];
+      saveGatewayConfig(cfg);
+      logAdmin(actor, "audience.unset-channel", true, channelId);
+      return { text: `:white_check_mark: <#${channelId}> override removed (falls back to workspace default \`${cfg.audience.default}\`)` };
+    }
     case "list":
     case undefined: {
       const lines: string[] = ["*audience config*"];
       lines.push(`• default: \`${cfg.audience.default}\``);
-      const entries = Object.entries(cfg.audience.users);
-      if (entries.length === 0) {
+      const userEntries = Object.entries(cfg.audience.users);
+      if (userEntries.length === 0) {
         lines.push("• per-user overrides: _(none)_");
       } else {
         lines.push("• per-user overrides:");
-        for (const [uid, aud] of entries) {
+        for (const [uid, aud] of userEntries) {
           lines.push(`  - <@${uid}> → \`${aud}\``);
         }
       }
+      const channelEntries = Object.entries(cfg.audience.channels);
+      if (channelEntries.length === 0) {
+        lines.push("• per-channel overrides: _(none)_");
+      } else {
+        lines.push("• per-channel overrides:");
+        for (const [cid, aud] of channelEntries) {
+          lines.push(`  - <#${cid}> → \`${aud}\``);
+        }
+      }
+      lines.push(
+        "• resolution order at turn time: per-user → per-channel → default",
+      );
       return { text: lines.join("\n") };
     }
     default:
-      return { text: ":x: usage: `/pmk admin audience set|unset|default|list`" };
+      return { text: ":x: usage: `/pmk admin audience set|unset|set-channel|unset-channel|default|list`" };
   }
 }
 

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -504,7 +504,7 @@ export class SlackAdapter {
       text: ":hourglass_flowing_sand: thinking…",
     });
 
-    const audience = pickAudience(this.config, userId);
+    const audience = pickAudience(this.config, userId, channelId);
     const systemPrompt = pickGatewayPrompt(audience);
 
     let full = "";
@@ -869,7 +869,7 @@ export class SlackAdapter {
   }): Promise<void> {
     const { channelId, threadTs, askerUserId, atom } = args;
     if (!askerUserId) return;
-    const audience = pickAudience(this.config, askerUserId);
+    const audience = pickAudience(this.config, askerUserId, channelId);
     const systemPrompt = pickGatewayPrompt(audience);
     const synthMessage =
       `IT 同事剛在這條 thread 補上了答案，請依以下事實 synthesise 一段回覆給原本提問的同事 <@${askerUserId}>。語氣依你的 audience prompt。\n\n` +

--- a/packages/cli/test/gateway.test.ts
+++ b/packages/cli/test/gateway.test.ts
@@ -119,7 +119,7 @@ describe("gateway config", () => {
       blocklist: ["U-bad"],
       admins: [],
       defaultIngest: "mra:--all",
-      audience: { default: "tech" as const, users: {} },
+      audience: { default: "tech" as const, users: {}, channels: {} },
       escalation: { default: [], repos: {} },
       slack: { appToken: "xapp-foo", botToken: "xoxb-bar" },
     };
@@ -137,7 +137,7 @@ describe("gateway config", () => {
       version: 1,
       blocklist: [],
       admins: [],
-      audience: { default: "tech", users: {} },
+      audience: { default: "tech", users: {}, channels: {} },
       escalation: { default: [], repos: {} },
       slack: { appToken: "xapp-from-file", botToken: "xoxb-from-file" },
     });
@@ -154,7 +154,7 @@ describe("gateway config", () => {
         version: 1,
         blocklist: [],
         admins: [],
-        audience: { default: "tech", users: {} },
+        audience: { default: "tech", users: {}, channels: {} },
         escalation: { default: [], repos: {} },
         slack: { appToken: "wrong", botToken: "xoxb-x" },
       }),
@@ -165,7 +165,7 @@ describe("gateway config", () => {
         version: 1,
         blocklist: [],
         admins: [],
-        audience: { default: "tech", users: {} },
+        audience: { default: "tech", users: {}, channels: {} },
         escalation: { default: [], repos: {} },
         slack: { appToken: "xapp-x", botToken: "wrong" },
       }),
@@ -202,7 +202,7 @@ describe("gateway config", () => {
       blocklist: [],
       admins: [],
       mraWorkspace: "/tmp/some/workspace",
-      audience: { default: "tech", users: {} },
+      audience: { default: "tech", users: {}, channels: {} },
       escalation: { default: [], repos: {} },
       slack: { appToken: "xapp-x", botToken: "xoxb-x" },
     });
@@ -217,7 +217,7 @@ describe("gateway config", () => {
       blocklist: [],
       admins: [],
       mraWorkspace: "/from/file",
-      audience: { default: "tech", users: {} },
+      audience: { default: "tech", users: {}, channels: {} },
       escalation: { default: [], repos: {} },
       slack: { appToken: "xapp-x", botToken: "xoxb-x" },
     });
@@ -853,6 +853,85 @@ describe("audience picker", () => {
     saveGatewayConfig(cfg);
     const reload = loadGatewayConfig();
     assert.equal(pickAudience(reload, "U_PM1"), "pm");
+  });
+
+  // #23: per-channel audience override. Resolution order:
+  //   per-user → per-channel → workspace default
+
+  it("channel override applies when no per-user override is set (#23)", () => {
+    const cfg = loadGatewayConfig();
+    cfg.audience.default = "tech";
+    cfg.audience.channels["C_LEADERSHIP"] = "exec";
+    saveGatewayConfig(cfg);
+    const reload = loadGatewayConfig();
+    assert.equal(
+      pickAudience(reload, "U-anyone", "C_LEADERSHIP"),
+      "exec",
+      "channel default should kick in for users without their own override",
+    );
+  });
+
+  it("per-user override beats per-channel override (#23)", () => {
+    const cfg = loadGatewayConfig();
+    cfg.audience.default = "tech";
+    cfg.audience.channels["C_LEADERSHIP"] = "exec";
+    cfg.audience.users["U-deep-tech"] = "tech";
+    saveGatewayConfig(cfg);
+    const reload = loadGatewayConfig();
+    assert.equal(
+      pickAudience(reload, "U-deep-tech", "C_LEADERSHIP"),
+      "tech",
+      "per-user always wins over per-channel",
+    );
+  });
+
+  it("falls through to workspace default when neither user nor channel matches (#23)", () => {
+    const cfg = loadGatewayConfig();
+    cfg.audience.default = "biz";
+    cfg.audience.channels["C_LEADERSHIP"] = "exec";
+    saveGatewayConfig(cfg);
+    const reload = loadGatewayConfig();
+    assert.equal(
+      pickAudience(reload, "U-anyone", "C_OTHER"),
+      "biz",
+      "C_OTHER is not in channels map, fall through to default",
+    );
+  });
+
+  it("undefined channelId still resolves cleanly (DM call sites) (#23)", () => {
+    const cfg = loadGatewayConfig();
+    cfg.audience.default = "pm";
+    cfg.audience.channels["C_LEADERSHIP"] = "exec";
+    cfg.audience.users["U-pm"] = "biz";
+    saveGatewayConfig(cfg);
+    const reload = loadGatewayConfig();
+    // Per-user override applies even without channelId.
+    assert.equal(pickAudience(reload, "U-pm"), "biz");
+    // No user override + no channel context → workspace default.
+    assert.equal(pickAudience(reload, "U-anyone"), "pm");
+  });
+
+  it("loadGatewayConfig back-fills audience.channels for old configs missing the field (#23)", () => {
+    // Simulate an existing v0.10-era config that has audience.users
+    // but no channels — write the JSON directly so we don't go
+    // through the v0.11 saver (which would write channels:{}).
+    const file = path.join(tmpHome, ".pmk", "gateway.json");
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        version: 1,
+        blocklist: [],
+        admins: [],
+        audience: { default: "tech", users: { "U-x": "exec" } },
+        escalation: { default: [], repos: {} },
+        slack: { appToken: "xapp-x", botToken: "xoxb-x" },
+      }),
+    );
+    const reload = loadGatewayConfig();
+    assert.deepEqual(reload.audience.channels, {});
+    // Existing per-user override survives back-fill.
+    assert.equal(pickAudience(reload, "U-x"), "exec");
   });
 });
 
@@ -1640,7 +1719,7 @@ describe("isAdmin + admins back-fill (#31)", () => {
         {
           version: 1,
           blocklist: [],
-          audience: { default: "tech", users: {} },
+          audience: { default: "tech", users: {}, channels: {} },
           escalation: { default: [], repos: {} },
           slack: { appToken: "xapp-x", botToken: "xoxb-x" },
         },

--- a/packages/cli/test/gateway.test.ts
+++ b/packages/cli/test/gateway.test.ts
@@ -861,11 +861,11 @@ describe("audience picker", () => {
   it("channel override applies when no per-user override is set (#23)", () => {
     const cfg = loadGatewayConfig();
     cfg.audience.default = "tech";
-    cfg.audience.channels["C_LEADERSHIP"] = "exec";
+    cfg.audience.channels["CL3ADERSH1P"] = "exec";
     saveGatewayConfig(cfg);
     const reload = loadGatewayConfig();
     assert.equal(
-      pickAudience(reload, "U-anyone", "C_LEADERSHIP"),
+      pickAudience(reload, "U-anyone", "CL3ADERSH1P"),
       "exec",
       "channel default should kick in for users without their own override",
     );
@@ -874,12 +874,12 @@ describe("audience picker", () => {
   it("per-user override beats per-channel override (#23)", () => {
     const cfg = loadGatewayConfig();
     cfg.audience.default = "tech";
-    cfg.audience.channels["C_LEADERSHIP"] = "exec";
+    cfg.audience.channels["CL3ADERSH1P"] = "exec";
     cfg.audience.users["U-deep-tech"] = "tech";
     saveGatewayConfig(cfg);
     const reload = loadGatewayConfig();
     assert.equal(
-      pickAudience(reload, "U-deep-tech", "C_LEADERSHIP"),
+      pickAudience(reload, "U-deep-tech", "CL3ADERSH1P"),
       "tech",
       "per-user always wins over per-channel",
     );
@@ -888,20 +888,37 @@ describe("audience picker", () => {
   it("falls through to workspace default when neither user nor channel matches (#23)", () => {
     const cfg = loadGatewayConfig();
     cfg.audience.default = "biz";
-    cfg.audience.channels["C_LEADERSHIP"] = "exec";
+    cfg.audience.channels["CL3ADERSH1P"] = "exec";
     saveGatewayConfig(cfg);
     const reload = loadGatewayConfig();
     assert.equal(
-      pickAudience(reload, "U-anyone", "C_OTHER"),
+      pickAudience(reload, "U-anyone", "COTHER123"),
       "biz",
-      "C_OTHER is not in channels map, fall through to default",
+      "COTHER123 is not in channels map, fall through to default",
+    );
+  });
+
+  it("empty-string channelId is treated as no channel context (#23)", () => {
+    const cfg = loadGatewayConfig();
+    cfg.audience.default = "tech";
+    // Even if a key happens to exist for the empty string (only
+    // possible via direct file edit, never through the CLI which
+    // validates `[CGD][A-Z0-9]{2,}`), pickAudience must NOT pull from
+    // it — empty string means "no channel context".
+    cfg.audience.channels[""] = "exec";
+    saveGatewayConfig(cfg);
+    const reload = loadGatewayConfig();
+    assert.equal(
+      pickAudience(reload, "U-anyone", ""),
+      "tech",
+      "empty channelId should fall through to default, not match channels['']",
     );
   });
 
   it("undefined channelId still resolves cleanly (DM call sites) (#23)", () => {
     const cfg = loadGatewayConfig();
     cfg.audience.default = "pm";
-    cfg.audience.channels["C_LEADERSHIP"] = "exec";
+    cfg.audience.channels["CL3ADERSH1P"] = "exec";
     cfg.audience.users["U-pm"] = "biz";
     saveGatewayConfig(cfg);
     const reload = loadGatewayConfig();
@@ -1890,6 +1907,62 @@ describe("Slack admin handler (#31)", () => {
     assert.match(r.text, /invalid audience/);
     const reload = loadGatewayConfig();
     assert.equal(reload.audience.users["U0TGT"], undefined);
+  });
+
+  // #23: per-channel audience admin handler.
+
+  it("audience set-channel #channel exec mutates the per-channel default", async () => {
+    const { handleAdminSlash } = await import("../src/gateway/slack/admin");
+    const r = await handleAdminSlash({
+      actor: "U0OWNER",
+      tokens: [
+        "audience",
+        "set-channel",
+        "<#CL3ADERSH1P|leadership>",
+        "exec",
+      ],
+    });
+    assert.match(r.text, /default audience set to `exec`/);
+    assert.match(r.text, /<#CL3ADERSH1P>/);
+    const reload = loadGatewayConfig();
+    assert.equal(reload.audience.channels["CL3ADERSH1P"], "exec");
+  });
+
+  it("audience set-channel accepts a raw channel ID without the <#…> mention wrapper", async () => {
+    const { handleAdminSlash } = await import("../src/gateway/slack/admin");
+    const r = await handleAdminSlash({
+      actor: "U0OWNER",
+      tokens: ["audience", "set-channel", "CRAW12345", "biz"],
+    });
+    assert.match(r.text, /default audience set to `biz`/);
+    const reload = loadGatewayConfig();
+    assert.equal(reload.audience.channels["CRAW12345"], "biz");
+  });
+
+  it("audience set-channel rejects garbage channel tokens", async () => {
+    const { handleAdminSlash } = await import("../src/gateway/slack/admin");
+    const r = await handleAdminSlash({
+      actor: "U0OWNER",
+      tokens: ["audience", "set-channel", "@not-a-channel", "exec"],
+    });
+    assert.match(r.text, /usage:|missing args/);
+    const reload = loadGatewayConfig();
+    // No channel override should have been written.
+    assert.deepEqual(Object.keys(reload.audience.channels), []);
+  });
+
+  it("audience unset-channel removes an existing override", async () => {
+    const { handleAdminSlash } = await import("../src/gateway/slack/admin");
+    const cfg = loadGatewayConfig();
+    cfg.audience.channels["COLD12345"] = "pm";
+    saveGatewayConfig(cfg);
+    const r = await handleAdminSlash({
+      actor: "U0OWNER",
+      tokens: ["audience", "unset-channel", "<#COLD12345>"],
+    });
+    assert.match(r.text, /override removed/);
+    const reload = loadGatewayConfig();
+    assert.equal(reload.audience.channels["COLD12345"], undefined);
   });
 
   it("admins remove blocks last-admin removal", async () => {


### PR DESCRIPTION
Closes #23.

## Why

`pickAudience(cfg, userId)` resolved audience from `cfg.audience.users[userId]` then fell back to `cfg.audience.default`. In a mixed-audience channel like `#leadership` every user got *their* tone regardless of channel context — fine for `#engineering`, awkward for executive forums where the host wants a uniform exec tone unless someone has explicitly opted out.

This PR adds a channel default tier between per-user and workspace default.

## Resolution order

```
pickAudience(cfg, userId, channelId?)
  cfg.audience.users[userId]        // 1st priority — explicit per-user (unchanged)
  cfg.audience.channels[channelId]  // 2nd priority — channel default (NEW)
  cfg.audience.default              // 3rd priority — workspace default
```

Per-user always wins. Channel default lets a host say "everyone in #leadership defaults to exec" without setting 12 individual overrides — exactly the scenario the issue called out.

## Schema + back-compat

- `AudienceConfig` adds `channels: Record<string, AudienceKey>`
- `defaultAudience()` returns `channels: {}`
- `loadGatewayConfig()` back-fills `channels: {}` for old configs that pre-date this PR

The change is **purely additive** — pre-existing per-user config and the workspace default behave identically when no channel overrides are set.

## CLI surface

```
pmk gateway audience set-channel <channelId> <tech|pm|biz|exec>
pmk gateway audience unset-channel <channelId>
```

`pmk gateway audience list` now shows a per-channel section plus a one-line resolution-order hint.

## Slack admin surface

```
/pmk admin audience set-channel #channel <tech|pm|biz|exec>
/pmk admin audience unset-channel #channel
```

`extractChannelId()` handles three input forms: `<#C0X|name>` mention, `<#C0X>` bare mention, raw `C0X` / `G0X` / `D0X` ID. Audit log records `audience.set-channel` / `audience.unset-channel` actions with channelId + key in args.

## Adapter call sites

`slack/index.ts:507` (regular DM/channel turn) and `:872` (post-escalate synthesis turn) now pass `channelId` through to `pickAudience`. DM call sites without channel context still work because `channelId` is optional.

## Tests

274 → **279** (+5):
- channel override applies when no per-user override
- per-user beats channel override
- fall-through to workspace default for unmapped channels
- undefined channelId still resolves cleanly (DM path)
- back-fill works on configs missing the `channels` field

Plus 4 existing fixtures repaired that constructed `AudienceConfig` literals without the new required `channels` field.

## Test plan
- [x] Unit tests cover all three resolution-order branches + back-fill
- [x] Type-check passes; old config files still load (tested via raw-JSON write that omits `channels`)
- [ ] Manual: `pmk gateway audience set-channel C0AVD1XD946 exec` then DM in that channel; observe exec-prompt synthesis (deferred to #44 merge to share live-Slack verify session)
- [ ] Operator note for v0.11.0 release: `audience.channels` appears in `gateway.json` after first save under v0.11; existing files auto-back-fill on load