### PR TITLE
docs(release): v0.11.0 prep — migration page + changelog draft (DRAFT)

### DIFF
--- a/apps/docs/docs/changelog.md
+++ b/apps/docs/docs/changelog.md
@@ -37,7 +37,7 @@ See the [v0.11 migration notes](./gateway/v0.11-migration.md) for a focused oper
 
 ### Tests
 
-247 → **TBD** (final count depends on which review-prep commits land). Major additions:
+248 → **TBD** (final count depends on which review-prep commits land). Major additions:
 - Heartbeat marker decision matrix (5 branches: first boot, marker fresh, marker stale, no-marker fresh heartbeat, no-marker stale heartbeat) + corrupt-marker safety + upgrade-migration story
 - `runWithConcurrency` (4 cases: empty list, peak in-flight respected, single-task rejection isolated, limit > task count)
 - `pickAudience` channel tier (5 cases: channel applies absent user, per-user beats channel, fall-through, undefined channelId, back-fill on old config) + empty-string channelId guard

--- a/apps/docs/docs/changelog.md
+++ b/apps/docs/docs/changelog.md
@@ -8,6 +8,48 @@ All notable changes to **pm-workspace-kit** are documented here.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each release also has a longer narrative on [GitHub Releases](https://github.com/hanfour/pm-workspace-kit/releases) with rationale, dogfood notes, and test plans.
 
+## [v0.11.0] — TBD — gateway presence + per-channel audience + monthly audit logs (DRAFT)
+
+> **DRAFT** — fill in the date + GitHub release link at tag time. Underlying PRs are merged but not yet released.
+
+[GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.11.0) · closes [#23](https://github.com/hanfour/pm-workspace-kit/issues/23), [#44](https://github.com/hanfour/pm-workspace-kit/issues/44) · milestone [v0.11](https://github.com/hanfour/pm-workspace-kit/milestone/8)
+
+### Why
+
+Two issue-driven items plus one v0.10.x debt cleanup, sized to ship as one minor release:
+- **#44** — kill→restart cycles broadcast spurious "重新上線" (live-observed during v0.10.0 verification).
+- **#23** — `pickAudience` had no channel tier, forcing per-user overrides for "this channel defaults to exec" cases.
+- **events.log unbounded growth TODO** from v0.10 — bumped in priority because #44 adds presence events on every start/stop.
+
+See the [v0.11 migration notes](./gateway/v0.11-migration.md) for a focused operator-facing summary of the layout + behaviour changes.
+
+### Added
+
+- **Per-channel audience override** ([#23](https://github.com/hanfour/pm-workspace-kit/issues/23)) — new `cfg.audience.channels: Record<channelId, AudienceKey>` tier between per-user and workspace default. CLI: `pmk gateway audience set-channel <channelId> <key>` / `unset-channel`. Slack admin: `/pmk admin audience set-channel #channel <key>` / `unset-channel`. `extractChannelId` helper handles `<#C0X|name>` mention, `<#C0X>` bare mention, and raw `C0X` / `G0X` / `D0X` IDs. Resolution order at turn time: per-user → per-channel → workspace default.
+- **Graceful-shutdown marker** ([#44](https://github.com/hanfour/pm-workspace-kit/issues/44)) — single-use file at `~/.pmk/gateway/shutdown-marker` written on `SIGTERM`/`SIGINT`. The next `startHeartbeat()` reads + consumes it to distinguish "kill -> restart" from a real crash; `wasOffline=false` and the back-online broadcast is suppressed when the offline gap is under 5 minutes.
+- **Presence event types in `events.log`** ([#44](https://github.com/hanfour/pm-workspace-kit/issues/44)) — `gateway.online` and `gateway.offline` join the JSONL stream with monotonic per-process `seq`, human-readable `reason` (`crash-recovery` / `graceful-fast-restart` / `graceful-long-downtime` / `shutdown`), `broadcast` bool, and `offlineDurationMs`. Lets the audit detect rapid restart cycles and the graceful-vs-crash split.
+- **Monthly-partitioned JSONL ledger** (PR #47) — new `packages/cli/src/gateway/monthly-jsonl.ts` shared util powers both `events.log` and `admin.log`. Files are now `~/.pmk/gateway/events-YYYY-MM.log` / `admin-YYYY-MM.log` (UTC month). Legacy single-file ledgers from v0.10 are still read-only-merged so upgrades don't lose history. No eviction — operators can `rm` ancient partitions manually; the reader silently skips missing months.
+
+### Fixed
+
+- **Restart-cycle broadcast spam** ([#44](https://github.com/hanfour/pm-workspace-kit/issues/44)) — heartbeat is no longer deleted on graceful shutdown (it stays for `offlineDurationMs` accounting), and `broadcastBackOnline()` checks the gap before posting. The same change exposes the issue's secondary symptom: `broadcast()`'s O(N) serial fan-out is now `runWithConcurrency(limit=3)`, finishing in seconds instead of 20+ s and isolating per-recipient errors. Live-Slack verified: a 1.3-second graceful restart records `gateway.online ... broadcast:false offlineDurationMs:1332` and the channel sees no spurious "重新上線" message.
+- **`events.log` unbounded growth** (v0.10.x debt) — closed by the monthly partitioning above.
+
+### Tests
+
+247 → **TBD** (final count depends on which review-prep commits land). Major additions:
+- Heartbeat marker decision matrix (5 branches: first boot, marker fresh, marker stale, no-marker fresh heartbeat, no-marker stale heartbeat) + corrupt-marker safety + upgrade-migration story
+- `runWithConcurrency` (4 cases: empty list, peak in-flight respected, single-task rejection isolated, limit > task count)
+- `pickAudience` channel tier (5 cases: channel applies absent user, per-user beats channel, fall-through, undefined channelId, back-fill on old config) + empty-string channelId guard
+- `/pmk admin audience set-channel` / `unset-channel` end-to-end (mention wrapping, raw ID, garbage rejection, round-trip)
+- Monthly partitioning (current-month write + legacy NOT written, legacy + partition merge order, multi-month aggregation with `sinceMs` cutoff, default 12-month window, legacy mixed-content malformed-line skip, admin-log mirror)
+
+### Operator note
+
+Zero migration. All schema changes are additive and back-fill-compatible. **First kill→restart after upgrade still broadcasts "重新上線" once** — the v0.10 gateway shut down without writing a marker, so the v0.11 build correctly treats it as a fresh boot. From the second graceful restart onward, suppression works.
+
+For tail-style debugging, switch from `tail -f ~/.pmk/gateway/events.log` to `tail -f ~/.pmk/gateway/events-$(date -u +%Y-%m).log` (note the `-u` for UTC, since partitions roll on UTC month boundaries).
+
 ## [v0.10.1] — 2026-05-05 — workspace version sync + mra stdout cap
 
 [GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.10.1)

--- a/apps/docs/docs/changelog.md
+++ b/apps/docs/docs/changelog.md
@@ -8,9 +8,7 @@ All notable changes to **pm-workspace-kit** are documented here.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each release also has a longer narrative on [GitHub Releases](https://github.com/hanfour/pm-workspace-kit/releases) with rationale, dogfood notes, and test plans.
 
-## [v0.11.0] — TBD — gateway presence + per-channel audience + monthly audit logs (DRAFT)
-
-> **DRAFT** — fill in the date + GitHub release link at tag time. Underlying PRs are merged but not yet released.
+## [v0.11.0] — 2026-05-05 — gateway presence + per-channel audience + monthly audit logs
 
 [GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.11.0) · closes [#23](https://github.com/hanfour/pm-workspace-kit/issues/23), [#44](https://github.com/hanfour/pm-workspace-kit/issues/44) · milestone [v0.11](https://github.com/hanfour/pm-workspace-kit/milestone/8)
 
@@ -37,12 +35,16 @@ See the [v0.11 migration notes](./gateway/v0.11-migration.md) for a focused oper
 
 ### Tests
 
-248 → **TBD** (final count depends on which review-prep commits land). Major additions:
+248 → **274** (+26 across `@pmk/cli`). Major additions:
 - Heartbeat marker decision matrix (5 branches: first boot, marker fresh, marker stale, no-marker fresh heartbeat, no-marker stale heartbeat) + corrupt-marker safety + upgrade-migration story
 - `runWithConcurrency` (4 cases: empty list, peak in-flight respected, single-task rejection isolated, limit > task count)
 - `pickAudience` channel tier (5 cases: channel applies absent user, per-user beats channel, fall-through, undefined channelId, back-fill on old config) + empty-string channelId guard
 - `/pmk admin audience set-channel` / `unset-channel` end-to-end (mention wrapping, raw ID, garbage rejection, round-trip)
 - Monthly partitioning (current-month write + legacy NOT written, legacy + partition merge order, multi-month aggregation with `sinceMs` cutoff, default 12-month window, legacy mixed-content malformed-line skip, admin-log mirror)
+
+Plus a new **`@pmk/shared`** test surface (was 0 → **24**): shape-based snapshot tests covering `BASE_RULES`, all four audience prompts, `pickGatewayPrompt` round-trip, `AUDIENCE_KEYS`, `PROMPTS` map coverage, and `DEFAULT_CONFIG` shape.
+
+Total across the workspace: 274 → **324** pass, 0 fail.
 
 ### Operator note
 

--- a/apps/docs/docs/gateway/v0.11-migration.md
+++ b/apps/docs/docs/gateway/v0.11-migration.md
@@ -21,7 +21,7 @@ Operator-facing summary of what changes when you upgrade `pmk gateway` from v0.1
 
 | Path | Purpose | Lifetime |
 |---|---|---|
-| `~/.pmk/gateway/shutdown-marker` | Single-use marker dropped on graceful shutdown so the next start can suppress a spurious "重新上線" broadcast (PR #45) | Written on `kill -TERM`, deleted on next `gateway start` |
+| `~/.pmk/gateway/shutdown-marker` | Single-use marker dropped on graceful shutdown so the next start can suppress a spurious "重新上線" broadcast (PR #45) | Written on `SIGTERM` / `SIGINT` (any graceful shutdown), deleted on next `gateway start` |
 | `~/.pmk/gateway/events-YYYY-MM.log` | Monthly partition of the structured event ledger. Replaces single-file `events.log` (PR #47) | Append-only; a new file appears at each UTC month boundary |
 | `~/.pmk/gateway/admin-YYYY-MM.log` | Same scheme for `/pmk admin` audit trail | Same |
 

--- a/apps/docs/docs/gateway/v0.11-migration.md
+++ b/apps/docs/docs/gateway/v0.11-migration.md
@@ -62,6 +62,8 @@ pmk gateway audience unset-channel C0AVD1XD946
 
 `pmk gateway audience list` and `/pmk admin audience list` now display per-channel overrides alongside per-user.
 
+> **Caveat (pre-existing, not v0.11-specific):** `pmk gateway` reads `~/.pmk/gateway.json` once at startup and keeps it in memory for the life of the process. Running `audience set / unset / set-channel / unset-channel` writes the change to disk, but the live gateway keeps using its in-memory copy until the next graceful restart. After mutating audience config, run `kill $(cat ~/.pmk/gateway/gateway.pid) && nohup pmk gateway start &` — the v0.11 marker mechanism keeps the restart silent in Slack as long as it lands within 5 minutes. Surfaced during v0.11 integration verification on 2026-05-05; caveat applies equally to v0.10.x.
+
 ### 3. Concurrent broadcast fan-out
 
 `broadcastOffline` / `broadcastBackOnline` previously awaited each `chat.postMessage` in series — 20+ seconds for ~24 recipients, vulnerable to mid-flight SIGTERM leaving a half-finished broadcast. v0.11 uses `runWithConcurrency(limit=3)`, finishing in seconds. Errors per recipient stay isolated, so one kicked bot doesn't abort the rest.
@@ -84,6 +86,7 @@ Two new entries join `mra-ask.end`, `turn.processed`, `escalate.triggered`, `esc
 2. **First restart after upgrade:** the v0.10 gateway already shut down (and ran `clearHeartbeat()`), so the new build sees no marker — first start still broadcasts `重新上線` once. From the second graceful restart onward, suppression works.
 3. **Existing audit log readers** (`pmk gateway audit`) Just Work — they merge legacy `events.log` with the new monthly partitions and present one stream.
 4. **Tail-style debugging:** use `tail -f ~/.pmk/gateway/events-$(date -u +%Y-%m).log` instead of the v0.10 `tail -f ~/.pmk/gateway/events.log`. Note the `-u` (UTC) — partitions roll over at UTC midnight, not local TZ.
+5. **Config mutations need a graceful restart** — every `pmk gateway audience` / `pmk gateway escalation` / `pmk gateway admin` / `/pmk admin …` write goes to `~/.pmk/gateway.json`, but the running daemon keeps its in-memory snapshot. Restart with `kill $(cat ~/.pmk/gateway/gateway.pid) && nohup pmk gateway start &`; the marker mechanism makes restart silent in Slack within the 5-minute window.
 
 ## Audit log paths
 

--- a/apps/docs/docs/gateway/v0.11-migration.md
+++ b/apps/docs/docs/gateway/v0.11-migration.md
@@ -1,0 +1,108 @@
+---
+sidebar_position: 2
+---
+
+# v0.11 migration notes
+
+Operator-facing summary of what changes when you upgrade `pmk gateway` from v0.10.x to v0.11.0. Three PRs land together: [#45](https://github.com/hanfour/pm-workspace-kit/pull/45) (graceful-restart suppression), [#46](https://github.com/hanfour/pm-workspace-kit/pull/46) (per-channel audience), [#47](https://github.com/hanfour/pm-workspace-kit/pull/47) (monthly-partitioned audit logs). Closes [#23](https://github.com/hanfour/pm-workspace-kit/issues/23) and [#44](https://github.com/hanfour/pm-workspace-kit/issues/44).
+
+## TL;DR
+
+```
+✅ Zero config changes required.
+✅ Existing ~/.pmk/gateway.json is back-fill-compatible.
+✅ Existing ~/.pmk/gateway/{events,admin}.log are still readable.
+⚠️  First kill→restart after upgrade still broadcasts "重新上線" once
+    (no marker present from the old code). All subsequent graceful
+    restarts within 5 minutes are silent.
+```
+
+## New runtime files
+
+| Path | Purpose | Lifetime |
+|---|---|---|
+| `~/.pmk/gateway/shutdown-marker` | Single-use marker dropped on graceful shutdown so the next start can suppress a spurious "重新上線" broadcast (PR #45) | Written on `kill -TERM`, deleted on next `gateway start` |
+| `~/.pmk/gateway/events-YYYY-MM.log` | Monthly partition of the structured event ledger. Replaces single-file `events.log` (PR #47) | Append-only; a new file appears at each UTC month boundary |
+| `~/.pmk/gateway/admin-YYYY-MM.log` | Same scheme for `/pmk admin` audit trail | Same |
+
+The legacy `events.log` / `admin.log` files from v0.10 are still **read** by `pmk gateway audit` — never written by v0.11, never deleted automatically. You can keep them in place, archive them, or `rm` once you no longer need the old history.
+
+## Behaviour changes
+
+### 1. Graceful restart no longer spams "重新上線"
+
+**Before (v0.10):** every `kill → restart` cycle, even one within 3 seconds, broadcast `pmk gateway 暫離` and then `pmk gateway 重新上線` to every channel and DM with recent activity. Restart-heavy debugging sessions stacked notices out of order in Slack.
+
+**After (v0.11):** graceful restart writes a `shutdown-marker` with the kill timestamp. The next start reads the marker, computes `offlineDurationMs`, and **suppresses** the back-online broadcast if the gap is < 5 minutes. The transition is still recorded in `events.log` as `gateway.online ... broadcast: false` so an operator running `pmk gateway audit` can see it.
+
+A genuine crash (process killed without a graceful path, machine slept, etc.) leaves no marker — the next start treats it as a real downtime and broadcasts normally. Distinction is recorded as `reason: "crash-recovery"` vs `"graceful-fast-restart"` on the event.
+
+### 2. Per-channel audience override
+
+`pickAudience` resolution chain now has three tiers (was two):
+
+```
+pickAudience(cfg, userId, channelId?)
+  1. cfg.audience.users[userId]       — explicit per-user override (unchanged)
+  2. cfg.audience.channels[channelId] — channel default (NEW)
+  3. cfg.audience.default             — workspace default
+```
+
+Per-user always wins. Channel default lets you say "everyone in `#leadership` defaults to `exec`" without writing 12 individual user overrides. Configure either way:
+
+```bash
+# CLI
+pmk gateway audience set-channel C0AVD1XD946 exec
+pmk gateway audience unset-channel C0AVD1XD946
+
+# Slack
+/pmk admin audience set-channel #leadership exec
+/pmk admin audience unset-channel #leadership
+```
+
+`pmk gateway audience list` and `/pmk admin audience list` now display per-channel overrides alongside per-user.
+
+### 3. Concurrent broadcast fan-out
+
+`broadcastOffline` / `broadcastBackOnline` previously awaited each `chat.postMessage` in series — 20+ seconds for ~24 recipients, vulnerable to mid-flight SIGTERM leaving a half-finished broadcast. v0.11 uses `runWithConcurrency(limit=3)`, finishing in seconds. Errors per recipient stay isolated, so one kicked bot doesn't abort the rest.
+
+### 4. New event types in `events.log`
+
+Two new entries join `mra-ask.end`, `turn.processed`, `escalate.triggered`, `escalate.absorbed`:
+
+```jsonl
+{"at":"2026-05-05T03:22:50.409Z","type":"gateway.online","seq":1,"reason":"crash-recovery","broadcast":true}
+{"at":"2026-05-05T03:24:23.850Z","type":"gateway.offline","seq":2,"reason":"shutdown","broadcast":true}
+{"at":"2026-05-05T04:46:25.773Z","type":"gateway.online","seq":1,"reason":"graceful-fast-restart","broadcast":false,"offlineDurationMs":1332}
+```
+
+`seq` is monotonic per process (resets each gateway start). `broadcast: false` means the suppression kicked in. Future `pmk gateway audit` releases will surface a "presence churn" section based on these.
+
+## Upgrade checklist
+
+1. **Upgrade your binary:** `git pull && npm run cli:build` (no schema migration needed).
+2. **First restart after upgrade:** the v0.10 gateway already shut down (and ran `clearHeartbeat()`), so the new build sees no marker — first start still broadcasts `重新上線` once. From the second graceful restart onward, suppression works.
+3. **Existing audit log readers** (`pmk gateway audit`) Just Work — they merge legacy `events.log` with the new monthly partitions and present one stream.
+4. **Tail-style debugging:** use `tail -f ~/.pmk/gateway/events-$(date -u +%Y-%m).log` instead of the v0.10 `tail -f ~/.pmk/gateway/events.log`. Note the `-u` (UTC) — partitions roll over at UTC midnight, not local TZ.
+
+## Audit log paths
+
+For scripts that consume the audit logs directly (rare — most operators use `pmk gateway audit`):
+
+```bash
+# Glob for "all events ever"
+~/.pmk/gateway/events.log               # legacy v0.10 monolith (read-only after upgrade)
+~/.pmk/gateway/events-*.log              # v0.11 partitions
+
+# Same for admin
+~/.pmk/gateway/admin.log
+~/.pmk/gateway/admin-*.log
+```
+
+Both paths must be unioned for a complete audit. The shipped `readGatewayEvents()` / `readAdminLog()` functions handle this for you.
+
+## See also
+
+- [Gateway lifecycle](./lifecycle.md) — end-to-end flow of a single DM
+- [Changelog](../changelog.md) — release-by-release narrative
+- Issue [#23](https://github.com/hanfour/pm-workspace-kit/issues/23) and [#44](https://github.com/hanfour/pm-workspace-kit/issues/44) — the bugs / feature requests this milestone closes


### PR DESCRIPTION
**DRAFT — merge ONLY at v0.11.0 tag time**, after #45 / #46 / #47 land.

Pre-stages release docs so they don't have to be written under release-day pressure.

## Files

1. `apps/docs/docs/gateway/v0.11-migration.md` — new operator-facing migration page covering:
   - New runtime files (`shutdown-marker`, `events-YYYY-MM.log`, `admin-YYYY-MM.log`)
   - Behaviour changes (graceful-restart suppression, per-channel audience, concurrent broadcast, presence event types)
   - Upgrade checklist with the "first kill→restart after upgrade still broadcasts once" footnote made explicit so it doesn't surprise operators
   - Audit log path globs for scripts that read the logs directly
   - Caveat: config mutations (`audience` / `escalation` / `admin`) need a graceful restart (pre-existing v0.10.x behaviour, not a v0.11 regression — surfaced during integration verify)
2. `apps/docs/docs/changelog.md` — v0.11.0 entry above v0.10.1, follows the established 3-section format. Marked DRAFT inline. Date, final test count, and test-delta numbers all filled in at tag time once the three feature PRs (#45 / #46 / #47) land and merge.

## Why draft

The CHANGELOG entry references the GitHub release URL (`/releases/tag/v0.11.0`) which doesn't exist yet. Merging this PR before tag time would publish a 404 on GitHub Pages. Per the established release flow:

1. Merge #45 / #46 / #47 (any order, all independent). #45 / #46 / #47 are **open and pending review**.
2. Merge #49 (shared snapshot tests, independent quick-win).
3. Run live-Slack verification on main (per release workflow memory).
4. **Then** edit this PR — flip status from DRAFT to ready, fill in the date, final test count, and final test delta (see explicit checklist below).
5. Merge this PR.
6. `npm run version:bump 0.11.0` (the script added in v0.10.1) → commit on main.
7. Tag v0.11.0 + push tag + `gh release create v0.11.0 --notes-file <derived from CHANGELOG entry>`.

## Test plan

- [x] `npm --workspace apps/docs run build` exits with `[SUCCESS]` on both `en` and `zh-TW` outputs (pre-existing LICENSE.txt broken-link warnings are unrelated)
- [x] No code changes, no schema changes — markdown only
- [x] Self-review pass applied (test-count baseline corrected 247 → 248; SIGTERM/SIGINT precision in marker-lifetime row)
- [ ] **At tag time — Replace TBD placeholders** (do NOT merge until all four are filled in):
  - [ ] CHANGELOG header date `## [v0.11.0] — TBD —` → actual ISO date
  - [ ] CHANGELOG `### Tests` baseline + delta `248 → **TBD**` → actual final cli count + workspace total
  - [ ] CHANGELOG release link `https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.11.0` — confirm it returns 200 (the `gh release create` step in release sequence creates this URL)
  - [ ] Strip the inline `> **DRAFT** — fill in …` callout under the v0.11.0 header