### PR TITLE
refactor(gateway): monthly-partitioned JSONL ledger for events.log + admin.log

### DIFF
--- a/packages/cli/src/gateway/admin-log.ts
+++ b/packages/cli/src/gateway/admin-log.ts
@@ -18,10 +18,9 @@
  * audits can be filtered.
  */
 
-import * as fs from "node:fs";
 import * as os from "node:os";
-import * as path from "node:path";
 import { gatewayDir } from "./config";
+import { appendJsonl, monthlyPath, readJsonl } from "./monthly-jsonl";
 
 export interface AdminLogEntry {
   /** Slack user ID for "slack" origin; "cli:<unix_user>" for "cli". */
@@ -39,8 +38,15 @@ export interface AdminLogEntry {
   reason?: string;
 }
 
+/**
+ * Path to the current month's admin partition. Exposed for tests
+ * that inject synthetic / malformed lines and for operators tailing
+ * the live feed. The returned path moves on UTC month boundaries;
+ * callers needing a specific month should compute it via
+ * `monthlyPath` directly.
+ */
 export function adminLogPath(): string {
-  return path.join(gatewayDir(), "admin.log");
+  return monthlyPath(gatewayDir(), "admin");
 }
 
 /**
@@ -49,17 +55,7 @@ export function adminLogPath(): string {
  * audit-log corruption would be worse than the missing log line.
  */
 export function appendAdminLog(entry: AdminLogEntry): void {
-  try {
-    fs.mkdirSync(gatewayDir(), { recursive: true });
-    const line =
-      JSON.stringify({
-        at: new Date().toISOString(),
-        ...entry,
-      }) + "\n";
-    fs.appendFileSync(adminLogPath(), line, "utf8");
-  } catch {
-    /* non-fatal */
-  }
+  appendJsonl(gatewayDir(), "admin", entry);
 }
 
 /**
@@ -82,23 +78,18 @@ export function cliActor(): string {
  * audit` and the host CLI counterpart.
  */
 export function readAdminLog(limit = 50): AdminLogEntry[] {
-  const file = adminLogPath();
-  if (!fs.existsSync(file)) return [];
-  let text: string;
-  try {
-    text = fs.readFileSync(file, "utf8");
-  } catch {
-    return [];
-  }
-  const lines = text.split("\n").filter((l) => l.length > 0);
-  const tail = lines.slice(-limit);
-  const out: AdminLogEntry[] = [];
-  for (const line of tail) {
-    try {
-      out.push(JSON.parse(line) as AdminLogEntry);
-    } catch {
-      /* skip malformed line */
-    }
-  }
-  return out;
+  const all = readJsonl(gatewayDir(), "admin", isAdminLogEntry, {});
+  if (limit < 0 || all.length <= limit) return all;
+  return all.slice(all.length - limit);
+}
+
+function isAdminLogEntry(v: unknown): v is AdminLogEntry {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  return (
+    typeof o.actor === "string" &&
+    (o.origin === "cli" || o.origin === "slack") &&
+    typeof o.action === "string" &&
+    typeof o.ok === "boolean"
+  );
 }

--- a/packages/cli/src/gateway/events.ts
+++ b/packages/cli/src/gateway/events.ts
@@ -17,10 +17,9 @@
  * structured logging is out of scope.
  */
 
-import * as fs from "node:fs";
-import * as path from "node:path";
 import type { AudienceKey } from "@pmk/shared";
 import { gatewayDir } from "./config";
+import { appendJsonl, monthlyPath, readJsonl } from "./monthly-jsonl";
 
 // TODO(v0.10.x): events.log grows unbounded. At single-host workloads
 // (~100 events/day) we'd hit ~1MB/year — acceptable for now but the
@@ -100,8 +99,15 @@ const VALID_TYPES: ReadonlySet<string> = new Set([
   "escalate.absorbed",
 ]);
 
+/**
+ * Path to the current month's events partition. Exposed for tests
+ * that inject synthetic / malformed lines and for operators tailing
+ * the live feed (e.g., `tail -f $(pmk debug events-path)`). The
+ * returned path moves on UTC month boundaries; callers that need a
+ * specific month should compute it themselves via `monthlyPath`.
+ */
 export function gatewayEventsPath(): string {
-  return path.join(gatewayDir(), "events.log");
+  return monthlyPath(gatewayDir(), "events");
 }
 
 /**
@@ -110,17 +116,7 @@ export function gatewayEventsPath(): string {
  * be worse than the missing line. Mirrors {@link appendAdminLog}.
  */
 export function appendGatewayEvent(event: GatewayEvent): void {
-  try {
-    fs.mkdirSync(gatewayDir(), { recursive: true });
-    const line =
-      JSON.stringify({
-        at: new Date().toISOString(),
-        ...event,
-      }) + "\n";
-    fs.appendFileSync(gatewayEventsPath(), line, "utf8");
-  } catch {
-    /* non-fatal */
-  }
+  appendJsonl(gatewayDir(), "events", event);
 }
 
 export interface ReadGatewayEventsOptions {
@@ -138,34 +134,13 @@ export interface ReadGatewayEventsOptions {
 export function readGatewayEvents(
   opts: ReadGatewayEventsOptions = {},
 ): StoredGatewayEvent[] {
-  const file = gatewayEventsPath();
-  if (!fs.existsSync(file)) return [];
-  let text: string;
-  try {
-    text = fs.readFileSync(file, "utf8");
-  } catch {
-    return [];
+  const all = readJsonl(gatewayDir(), "events", isStoredGatewayEvent, {
+    sinceMs: opts.sinceMs,
+  });
+  if (opts.limit !== undefined && opts.limit >= 0 && all.length > opts.limit) {
+    return all.slice(all.length - opts.limit);
   }
-  const out: StoredGatewayEvent[] = [];
-  for (const line of text.split("\n")) {
-    if (line.length === 0) continue;
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(line);
-    } catch {
-      continue;
-    }
-    if (!isStoredGatewayEvent(parsed)) continue;
-    if (opts.sinceMs !== undefined) {
-      const t = Date.parse(parsed.at);
-      if (!Number.isFinite(t) || t < opts.sinceMs) continue;
-    }
-    out.push(parsed);
-  }
-  if (opts.limit !== undefined && opts.limit >= 0 && out.length > opts.limit) {
-    return out.slice(out.length - opts.limit);
-  }
-  return out;
+  return all;
 }
 
 function isStoredGatewayEvent(v: unknown): v is StoredGatewayEvent {

--- a/packages/cli/src/gateway/monthly-jsonl.ts
+++ b/packages/cli/src/gateway/monthly-jsonl.ts
@@ -3,15 +3,31 @@
  * (events.log + admin.log). Replaces the v0.10 single-file scheme
  * which was unbounded.
  *
- * Files: `<baseDir>/<prefix>-YYYY-MM.log` (UTC month). One JSON
- * object per line, the writer adds an `at` ISO timestamp before
- * stringify. Readers tolerate malformed lines so a single bad write
- * doesn't poison the audit.
+ * Files: `<baseDir>/<prefix>-YYYY-MM.log` — UTC month boundary, NOT
+ * the operator's local TZ. Two consequences worth knowing:
+ *
+ *   1. An event written at 2026-04-30T22:00 in UTC+8 (= 2026-05-01
+ *      local) lands in `*-2026-04.log`, not `*-2026-05.log`.
+ *      Operators grepping partition files by local date should
+ *      account for the offset — or use `pmk gateway audit --days N`
+ *      which works in absolute ms windows and doesn't care about
+ *      partition naming.
+ *   2. UTC is used so multi-host or cross-TZ deployments produce
+ *      the same partition file for the same wall-clock event.
+ *
+ * One JSON object per line; the writer adds an `at` ISO timestamp
+ * before stringify. Readers tolerate malformed lines so a single
+ * bad write doesn't poison the audit.
  *
  * Back-compat: legacy unpartitioned `<baseDir>/<prefix>.log` files
  * (the v0.10 scheme) are still **read** but no longer written. The
  * reader merges them in front of the partitioned files so an
  * operator who upgraded mid-month doesn't lose history.
+ *
+ * No eviction. Operators that want to prune old months can `rm`
+ * partition files manually; the reader silently skips missing
+ * months. Practical scale: ~100 events/day ≈ ~100KB/month
+ * uncompressed, so even 10 years is < 12 MB.
  */
 
 import * as fs from "node:fs";

--- a/packages/cli/src/gateway/monthly-jsonl.ts
+++ b/packages/cli/src/gateway/monthly-jsonl.ts
@@ -1,0 +1,178 @@
+/**
+ * Monthly-partitioned JSONL ledger for the gateway audit feeds
+ * (events.log + admin.log). Replaces the v0.10 single-file scheme
+ * which was unbounded.
+ *
+ * Files: `<baseDir>/<prefix>-YYYY-MM.log` (UTC month). One JSON
+ * object per line, the writer adds an `at` ISO timestamp before
+ * stringify. Readers tolerate malformed lines so a single bad write
+ * doesn't poison the audit.
+ *
+ * Back-compat: legacy unpartitioned `<baseDir>/<prefix>.log` files
+ * (the v0.10 scheme) are still **read** but no longer written. The
+ * reader merges them in front of the partitioned files so an
+ * operator who upgraded mid-month doesn't lose history.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface ReadJsonlOptions {
+  /**
+   * Lower bound on the line's `at` timestamp (ms since epoch). Lines
+   * before this are skipped at read time and partitions older than
+   * the matching month are skipped at file-open time.
+   */
+  sinceMs?: number;
+  /**
+   * Upper bound on how many months back to scan when `sinceMs` isn't
+   * given. Defaults to 12 — generous enough for "give me everything"
+   * audits without scanning years of partitions on long-lived hosts.
+   */
+  maxMonthsBack?: number;
+}
+
+/** Path to the partition for a given UTC month (defaults to now). */
+export function monthlyPath(
+  baseDir: string,
+  prefix: string,
+  d: Date = new Date(),
+): string {
+  const ym = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(
+    2,
+    "0",
+  )}`;
+  return path.join(baseDir, `${prefix}-${ym}.log`);
+}
+
+/**
+ * Path to the legacy unpartitioned file. Read-only — kept around so
+ * upgrades don't lose history but never written by this build.
+ */
+export function legacyMonolithPath(baseDir: string, prefix: string): string {
+  return path.join(baseDir, `${prefix}.log`);
+}
+
+/**
+ * Append one JSON object to the current-month partition. Writer
+ * stamps an ISO `at` field; caller payload fields override nothing
+ * because spread happens after `at` is set (callers shouldn't pass
+ * `at` themselves, but if they do their value wins, which preserves
+ * back-compat with the prior `appendGatewayEvent` shape).
+ *
+ * Best-effort: filesystem failures don't propagate, since blocking
+ * the gateway on a corrupt audit log would be worse than the
+ * missing line.
+ */
+export function appendJsonl(
+  baseDir: string,
+  prefix: string,
+  payload: object,
+): void {
+  try {
+    fs.mkdirSync(baseDir, { recursive: true });
+    const line =
+      JSON.stringify({ at: new Date().toISOString(), ...payload }) + "\n";
+    fs.appendFileSync(monthlyPath(baseDir, prefix), line, "utf8");
+  } catch {
+    /* non-fatal */
+  }
+}
+
+/**
+ * Read JSONL lines across legacy + monthly partitions, validated by
+ * the caller's predicate. Returns oldest-first (legacy lines, then
+ * partitions in chronological order).
+ *
+ * Predicate is required so each consumer keeps its own discriminated-
+ * union contract — the util doesn't know `MraAskEndEvent` from
+ * `AdminLogEntry`. Lines that fail JSON.parse OR the predicate are
+ * silently dropped.
+ */
+export function readJsonl<T>(
+  baseDir: string,
+  prefix: string,
+  predicate: (parsed: unknown) => parsed is T,
+  opts: ReadJsonlOptions = {},
+): T[] {
+  const out: T[] = [];
+
+  // Legacy unpartitioned file is always the oldest data.
+  const legacy = legacyMonolithPath(baseDir, prefix);
+  if (fs.existsSync(legacy)) {
+    pushParsedLines(legacy, predicate, opts.sinceMs, out);
+  }
+
+  // Decide the start month for partition scan.
+  const now = new Date();
+  let startYear: number;
+  let startMonth: number;
+  if (opts.sinceMs !== undefined) {
+    const since = new Date(opts.sinceMs);
+    startYear = since.getUTCFullYear();
+    startMonth = since.getUTCMonth();
+  } else {
+    const monthsBack = opts.maxMonthsBack ?? 12;
+    const back = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - monthsBack, 1),
+    );
+    startYear = back.getUTCFullYear();
+    startMonth = back.getUTCMonth();
+  }
+
+  // Walk months from start through the current UTC month inclusive.
+  let y = startYear;
+  let m = startMonth;
+  // Hard cap — a runaway loop here would be a bug but a defensive
+  // bound is cheap insurance against clock weirdness.
+  for (let i = 0; i < 240; i++) {
+    const file = monthlyPath(baseDir, prefix, new Date(Date.UTC(y, m, 1)));
+    if (fs.existsSync(file)) {
+      pushParsedLines(file, predicate, opts.sinceMs, out);
+    }
+    if (
+      y > now.getUTCFullYear() ||
+      (y === now.getUTCFullYear() && m >= now.getUTCMonth())
+    ) {
+      break;
+    }
+    m++;
+    if (m > 11) {
+      m = 0;
+      y++;
+    }
+  }
+
+  return out;
+}
+
+function pushParsedLines<T>(
+  file: string,
+  predicate: (v: unknown) => v is T,
+  sinceMs: number | undefined,
+  out: T[],
+): void {
+  let text: string;
+  try {
+    text = fs.readFileSync(file, "utf8");
+  } catch {
+    return;
+  }
+  for (const line of text.split("\n")) {
+    if (line.length === 0) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!predicate(parsed)) continue;
+    if (sinceMs !== undefined) {
+      const at = (parsed as { at?: unknown }).at;
+      if (typeof at !== "string") continue;
+      const t = Date.parse(at);
+      if (!Number.isFinite(t) || t < sinceMs) continue;
+    }
+    out.push(parsed);
+  }
+}

--- a/packages/cli/test/gateway-events.test.ts
+++ b/packages/cli/test/gateway-events.test.ts
@@ -314,4 +314,90 @@ describe("gateway events log (#24)", () => {
       .filter(Boolean);
     assert.deepEqual(recentActors, ["U_RECENT", "U_TODAY"]);
   });
+
+  // Review-prep for PR #47.
+
+  it("default no-sinceMs read covers ~12 months back; older partitions are skipped", async () => {
+    const { readJsonl, monthlyPath } = await import(
+      "../src/gateway/monthly-jsonl"
+    );
+    const gatewayDir = path.join(tmpHome, ".pmk", "gateway");
+    fs.mkdirSync(gatewayDir, { recursive: true });
+    const now = new Date();
+    const longAgo = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 13, 15),
+    );
+    const recently = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 15),
+    );
+    const writeAt = (file: string, ts: Date, marker: string) => {
+      fs.writeFileSync(
+        file,
+        JSON.stringify({ at: ts.toISOString(), kind: "test", marker }) + "\n",
+      );
+    };
+    writeAt(monthlyPath(gatewayDir, "events", longAgo), longAgo, "TOO_OLD");
+    writeAt(monthlyPath(gatewayDir, "events", recently), recently, "IN_WINDOW");
+
+    const isTestEntry = (v: unknown): v is { kind: string; marker: string } => {
+      const o = v as Record<string, unknown>;
+      return (
+        !!o &&
+        typeof o === "object" &&
+        o.kind === "test" &&
+        typeof o.marker === "string"
+      );
+    };
+    const got = readJsonl(gatewayDir, "events", isTestEntry);
+    const markers = got.map((e) => e.marker);
+    assert.ok(
+      markers.includes("IN_WINDOW"),
+      "in-window partition should be read",
+    );
+    assert.ok(
+      !markers.includes("TOO_OLD"),
+      "13-month-old partition should be skipped under the 12-month default",
+    );
+
+    const everything = readJsonl(gatewayDir, "events", isTestEntry, {
+      maxMonthsBack: 24,
+    });
+    const allMarkers = everything.map((e) => e.marker);
+    assert.ok(allMarkers.includes("TOO_OLD"));
+    assert.ok(allMarkers.includes("IN_WINDOW"));
+  });
+
+  it("legacy events.log with mixed valid + malformed lines: malformed are skipped, valid still parse", async () => {
+    const { readGatewayEvents } = await import("../src/gateway/events");
+    const gatewayDir = path.join(tmpHome, ".pmk", "gateway");
+    fs.mkdirSync(gatewayDir, { recursive: true });
+    const legacy = path.join(gatewayDir, "events.log");
+    const valid = JSON.stringify({
+      at: new Date().toISOString(),
+      type: "turn.processed",
+      actor: "U_VALID_LEGACY",
+      audience: "tech",
+      hadMraAsk: false,
+      atomsInjected: 0,
+    });
+    fs.writeFileSync(
+      legacy,
+      [
+        valid,
+        "this is not json — a partial write from a crashed process",
+        '{"truncated":',
+        valid.replace("U_VALID_LEGACY", "U_VALID_2"),
+      ].join("\n") + "\n",
+    );
+    const entries = readGatewayEvents();
+    assert.equal(entries.length, 2);
+    assert.equal(
+      entries[0].type === "turn.processed" && entries[0].actor,
+      "U_VALID_LEGACY",
+    );
+    assert.equal(
+      entries[1].type === "turn.processed" && entries[1].actor,
+      "U_VALID_2",
+    );
+  });
 });

--- a/packages/cli/test/gateway-events.test.ts
+++ b/packages/cli/test/gateway-events.test.ts
@@ -203,4 +203,115 @@ describe("gateway events log (#24)", () => {
     );
     fs.rmSync(blocking, { recursive: true, force: true });
   });
+
+  // v0.10.x: monthly partitioning + legacy fallback.
+
+  it("appendGatewayEvent writes to a YYYY-MM partition file, not the legacy events.log", async () => {
+    const { appendGatewayEvent, gatewayEventsPath } = await import(
+      "../src/gateway/events"
+    );
+    appendGatewayEvent({
+      type: "turn.processed",
+      actor: "U_PART",
+      audience: "tech",
+      hadMraAsk: false,
+      atomsInjected: 0,
+    });
+    const partition = gatewayEventsPath();
+    assert.match(
+      path.basename(partition),
+      /^events-\d{4}-\d{2}\.log$/,
+      "current-month partition path should be events-YYYY-MM.log",
+    );
+    assert.ok(fs.existsSync(partition), "partition file should be created");
+    const legacy = path.join(tmpHome, ".pmk", "gateway", "events.log");
+    assert.ok(
+      !fs.existsSync(legacy),
+      "legacy events.log should NOT be written by v0.10.x and beyond",
+    );
+  });
+
+  it("readGatewayEvents merges legacy events.log with the current-month partition", async () => {
+    const { appendGatewayEvent, readGatewayEvents } = await import(
+      "../src/gateway/events"
+    );
+    const gatewayDir = path.join(tmpHome, ".pmk", "gateway");
+    fs.mkdirSync(gatewayDir, { recursive: true });
+    const legacy = path.join(gatewayDir, "events.log");
+    fs.writeFileSync(
+      legacy,
+      JSON.stringify({
+        at: new Date().toISOString(),
+        type: "turn.processed",
+        actor: "U_LEGACY",
+        audience: "tech",
+        hadMraAsk: false,
+        atomsInjected: 0,
+      }) + "\n",
+    );
+    appendGatewayEvent({
+      type: "turn.processed",
+      actor: "U_NEW",
+      audience: "tech",
+      hadMraAsk: false,
+      atomsInjected: 0,
+    });
+    const entries = readGatewayEvents();
+    assert.equal(entries.length, 2);
+    assert.equal(
+      entries[0].type === "turn.processed" && entries[0].actor,
+      "U_LEGACY",
+    );
+    assert.equal(
+      entries[1].type === "turn.processed" && entries[1].actor,
+      "U_NEW",
+    );
+  });
+
+  it("readGatewayEvents reads across multiple month partitions and respects sinceMs", async () => {
+    const { readGatewayEvents } = await import("../src/gateway/events");
+    const { monthlyPath } = await import("../src/gateway/monthly-jsonl");
+    const gatewayDir = path.join(tmpHome, ".pmk", "gateway");
+    fs.mkdirSync(gatewayDir, { recursive: true });
+    const now = new Date();
+    const twoMonthsAgo = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 2, 15),
+    );
+    const oneMonthAgo = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 15),
+    );
+    const writeAt = (file: string, ts: Date, actor: string) => {
+      fs.writeFileSync(
+        file,
+        JSON.stringify({
+          at: ts.toISOString(),
+          type: "turn.processed",
+          actor,
+          audience: "tech",
+          hadMraAsk: false,
+          atomsInjected: 0,
+        }) + "\n",
+      );
+    };
+    writeAt(monthlyPath(gatewayDir, "events", twoMonthsAgo), twoMonthsAgo, "U_OLD");
+    writeAt(monthlyPath(gatewayDir, "events", oneMonthAgo), oneMonthAgo, "U_RECENT");
+    writeAt(monthlyPath(gatewayDir, "events", now), now, "U_TODAY");
+
+    const all = readGatewayEvents();
+    const actors = all
+      .filter((e) => e.type === "turn.processed")
+      .map((e) => e.type === "turn.processed" && e.actor)
+      .filter(Boolean);
+    assert.deepEqual(actors, ["U_OLD", "U_RECENT", "U_TODAY"]);
+
+    const cutoff = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1),
+    ).getTime();
+    const recent = readGatewayEvents({ sinceMs: cutoff });
+    const recentActors = recent
+      .filter((e) => e.type === "turn.processed")
+      .map((e) => e.type === "turn.processed" && e.actor)
+      .filter(Boolean);
+    assert.deepEqual(recentActors, ["U_RECENT", "U_TODAY"]);
+  });
 });

--- a/packages/cli/test/gateway.test.ts
+++ b/packages/cli/test/gateway.test.ts
@@ -1744,6 +1744,46 @@ describe("admin-log (#31)", () => {
     });
     fs.rmSync(blocking, { recursive: true, force: true });
   });
+
+  it("admin.log writes go to a YYYY-MM partition; legacy admin.log is read-only", async () => {
+    const { appendAdminLog, readAdminLog, adminLogPath } = await import(
+      "../src/gateway/admin-log"
+    );
+    const gatewayDir = path.join(tmpHome, ".pmk", "gateway");
+    fs.mkdirSync(gatewayDir, { recursive: true });
+    // Drop a legacy v0.10-era line that pre-dates partitioning.
+    const legacy = path.join(gatewayDir, "admin.log");
+    fs.writeFileSync(
+      legacy,
+      JSON.stringify({
+        at: new Date().toISOString(),
+        actor: "U_LEGACY",
+        origin: "cli",
+        action: "audience.list",
+        ok: true,
+      }) + "\n",
+    );
+    // New write goes to the partition file, not the legacy one.
+    appendAdminLog({
+      actor: "U_NEW",
+      origin: "slack",
+      action: "audience.list",
+      ok: true,
+    });
+    assert.match(
+      path.basename(adminLogPath()),
+      /^admin-\d{4}-\d{2}\.log$/,
+      "current-month partition path",
+    );
+    // Legacy file untouched (still 1 line).
+    const legacyLines = fs.readFileSync(legacy, "utf8").trim().split("\n");
+    assert.equal(legacyLines.length, 1);
+    // Reader merges both — legacy line first (oldest tier), partition second.
+    const all = readAdminLog();
+    assert.equal(all.length, 2);
+    assert.equal(all[0].actor, "U_LEGACY");
+    assert.equal(all[1].actor, "U_NEW");
+  });
 });
 
 describe("Slack admin handler (#31)", () => {


### PR DESCRIPTION
Closes the v0.10.x `events.log` unbounded-growth TODO (events.ts:25). The original single-file scheme noted ~1MB/year at single-host workloads — acceptable then, but PR #45 just added presence events on every gateway start/stop/suppression which raises the rate, and `admin.log` has the same gap. Same lift covers both, via a shared util.

## Layout change

```
write path  →  ~/.pmk/gateway/events-YYYY-MM.log     (UTC month)
               ~/.pmk/gateway/admin-YYYY-MM.log

read path   →  walk legacy single-file (events.log / admin.log)
               first if present, then partitions in chrono order
```

Legacy single-file ledgers from v0.10 are **read-only** — never written by this build, but never deleted either, so a host that upgrades mid-month doesn't lose history. The reader merges both tiers; the audit consumer sees one continuous chronologically-ordered stream.

## New shared util

`packages/cli/src/gateway/monthly-jsonl.ts` exposes:
- `monthlyPath(baseDir, prefix, d?)` — partition path helper
- `legacyMonolithPath(baseDir, prefix)` — pre-partition file
- `appendJsonl(baseDir, prefix, payload)` — best-effort write
- `readJsonl(baseDir, prefix, predicate, opts)` — reads across tiers

Both `events.ts` and `admin-log.ts` now defer to this util; their internals shrink to ~10 lines each. Exported `gatewayEventsPath()` / `adminLogPath()` are preserved for tests + tail-style debug, but they now return the **current month's partition** (moves on UTC month boundaries).

## Tests

274 → **278** (+4):
- partition file matches `/^events-\d{4}-\d{2}\.log$/`; legacy never written
- reader merges legacy `events.log` with current partition, oldest first
- multi-month aggregation walks 3 partitions in order; `sinceMs` cuts off the oldest entirely
- admin-log mirrors the same behaviour with its own legacy `admin.log`

## No API surface change

Consumers (`audit.ts`, `commands/gateway.ts auditCmd`, `slack/admin.ts handleAdminAudit`) keep calling `readGatewayEvents()` / `readAdminLog()` with the same shapes — only the on-disk layout moved.

## Test plan
- [x] All cli/rag/desktop tests green: 274 → 278 pass, 0 fail
- [x] Type-check passes after refactor
- [x] Predicate validation rejects malformed lines (existing tests)
- [x] Both packages' write paths exit cleanly when filesystem is unwritable (existing best-effort tests)
- [ ] Manual: `pmk gateway audit --days 7` after first month boundary on a real host (deferred to v0.11.0 close)

## Operator note for v0.11.0 release

Existing `events.log` / `admin.log` files keep being read forever; the next gateway start writes new lines to `events-YYYY-MM.log` / `admin-YYYY-MM.log` partitions for the current UTC month. Operators tailing the live feed should update their command — `tail -f $(node -e 'console.log(...)')` patterns or rerun `pmk gateway audit` directly.