### PR TITLE
v0.11.1: gateway msg_too_long hardening

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmk/desktop",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "description": "Desktop app for pm-workspace-kit — Electron + Vite + React",
   "license": "MIT",

--- a/apps/docs/docs/changelog.md
+++ b/apps/docs/docs/changelog.md
@@ -8,6 +8,42 @@ All notable changes to **pm-workspace-kit** are documented here.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each release also has a longer narrative on [GitHub Releases](https://github.com/hanfour/pm-workspace-kit/releases) with rationale, dogfood notes, and test plans.
 
+## [v0.11.1] — 2026-05-07 — gateway `msg_too_long` hardening
+
+### Why
+
+A live Slack thread on 2026-05-07 returned `pmk 內部錯誤：An API error occurred: msg_too_long` after several `mra-ask` rounds. Root-cause analysis surfaced four issues and v0.11.1 layers defenses against all of them so the failure mode does not reach production users again. See [`apps/docs/docs/plans/2026-05-07-gateway-msg-too-long-hardening.md`](./plans/2026-05-07-gateway-msg-too-long-hardening.md) for the full design spec, and `2026-05-07-gateway-msg-too-long-hardening-implementation.md` for the per-task TDD plan.
+
+### Fixed
+
+- **`msg_too_long` no longer reaches end users.** Three layered defenses:
+  - (a) `pruneSessionIfNeeded` now runs **before** the LLM call (was after — closed a fail-loop introduced in v0.8.1 where a session over budget could never recover because prune only fired after a successful call).
+  - (b) The PKB seed and `mra-ask` results are capped at write-time so a single bloated message cannot single-handedly exhaust the input window.
+  - (c) Any residual `msg_too_long` triggers a typed `PmkContextTooLongError`, an automatic `forcePruneToMinimum`, and a retry. The reply is prefixed with `:scissors: 對話過長，已自動裁掉 N 輪舊訊息` so users know context was trimmed. Hard failure (both calls reject) shows `:x: 對話太長，請開新 thread 重新提問` instead of the raw API error.
+
+### Changed
+
+- `PMK_MAX_SESSION_TOKENS` default lowered 60_000 → 25_000 to leave headroom for system prompt, retrieval prefix, the SDK-inherited host context (`claude-agent-sdk` spawns the local `claude` CLI, which inherits `~/.claude/` skills/hooks/MCP descriptions), the new turn, and the model's reply.
+
+### Added
+
+- New env vars `PMK_SEED_CAP` (default 12_000 chars) and `PMK_MRA_RESULT_CAP` (default 16_000 chars) for per-host tuning. The previously-hardcoded 24_000-char `mra-ask` truncation in `buildMraSuccessMessage` is replaced by `PMK_MRA_RESULT_CAP`.
+- New event types in `events-YYYY-MM.log`: `context.exceeded` (with `phase: "first-call" | "synthesise"`), `context.force-pruned`, `message.capped` (with `kind: "seed" | "mra-result"`).
+- `pmk gateway audit` gains a `Context safety` section rolling up the new events. Tighten the `*_CAP` env vars if `context.exceeded` appears in your weekly audit.
+- Helper `chatWithContextRetry` extracted to `packages/cli/src/gateway/slack/context-retry.ts` so the retry+force-prune+events pattern is unit-testable in isolation (no `SlackGateway` integration harness needed) and reused at both LLM call sites (`runFreeChatTurn` first-call, `synthesiseAfterMra` mra-ask round).
+
+### Tests
+
+`@pmk/cli` 274 → **304** (+30): unit coverage for `capMessageContent`, `forcePruneToMinimum`, `pruneSessionIfNeeded` extras-aware budgeting, `approxTokensFor` with `extra` param, `PmkContextTooLongError` detection, the six-discriminant `chatWithContextRetry` (happy / non-context error / context-then-success-with-scissors / context-then-fail / `dropped=0` degenerate / `phase=synthesise` audit), audit `contextSafety` rollup, formatter `Context safety` section non-zero + zero-count rendering, and the three new event-type round-trip in `gateway-events.test.ts`.
+
+The seed-cap and mra-result-cap wiring sites in `slack/index.ts` and the `runFreeChatTurn` retry-prefix wiring rely on the constituent helpers' unit tests + manual verification (no `SlackGateway` integration harness in this release; tracked as a follow-up).
+
+### Forward-looking
+
+v0.12 is planned to switch the gateway provider from `claude-agent-sdk` to `anthropic-api`, removing the SDK-inherited host-context as a budget unknown. The cap mechanism from v0.11.1 stays; only the budgets relax toward the model's true context window. See the v0.12 stub at the end of the v0.11.1 design spec.
+
+---
+
 ## [v0.11.0] — 2026-05-05 — gateway presence + per-channel audience + monthly audit logs
 
 [GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.11.0) · closes [#23](https://github.com/hanfour/pm-workspace-kit/issues/23), [#44](https://github.com/hanfour/pm-workspace-kit/issues/44) · milestone [v0.11](https://github.com/hanfour/pm-workspace-kit/milestone/8)

--- a/apps/docs/docs/gateway/v0.11-migration.md
+++ b/apps/docs/docs/gateway/v0.11-migration.md
@@ -104,6 +104,70 @@ For scripts that consume the audit logs directly (rare — most operators use `p
 
 Both paths must be unioned for a complete audit. The shipped `readGatewayEvents()` / `readAdminLog()` functions handle this for you.
 
+## v0.11.1: context-safety hardening (additive)
+
+No breaking changes. Operator-facing additions on top of v0.11.0.
+
+### Env vars
+
+| Env var | Default | What it caps |
+|---|---|---|
+| `PMK_MAX_SESSION_TOKENS` | `25000` (was `60000`) | Soft session-prune budget. Lower if your host has a heavy `~/.claude/` config (lots of skills/hooks/MCP servers) — that overhead is inherited every time `claude-agent-sdk` spawns the local CLI. |
+| `PMK_SEED_CAP` | `12000` | Maximum chars in the PKB ingest seed pushed at session start. |
+| `PMK_MRA_RESULT_CAP` | `16000` | Maximum chars in any `mra-ask` stdout pushed into session history. Replaces the prior hardcoded 24_000 in `buildMraSuccessMessage`. |
+
+### New event types in `events-YYYY-MM.log`
+
+JSONL lines (synthetic samples — `actor: "U…"` is a redacted Slack user ID; `at` is ISO-8601):
+
+```jsonl
+{"at":"…","type":"context.exceeded","actor":"U…","sessionTokensBefore":31578,"retrievalAtoms":1,"phase":"first-call"}
+{"at":"…","type":"context.force-pruned","actor":"U…","droppedPairs":4,"tokensAfter":1200}
+{"at":"…","type":"message.capped","actor":"U…","kind":"seed","originalChars":88292,"cappedChars":12000}
+```
+
+`phase` is `"first-call"` or `"synthesise"`; `kind` is `"seed"` or `"mra-result"`.
+
+### `pmk gateway audit` — new `Context safety` section
+
+Always rendered (even when all counts are zero, so an operator can see the safety net is in place):
+
+```
+Context safety
+  context.exceeded:              0 (first-call 0, synthesise 0)
+  force-pruned:                  0
+  messages capped:               0 (seed 0, mra-result 0)
+```
+
+If `context.exceeded` is non-zero in your weekly audit, the cap defaults are too loose for your host — tighten `PMK_MAX_SESSION_TOKENS` first, then `PMK_SEED_CAP` / `PMK_MRA_RESULT_CAP`.
+
+### User-visible Slack changes
+
+When `msg_too_long` does fire and the auto-retry recovers, the user sees a one-line scissors prefix on the reply:
+
+```
+:scissors: 對話過長，已自動裁掉 N 輪舊訊息
+
+<the actual answer>
+```
+
+When even the auto-retry fails (extremely rare — single message larger than the model can take after force-prune), the user sees:
+
+```
+:x: 對話太長，請開新 thread 重新提問
+```
+
+Both replace the prior raw `pmk 內部錯誤：An API error occurred: msg_too_long` leak.
+
+### Upgrade checklist (v0.11.0 → v0.11.1)
+
+1. `git pull && npm run cli:build` — no schema migration needed.
+2. Existing sessions on disk: nothing to do. Pre-existing oversized messages stay as-is; the new caps apply going forward at write-time.
+3. Tail the new event types: `tail -f ~/.pmk/gateway/events-$(date -u +%Y-%m).log | grep -E 'context\.|message\.capped'`.
+4. After a week, run `pmk gateway audit --days 7` and check the `Context safety` section.
+
+---
+
 ## See also
 
 - [Gateway lifecycle](./lifecycle.md) — end-to-end flow of a single DM

--- a/apps/docs/docs/plans/2026-05-07-gateway-msg-too-long-hardening-implementation.md
+++ b/apps/docs/docs/plans/2026-05-07-gateway-msg-too-long-hardening-implementation.md
@@ -1,0 +1,1010 @@
+# Gateway `msg_too_long` Hardening — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate `msg_too_long` from the gateway's user-visible failure surface in v0.11.1 by fixing prune ordering, capping single-message bloat, and adding an auto-retry path with audit trail.
+
+**Architecture:** Layered defense in `packages/cli/src/gateway/`. (1) New helpers in `messaging.ts` for write-time content caps and last-resort pruning. (2) Provider-level typed error in `claude-agent.ts`. (3) Reordering + retry wrapper around the two LLM call sites in `slack/index.ts`. (4) Three new event-types feed `pmk gateway audit`'s new `Context safety` section.
+
+**Tech Stack:** TypeScript, `node:test` runner via `tsx`, `@anthropic-ai/claude-agent-sdk`, `@slack/socket-mode` + `@slack/web-api`. Tests under `packages/cli/test/<area>.test.ts`. Run all: `npm --workspace packages/cli test`. Single file: `node --import tsx --test test/<file>.test.ts` (run from `packages/cli/`).
+
+**Source spec:** `apps/docs/docs/plans/2026-05-07-gateway-msg-too-long-hardening.md` (commit 6773eae).
+
+---
+
+## File map
+
+| Path | Touched by |
+|---|---|
+| `packages/cli/src/gateway/messaging.ts` | T1, T2, T3, T4, T5, T9 |
+| `packages/cli/src/gateway/slack/index.ts` | T3, T8, T9, T10, T11, T12 |
+| `packages/cli/src/llm/claude-agent.ts` | T7 |
+| `packages/cli/src/gateway/events.ts` | T6 |
+| `packages/cli/src/gateway/audit.ts` | T13 |
+| `packages/cli/src/gateway/audit-format.ts` | T14 |
+| `packages/cli/test/messaging.test.ts` (extend) | T1-T5 |
+| `packages/cli/test/llm-claude-agent.test.ts` (new) | T7 |
+| `packages/cli/test/gateway.test.ts` (extend) | T8, T10, T11, T12 |
+| `packages/cli/test/gateway-events.test.ts` (extend) | T6, T9 |
+| `packages/cli/test/gateway-audit.test.ts` (extend) | T13 |
+| `packages/cli/test/gateway-audit-format.test.ts` (extend) | T14 |
+| `apps/docs/docs/changelog.md` | T15 |
+| `apps/docs/docs/gateway/v0.11-migration.md` | T15 |
+
+## Conventions
+
+- TDD: write failing test → run (FAIL) → minimal impl → run (PASS) → commit. Steps below show test + impl; the run-fail / run-pass invocations are implicit but **mandatory**.
+- Commit messages follow existing repo style: `<type>(<scope>): <description>`.
+- Each commit must leave `npm --workspace packages/cli test` green.
+- No version bump inside individual tasks. Version bump is T16 only.
+- Worktree: per `superpowers:using-git-worktrees`, the executor should create an isolated worktree before T1.
+
+---
+
+## Task 1: `capMessageContent` helper
+
+**Files:** modify `packages/cli/src/gateway/messaging.ts`; extend `packages/cli/test/messaging.test.ts`.
+
+- [ ] **Test** (append to messaging.test.ts):
+
+```ts
+import { capMessageContent } from "../src/gateway/messaging";
+describe("capMessageContent", () => {
+  it("returns content unchanged when within limit", () => {
+    const r = capMessageContent("hello", 10);
+    assert.deepEqual(r, { content: "hello", capped: false, originalChars: 5 });
+  });
+  it("truncates over-limit content and reports originalChars", () => {
+    const r = capMessageContent("x".repeat(100), 20);
+    assert.equal(r.capped, true);
+    assert.equal(r.originalChars, 100);
+    assert.ok(r.content.startsWith("x".repeat(20)));
+    assert.ok(r.content.includes("truncated"));
+  });
+  it("boundary: length === limit returns unchanged", () => {
+    assert.equal(capMessageContent("12345", 5).capped, false);
+  });
+  it("counts chars not bytes (multibyte safe)", () => {
+    assert.equal(capMessageContent("你好你好你好", 10).originalChars, 6);
+  });
+});
+```
+
+- [ ] **Impl** (insert after existing `truncate` in messaging.ts, ~line 24):
+
+```ts
+export interface CapResult {
+  content: string;
+  capped: boolean;
+  originalChars: number;
+}
+
+export function capMessageContent(content: string, limit: number): CapResult {
+  if (content.length <= limit) {
+    return { content, capped: false, originalChars: content.length };
+  }
+  return {
+    content: truncate(content, limit),
+    capped: true,
+    originalChars: content.length,
+  };
+}
+```
+
+- [ ] **Commit:**
+
+```bash
+git add packages/cli/src/gateway/messaging.ts packages/cli/test/messaging.test.ts
+git commit -m "feat(gateway): capMessageContent helper for write-time bloat caps"
+```
+
+---
+
+## Task 2: Lower `MAX_SESSION_TOKENS` default + add `SEED_CAP` / `MRA_RESULT_CAP`
+
+**Files:** modify `messaging.ts`; extend `messaging.test.ts`.
+
+- [ ] **Test:**
+
+```ts
+import { MAX_SESSION_TOKENS, SEED_CAP, MRA_RESULT_CAP } from "../src/gateway/messaging";
+describe("messaging cap defaults", () => {
+  it("MAX_SESSION_TOKENS default is 25_000 (v0.11.1)", () => {
+    assert.equal(MAX_SESSION_TOKENS, 25_000);
+  });
+  it("SEED_CAP default is 12_000", () => {
+    assert.equal(SEED_CAP, 12_000);
+  });
+  it("MRA_RESULT_CAP default is 16_000", () => {
+    assert.equal(MRA_RESULT_CAP, 16_000);
+  });
+});
+```
+
+(Env-var override behaviour is exercised by the existing test infrastructure for `PMK_MAX_SESSION_TOKENS`; the new vars use the same parser so we trust transitively.)
+
+- [ ] **Impl:** Replace the `MAX_SESSION_TOKENS` IIFE (~line 138-142) with:
+
+```ts
+function parsePositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export const MAX_SESSION_TOKENS = parsePositiveIntEnv("PMK_MAX_SESSION_TOKENS", 25_000);
+export const SEED_CAP = parsePositiveIntEnv("PMK_SEED_CAP", 12_000);
+export const MRA_RESULT_CAP = parsePositiveIntEnv("PMK_MRA_RESULT_CAP", 16_000);
+```
+
+Add a one-line comment above each constant explaining purpose (mirrors existing tone).
+
+- [ ] **Commit:**
+
+```bash
+git commit -am "feat(gateway): lower MAX_SESSION_TOKENS to 25k + add SEED_CAP/MRA_RESULT_CAP env knobs"
+```
+
+---
+
+## Task 3: Export `approxTokensFor` with `extra` param; drop slack duplicate
+
+**Files:** modify `messaging.ts` and `slack/index.ts`; extend `messaging.test.ts`.
+
+- [ ] **Test:**
+
+```ts
+import { approxTokensFor } from "../src/gateway/messaging";
+describe("approxTokensFor", () => {
+  it("sums primary message content / 3.5", () => {
+    assert.equal(approxTokensFor([{ role: "user", content: "x".repeat(35) }]), 10);
+  });
+  it("includes extra in total", () => {
+    const got = approxTokensFor(
+      [{ role: "user", content: "x".repeat(35) }],
+      [{ role: "user", content: "y".repeat(35) }],
+    );
+    assert.equal(got, 20);
+  });
+  it("backward-compatible: omitted extra ≡ []", () => {
+    const a = approxTokensFor([{ role: "user", content: "ab" }]);
+    const b = approxTokensFor([{ role: "user", content: "ab" }], []);
+    assert.equal(a, b);
+  });
+});
+```
+
+- [ ] **Impl in `messaging.ts`** (replace private function around line 165):
+
+```ts
+export function approxTokensFor(
+  messages: ChatMessage[],
+  extra: ChatMessage[] = [],
+): number {
+  let total = 0;
+  for (const m of messages) total += m.content.length;
+  for (const m of extra) total += m.content.length;
+  return Math.ceil(total / 3.5);
+}
+```
+
+- [ ] **Impl in `slack/index.ts`:** delete local `approxTokensFor` (lines 130-136), and add `approxTokensFor` to the existing import from `../messaging`:
+
+```ts
+import {
+  approxTokensFor,
+  buildIngestSeed,
+  buildMraFailureMessage,
+  buildMraSuccessMessage,
+  pruneSessionIfNeeded,
+  truncate,
+} from "../messaging";
+```
+
+- [ ] **Commit:**
+
+```bash
+git commit -am "refactor(gateway): export approxTokensFor with extra-param; drop slack duplicate"
+```
+
+---
+
+## Task 4: Extend `pruneSessionIfNeeded` to accept `{extra, newUser}`
+
+**Files:** modify `messaging.ts`; extend `messaging.test.ts`.
+
+- [ ] **Test:**
+
+```ts
+describe("pruneSessionIfNeeded with opts", () => {
+  it("recomputes approxTokens including extra+newUser", () => {
+    const session = {
+      messages: [
+        { role: "user" as const, content: "Q" },
+        { role: "assistant" as const, content: "A" },
+      ],
+      approxTokens: 0,
+    };
+    pruneSessionIfNeeded(session, {
+      extra: [{ role: "user", content: "x".repeat(7000) }],
+      newUser: "y".repeat(7000),
+    });
+    assert.ok(session.approxTokens > 3000);
+  });
+  it("backward-compatible: omitted opts behaves like before", () => {
+    const session = {
+      messages: [{ role: "user" as const, content: "hi" }, { role: "assistant" as const, content: "ok" }],
+      approxTokens: 0,
+    };
+    const r = pruneSessionIfNeeded(session);
+    assert.equal(r.pruned, false);
+  });
+});
+```
+
+- [ ] **Impl** in `messaging.ts`. Add interface and update signature:
+
+```ts
+export interface PruneOpts {
+  extra?: ChatMessage[];
+  newUser?: string;
+}
+
+export function pruneSessionIfNeeded(
+  session: SessionLike,
+  opts: PruneOpts = {},
+): PruneResult {
+  const extras: ChatMessage[] = [
+    ...(opts.extra ?? []),
+    ...(opts.newUser ? [{ role: "user" as const, content: opts.newUser }] : []),
+  ];
+  session.approxTokens = approxTokensFor(session.messages, extras);
+  // … existing body unchanged from the early-return check onward
+```
+
+At the end of the function (where `session.approxTokens = approxTokensFor(session.messages)` recomputes after a prune), pass `extras` too: `approxTokensFor(session.messages, extras)`.
+
+- [ ] **Commit:**
+
+```bash
+git commit -am "feat(gateway): pruneSessionIfNeeded counts retrievalPrefix + newUser in budget"
+```
+
+---
+
+## Task 5: `forcePruneToMinimum`
+
+**Files:** modify `messaging.ts`; extend `messaging.test.ts`.
+
+- [ ] **Test:**
+
+```ts
+import { forcePruneToMinimum } from "../src/gateway/messaging";
+const SEED = "我先把 workspace 的 PKB context 給你 xxx";
+describe("forcePruneToMinimum", () => {
+  it("keeps seed pair + last pair, returns droppedPairs", () => {
+    const session = {
+      messages: [
+        { role: "user" as const, content: SEED }, { role: "assistant" as const, content: "ok" },
+        { role: "user" as const, content: "Q1" }, { role: "assistant" as const, content: "A1" },
+        { role: "user" as const, content: "Q2" }, { role: "assistant" as const, content: "A2" },
+        { role: "user" as const, content: "Q3" }, { role: "assistant" as const, content: "A3" },
+      ],
+      approxTokens: 0,
+    };
+    const dropped = forcePruneToMinimum(session);
+    assert.equal(dropped, 2);
+    assert.equal(session.messages.length, 4);
+    assert.ok(session.messages[0].content.startsWith("我先把"));
+    assert.equal(session.messages[3].content, "A3");
+  });
+  it("works without seed pair", () => {
+    const session = {
+      messages: [
+        { role: "user" as const, content: "Q1" }, { role: "assistant" as const, content: "A1" },
+        { role: "user" as const, content: "Q2" }, { role: "assistant" as const, content: "A2" },
+      ],
+      approxTokens: 0,
+    };
+    assert.equal(forcePruneToMinimum(session), 1);
+    assert.equal(session.messages[0].content, "Q2");
+  });
+  it("idempotent on already-minimal sessions", () => {
+    const session = {
+      messages: [
+        { role: "user" as const, content: SEED }, { role: "assistant" as const, content: "ok" },
+        { role: "user" as const, content: "Q" }, { role: "assistant" as const, content: "A" },
+      ],
+      approxTokens: 0,
+    };
+    assert.equal(forcePruneToMinimum(session), 0);
+    assert.equal(session.messages.length, 4);
+  });
+});
+```
+
+- [ ] **Impl** (append to `messaging.ts`):
+
+```ts
+/**
+ * Last-resort prune for the msg_too_long retry path. Keeps PKB seed
+ * pair (if present) plus the most-recent user/assistant pair, drops
+ * everything between. Returns dropped (user,assistant) pair count.
+ * Idempotent. Does not consult MAX_SESSION_TOKENS.
+ */
+export function forcePruneToMinimum(session: SessionLike): number {
+  const msgs = session.messages;
+  const hasPkbSeed =
+    msgs.length >= 2 &&
+    msgs[0].role === "user" &&
+    msgs[0].content.startsWith(PKB_SEED_PREFIX) &&
+    msgs[1].role === "assistant";
+  const seedSlice = hasPkbSeed ? msgs.slice(0, 2) : [];
+  const seedEnd = hasPkbSeed ? 2 : 0;
+  if (msgs.length - seedEnd <= 2) return 0;
+  const droppedPairs = Math.floor((msgs.length - seedEnd - 2) / 2);
+  const tailSlice = msgs.slice(-2);
+  session.messages = [...seedSlice, ...tailSlice];
+  session.approxTokens = approxTokensFor(session.messages);
+  return droppedPairs;
+}
+```
+
+- [ ] **Commit:**
+
+```bash
+git commit -am "feat(gateway): forcePruneToMinimum for msg_too_long retry path"
+```
+
+---
+
+## Task 6: Add three event-type literals to `GatewayEvent` union
+
+**Files:** modify `packages/cli/src/gateway/events.ts`; extend `gateway-events.test.ts`.
+
+- [ ] **Test** (append to gateway-events.test.ts — verifies round-trip via append/read):
+
+```ts
+import { appendGatewayEvent, readGatewayEvents } from "../src/gateway/events";
+it("round-trips context.exceeded / context.force-pruned / message.capped", () => {
+  appendGatewayEvent({ type: "context.exceeded", actor: "Uabc", sessionTokensBefore: 31578, retrievalAtoms: 1, phase: "first-call" });
+  appendGatewayEvent({ type: "context.force-pruned", actor: "Uabc", droppedPairs: 4, tokensAfter: 1200 });
+  appendGatewayEvent({ type: "message.capped", actor: "Uabc", kind: "seed", originalChars: 88292, cappedChars: 12000 });
+  const events = readGatewayEvents({});
+  const types = events.map((e) => e.type);
+  assert.ok(types.includes("context.exceeded"));
+  assert.ok(types.includes("context.force-pruned"));
+  assert.ok(types.includes("message.capped"));
+});
+```
+
+- [ ] **Impl** in `events.ts`. Add three interfaces (next to existing event interfaces):
+
+```ts
+export interface ContextExceededEvent {
+  type: "context.exceeded";
+  actor: string;
+  sessionTokensBefore: number;
+  retrievalAtoms: number;
+  phase: "first-call" | "synthesise";
+}
+export interface ContextForcePrunedEvent {
+  type: "context.force-pruned";
+  actor: string;
+  droppedPairs: number;
+  tokensAfter: number;
+}
+export interface MessageCappedEvent {
+  type: "message.capped";
+  actor: string;
+  kind: "seed" | "mra-result";
+  originalChars: number;
+  cappedChars: number;
+}
+```
+
+Extend the `GatewayEvent` union (line 108):
+
+```ts
+export type GatewayEvent =
+  | MraAskEndEvent
+  | TurnProcessedEvent
+  | EscalateTriggeredEvent
+  | EscalateAbsorbedEvent
+  | GatewayPresenceEvent
+  | ContextExceededEvent
+  | ContextForcePrunedEvent
+  | MessageCappedEvent;
+```
+
+Extend `VALID_TYPES` (line 118):
+
+```ts
+const VALID_TYPES: ReadonlySet<string> = new Set([
+  "mra-ask.end", "turn.processed", "escalate.triggered", "escalate.absorbed",
+  "gateway.online", "gateway.offline",
+  "context.exceeded", "context.force-pruned", "message.capped",
+]);
+```
+
+- [ ] **Commit:**
+
+```bash
+git commit -am "feat(gateway): add context.exceeded / context.force-pruned / message.capped events"
+```
+
+---
+
+## Task 7: `PmkContextTooLongError` in `claude-agent.ts`
+
+**Files:** modify `packages/cli/src/llm/claude-agent.ts`; create `packages/cli/test/llm-claude-agent.test.ts`.
+
+- [ ] **Test** (new file):
+
+```ts
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import { PmkContextTooLongError, isContextTooLongError } from "../src/llm/claude-agent";
+
+describe("PmkContextTooLongError detection", () => {
+  it("matches msg_too_long error message", () => {
+    assert.equal(isContextTooLongError(new Error("An API error occurred: msg_too_long")), true);
+  });
+  it("matches 'prompt is too long'", () => {
+    assert.equal(isContextTooLongError(new Error("prompt is too long for the model")), true);
+  });
+  it("matches 'context window exceeded'", () => {
+    assert.equal(isContextTooLongError(new Error("context window exceeded")), true);
+  });
+  it("does not match unrelated errors", () => {
+    assert.equal(isContextTooLongError(new Error("rate limit hit")), false);
+  });
+  it("preserves cause", () => {
+    const cause = new Error("msg_too_long");
+    const err = new PmkContextTooLongError(cause);
+    assert.equal(err.cause, cause);
+    assert.ok(err instanceof Error);
+  });
+});
+```
+
+- [ ] **Impl** in `claude-agent.ts`. Add at the top of the file (after imports):
+
+```ts
+export class PmkContextTooLongError extends Error {
+  readonly cause: unknown;
+  constructor(cause: unknown) {
+    super("PmkContextTooLongError");
+    this.name = "PmkContextTooLongError";
+    this.cause = cause;
+  }
+}
+
+const CONTEXT_TOO_LONG_RE = /msg_too_long|prompt is too long|context.+exceed/i;
+
+export function isContextTooLongError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return CONTEXT_TOO_LONG_RE.test(err.message);
+}
+```
+
+Wrap the body of `chat()` in try/catch to convert matching errors:
+
+```ts
+async chat(systemPrompt, messages, opts = {}) {
+  try {
+    // … existing body unchanged …
+    return full;
+  } catch (err) {
+    if (isContextTooLongError(err)) throw new PmkContextTooLongError(err);
+    throw err;
+  }
+}
+```
+
+- [ ] **Commit:**
+
+```bash
+git add packages/cli/src/llm/claude-agent.ts packages/cli/test/llm-claude-agent.test.ts
+git commit -m "feat(llm): typed PmkContextTooLongError on msg_too_long-shaped errors"
+```
+
+---
+
+## Task 8: Apply seed cap in `runFreeChatTurn`
+
+**Files:** modify `slack/index.ts`; extend `gateway.test.ts`.
+
+- [ ] **Test** (extend gateway.test.ts) — sketch: drive `runFreeChatTurn` (or its testable extracted seed path) with `defaultIngest` returning a 50_000-char seed, assert that `session.messages[0].content.length <= SEED_CAP` and that a `message.capped` event with `kind:"seed"` was appended.
+
+Use the project's existing fake-LLM / fake-Slack harness. If gateway.test.ts already mocks WebClient and provider, follow that pattern; otherwise extract the seed-application block into a helper called `applySeed(session, ingestSpec, mraWorkspace, actor)` and unit-test that helper directly.
+
+- [ ] **Impl in `slack/index.ts`** at the seed write site (~line 497–509). Replace:
+
+```ts
+if (session.messages.length === 0 && this.config.defaultIngest) {
+  const seed = buildIngestSeed(this.config.defaultIngest, this.config.mraWorkspace);
+  if (seed) {
+    session.messages.push({ role: "user", content: seed });
+    session.messages.push({ role: "assistant", content: "了解，已載入 workspace PKB context。請繼續。" });
+  }
+}
+```
+
+With:
+
+```ts
+if (session.messages.length === 0 && this.config.defaultIngest) {
+  const seedRaw = buildIngestSeed(this.config.defaultIngest, this.config.mraWorkspace);
+  if (seedRaw) {
+    const cap = capMessageContent(seedRaw, SEED_CAP);
+    if (cap.capped) {
+      appendGatewayEvent({
+        type: "message.capped",
+        actor: userId,
+        kind: "seed",
+        originalChars: cap.originalChars,
+        cappedChars: cap.content.length,
+      });
+    }
+    session.messages.push({ role: "user", content: cap.content });
+    session.messages.push({ role: "assistant", content: "了解，已載入 workspace PKB context。請繼續。" });
+  }
+}
+```
+
+Update imports from `../messaging` to include `capMessageContent` and `SEED_CAP`.
+
+- [ ] **Commit:**
+
+```bash
+git commit -am "feat(gateway): cap PKB seed at SEED_CAP chars, emit message.capped audit event"
+```
+
+---
+
+## Task 9: Apply mra-result cap; remove hardcoded 24_000 in `buildMraSuccessMessage`
+
+**Files:** modify `messaging.ts` and `slack/index.ts`; extend `gateway.test.ts`.
+
+- [ ] **Test** (extend gateway.test.ts): drive `synthesiseAfterMra` (via `handleMraAskRound` happy path with a 30_000-char fake stdout). Assert: pushed `mra-result` user message length ≤ MRA_RESULT_CAP + truncate-marker overhead; a `message.capped` event with `kind:"mra-result"` was appended.
+
+- [ ] **Impl in `messaging.ts`:** change `buildMraSuccessMessage` (line 116-124) to accept already-capped stdout — remove the inner `truncate(stdout.trim(), 24_000)`:
+
+```ts
+export function buildMraSuccessMessage(repo: string, stdout: string): string {
+  return [
+    `這是 \`mra ask ${repo}\` 的回傳結果（請依此 synthesise 最終答案；若這份結果不足，可再 emit 一次 mra-ask，但仍以 PKB + 這份結果優先）：`,
+    "",
+    "```mra-result",
+    stdout.trim(),
+    "```",
+  ].join("\n");
+}
+```
+
+- [ ] **Impl in `slack/index.ts`** at the mra-success branch inside `handleMraAskRound` / `synthesiseAfterMra` (around line 1108-1111). Replace:
+
+```ts
+const mraMessage = result.ok
+  ? buildMraSuccessMessage(request.repo, result.stdout)
+  : buildMraFailureMessage(request.repo, result);
+session.messages.push({ role: "user", content: mraMessage });
+```
+
+With:
+
+```ts
+let mraMessage: string;
+if (result.ok) {
+  const cap = capMessageContent(result.stdout, MRA_RESULT_CAP);
+  if (cap.capped) {
+    appendGatewayEvent({
+      type: "message.capped",
+      actor: args.actor,
+      kind: "mra-result",
+      originalChars: cap.originalChars,
+      cappedChars: cap.content.length,
+    });
+  }
+  mraMessage = buildMraSuccessMessage(request.repo, cap.content);
+} else {
+  mraMessage = buildMraFailureMessage(request.repo, result);
+}
+session.messages.push({ role: "user", content: mraMessage });
+```
+
+Thread `actor: userId` into `synthesiseAfterMra`'s args interface (and into the call site at line 561 in `handleMraAskRound`). Update `synthesiseAfterMra`'s typed `args:` block to add `actor: string;`.
+
+Update `slack/index.ts` imports from `../messaging` to include `MRA_RESULT_CAP`.
+
+- [ ] **Commit:**
+
+```bash
+git commit -am "feat(gateway): cap mra-result at MRA_RESULT_CAP chars, emit message.capped event"
+```
+
+---
+
+## Task 10: Reorder prune to BEFORE the LLM call in `runFreeChatTurn`
+
+**Files:** modify `slack/index.ts`; extend `gateway.test.ts`.
+
+- [ ] **Test** (extend gateway.test.ts): inject a spy provider whose `chat` records a flag `pruneCalledBefore = (session.messages was already pruned)`. Set up a session whose `approxTokens > MAX_SESSION_TOKENS` before the turn. Assert: by the time `provider.chat` runs, `session.messages.length` reflects the pruned state.
+
+- [ ] **Impl** in `runFreeChatTurn` (`slack/index.ts:485-605`). Move the prune block to **before** `this.llm.chat(...)`:
+
+```ts
+// (after retrievalPrefix is computed and before placeholder is posted)
+const pruneReport = pruneSessionIfNeeded(session, {
+  extra: retrievalPrefix,
+  newUser: text,
+});
+if (pruneReport.pruned) {
+  this.onLog(`pruned session: dropped ${pruneReport.droppedPairs} pair(s); now ${pruneReport.tokensAfter} tokens`);
+}
+session.messages.push({ role: "user", content: text });
+session.turns += 1;
+
+// … placeholder.postMessage … pickAudience … pickGatewayPrompt …
+
+// LLM call (unchanged)
+let full = "";
+try {
+  full = await this.llm.chat(systemPrompt, [
+    ...retrievalPrefix,
+    ...session.messages,
+  ], { onToken: () => {} });
+} catch (err) { /* T11 retry path lands here */ }
+```
+
+Delete the old post-call prune block at line 598-603 (replaced by pre-call prune).
+
+The post-LLM `session.approxTokens = approxTokensFor(session.messages)` recompute (line 592) stays — it's just the snapshot for storage.
+
+- [ ] **Commit:**
+
+```bash
+git commit -am "fix(gateway): prune session BEFORE LLM call (closes msg_too_long fail-loop)"
+```
+
+---
+
+## Task 11: Retry path on `PmkContextTooLongError` (first call)
+
+**Files:** modify `slack/index.ts`; extend `gateway.test.ts`.
+
+- [ ] **Test** (extend gateway.test.ts): provider whose first `chat()` throws `new PmkContextTooLongError(...)`, second `chat()` returns "ok". Assert:
+  - Final Slack message body starts with `:scissors: 對話過長，已自動裁掉`
+  - `context.exceeded` event written with `phase: "first-call"`
+  - `context.force-pruned` event written
+  - `session.messages` after the turn has 4 (or 6 if seed) entries
+
+Second test: both calls throw `PmkContextTooLongError`. Assert: Slack `chat.update` called with `:x: 對話太長，請開新 thread 重新提問`; no assistant message appended to session.
+
+- [ ] **Impl in `runFreeChatTurn`:** wrap the LLM call:
+
+```ts
+import { PmkContextTooLongError } from "../../llm/claude-agent";
+
+// …
+let full = "";
+let scissorsPrefix = "";
+try {
+  full = await this.llm.chat(systemPrompt, [
+    ...retrievalPrefix, ...session.messages,
+  ], { onToken: () => {} });
+} catch (err) {
+  if (!(err instanceof PmkContextTooLongError)) {
+    await this.web.chat.update({
+      channel: channelId, ts: String(placeholder.ts),
+      text: `:warning: ${(err as Error).message}`,
+    });
+    return;
+  }
+  appendGatewayEvent({
+    type: "context.exceeded",
+    actor: userId,
+    sessionTokensBefore: session.approxTokens,
+    retrievalAtoms: retrieved.length,
+    phase: "first-call",
+  });
+  const dropped = forcePruneToMinimum(session);
+  appendGatewayEvent({
+    type: "context.force-pruned",
+    actor: userId,
+    droppedPairs: dropped,
+    tokensAfter: session.approxTokens,
+  });
+  try {
+    full = await this.llm.chat(systemPrompt, [
+      ...retrievalPrefix, ...session.messages,
+    ], { onToken: () => {} });
+    scissorsPrefix = `:scissors: 對話過長，已自動裁掉 ${dropped} 輪舊訊息\n\n`;
+  } catch (err2) {
+    await this.web.chat.update({
+      channel: channelId, ts: String(placeholder.ts),
+      text: ":x: 對話太長，請開新 thread 重新提問",
+    });
+    return;
+  }
+}
+```
+
+When prepending `visible` to the final Slack message at line 614+, prepend `scissorsPrefix` first.
+
+Add `forcePruneToMinimum` to imports from `../messaging`.
+
+- [ ] **Commit:**
+
+```bash
+git commit -am "feat(gateway): auto-retry on msg_too_long with force-prune + scissors marker"
+```
+
+---
+
+## Task 12: Same retry wrapper around `synthesiseAfterMra`
+
+**Files:** modify `slack/index.ts`; extend `gateway.test.ts`.
+
+- [ ] **Test:** mra-ask happy path → first synthesis call throws `PmkContextTooLongError`, second succeeds. Assert `phase: "synthesise"` event recorded and scissors prefix shown.
+
+- [ ] **Impl:** in `synthesiseAfterMra` (line 1091-1120), wrap the `this.llm.chat(...)` call with the same try/catch shape from Task 11. Set `phase: "synthesise"`. Return `{ full, scissorsPrefix }` instead of just `full`, and have the caller in `handleMraAskRound` prepend `scissorsPrefix` when posting the final message.
+
+To DRY: extract the retry wrapper into a private method:
+
+```ts
+private async chatWithContextRetry(args: {
+  systemPrompt: string;
+  messages: ChatMessage[];
+  session: FreeChatSession;
+  actor: string;
+  retrievalAtoms: number;
+  phase: "first-call" | "synthesise";
+}): Promise<{ ok: true; full: string; scissorsPrefix: string } | { ok: false }>
+```
+
+Use it from both `runFreeChatTurn` (T11) and `synthesiseAfterMra`. T11 task may opt to land the inline version first and refactor here — both are acceptable; pick one and stay consistent.
+
+- [ ] **Commit:**
+
+```bash
+git commit -am "feat(gateway): apply context-retry wrapper to synthesiseAfterMra (mra-ask round)"
+```
+
+---
+
+## Task 13: Add `Context safety` aggregation in `audit.ts`
+
+**Files:** modify `audit.ts`; extend `gateway-audit.test.ts`.
+
+- [ ] **Test:** seed events log with: 2× `context.exceeded` (1 first-call, 1 synthesise), 2× `context.force-pruned`, 3× `message.capped` (2 seed, 1 mra-result). Run `buildAuditReport({ days: 30 })`. Assert `report.contextSafety` equals:
+
+```ts
+{
+  contextExceeded: { total: 2, firstCall: 1, synthesise: 1 },
+  contextForcePruned: 2,
+  messageCapped: { total: 3, seed: 2, mraResult: 1 },
+}
+```
+
+- [ ] **Impl in `audit.ts`:** extend `AuditReport` interface (line 25-66) with:
+
+```ts
+contextSafety: {
+  contextExceeded: { total: number; firstCall: number; synthesise: number };
+  contextForcePruned: number;
+  messageCapped: { total: number; seed: number; mraResult: number };
+};
+```
+
+In `buildAuditReport`, add counters before the for-loop:
+
+```ts
+let ctxExc = 0, ctxExcFirst = 0, ctxExcSynth = 0;
+let ctxForcePruned = 0;
+let msgCap = 0, msgCapSeed = 0, msgCapMra = 0;
+```
+
+Add cases inside the existing `switch (e.type)`:
+
+```ts
+case "context.exceeded":
+  ctxExc++;
+  if (e.phase === "first-call") ctxExcFirst++;
+  else if (e.phase === "synthesise") ctxExcSynth++;
+  break;
+case "context.force-pruned":
+  ctxForcePruned++;
+  break;
+case "message.capped":
+  msgCap++;
+  if (e.kind === "seed") msgCapSeed++;
+  else if (e.kind === "mra-result") msgCapMra++;
+  break;
+```
+
+Add to the returned object:
+
+```ts
+contextSafety: {
+  contextExceeded: { total: ctxExc, firstCall: ctxExcFirst, synthesise: ctxExcSynth },
+  contextForcePruned: ctxForcePruned,
+  messageCapped: { total: msgCap, seed: msgCapSeed, mraResult: msgCapMra },
+},
+```
+
+- [ ] **Commit:**
+
+```bash
+git commit -am "feat(gateway): aggregate context.* + message.capped events into AuditReport"
+```
+
+---
+
+## Task 14: Render `Context safety` in `audit-format.ts`
+
+**Files:** modify `audit-format.ts`; extend `gateway-audit-format.test.ts`.
+
+- [ ] **Test:** call `formatAuditReport(report)` with a synthetic report whose `contextSafety` totals are non-zero. Assert output contains:
+  - `Context safety` (chalk.bold header)
+  - `context.exceeded:` line with `2 (first-call 1, synthesise 1)`
+  - `force-pruned:` line with `2`
+  - `messages capped:` line with `3 (seed 2, mra-result 1)`
+- Also test the all-zero case: section either rendered with `0` rows or omitted (pick one and assert it).
+
+Recommendation: always render the section so an operator sees the safety net is in place even when nothing fired.
+
+- [ ] **Impl** in `audit-format.ts` (insert before the `// flags` block, ~line 96):
+
+```ts
+// context safety
+lines.push("");
+lines.push(chalk.bold("Context safety"));
+const cs = report.contextSafety;
+lines.push(
+  label("context.exceeded:") +
+    `${cs.contextExceeded.total} (first-call ${cs.contextExceeded.firstCall}, synthesise ${cs.contextExceeded.synthesise})`,
+);
+lines.push(label("force-pruned:") + cs.contextForcePruned);
+lines.push(
+  label("messages capped:") +
+    `${cs.messageCapped.total} (seed ${cs.messageCapped.seed}, mra-result ${cs.messageCapped.mraResult})`,
+);
+```
+
+- [ ] **Commit:**
+
+```bash
+git commit -am "feat(gateway): render Context safety section in pmk gateway audit"
+```
+
+---
+
+## Task 15: Update `changelog.md` and `v0.11-migration.md`
+
+**Files:** modify `apps/docs/docs/changelog.md`; modify `apps/docs/docs/gateway/v0.11-migration.md`.
+
+- [ ] **Impl 1 — changelog:** add a new `## 0.11.1` heading above the existing `## 0.11.0` entry. Body:
+
+```md
+## 0.11.1 — 2026-05-DD
+
+### Fixed
+- gateway: `msg_too_long` no longer reaches end users. Three layered defenses: (a) prune now runs **before** the LLM call (closes a fail-loop introduced in v0.8.1); (b) PKB seed and `mra-ask` results are capped at write-time; (c) any residual `msg_too_long` triggers an automatic force-prune + retry path that prefixes the reply with `:scissors: 對話過長，已自動裁掉 N 輪舊訊息`. Hard failure shows a friendly `:x: 對話太長，請開新 thread 重新提問` rather than the raw API error.
+
+### Changed
+- `PMK_MAX_SESSION_TOKENS` default lowered 60_000 → 25_000 to leave headroom for SDK-inherited host context.
+
+### Added
+- New env vars `PMK_SEED_CAP` (default 12_000 chars) and `PMK_MRA_RESULT_CAP` (default 16_000 chars).
+- New event types `context.exceeded`, `context.force-pruned`, `message.capped` in the events log.
+- `pmk gateway audit` gains a `Context safety` section rolling up the new events.
+```
+
+- [ ] **Impl 2 — migration doc:** append at the bottom of `v0.11-migration.md`:
+
+```md
+## v0.11.1: context-safety hardening (additive)
+
+No breaking changes. Operator-facing additions:
+
+| Env var | Default | What it caps |
+|---|---|---|
+| `PMK_MAX_SESSION_TOKENS` | 25000 (was 60000) | Soft session-prune budget |
+| `PMK_SEED_CAP` | 12000 | Chars in PKB ingest seed |
+| `PMK_MRA_RESULT_CAP` | 16000 | Chars in any `mra-ask` stdout pushed into session history |
+
+Three new event types appear in `~/.pmk/gateway/events-YYYY-MM.log`:
+`context.exceeded`, `context.force-pruned`, `message.capped`.
+`pmk gateway audit` reports them under the new `Context safety`
+section. Tighten the `*_CAP` env vars if `context.exceeded` appears
+in your weekly audit.
+```
+
+- [ ] **Commit:**
+
+```bash
+git add apps/docs/docs/changelog.md apps/docs/docs/gateway/v0.11-migration.md
+git commit -m "docs: changelog + migration notes for v0.11.1 msg_too_long hardening"
+```
+
+---
+
+## Task 16: Pre-tag verification + version bump + release
+
+**Files:** run scripts; modify `package.json` files via existing bump script; tag.
+
+- [ ] **Step 1: Restart gateway after T11/T12 land**
+
+```bash
+npm --workspace packages/cli run start -- gateway start
+```
+
+- [ ] **Step 2: Verify prune-before-call fires**
+
+In the previously-bloated `#新頻道` thread `1778139665.927099` (already cleared on 2026-05-07; let it accumulate naturally), run several mra-ask rounds. Confirm: no `msg_too_long`. Tail events log:
+
+```bash
+tail -f ~/.pmk/gateway/events-2026-05.log
+```
+
+Expect to see at least one `message.capped` event for `kind:"seed"` on the first turn.
+
+- [ ] **Step 3: Force a synthetic msg_too_long to exercise the retry path**
+
+```bash
+PMK_MAX_SESSION_TOKENS=1 npm --workspace packages/cli run start -- gateway start
+```
+
+(Restart with the env var.) Send any DM. Expect:
+- Reply prefixed with `:scissors: 對話過長，已自動裁掉 …`
+- `context.exceeded` + `context.force-pruned` events in the log
+
+- [ ] **Step 4: Run audit**
+
+```bash
+npm --workspace packages/cli run start -- gateway audit --days 1
+```
+
+Confirm the new `Context safety` section renders with non-zero counters.
+
+- [ ] **Step 5: Bump version**
+
+```bash
+npm run version:bump -- 0.11.1
+```
+
+(Existing `scripts/bump-version.mjs` writes `0.11.1` into `package.json`, all workspace packages, and any version constants.)
+
+- [ ] **Step 6: Commit + tag + push**
+
+```bash
+git add package.json packages/*/package.json apps/*/package.json
+git commit -m "chore(release): bump workspace versions to 0.11.1"
+git tag v0.11.1
+git push origin main
+git push origin v0.11.1
+```
+
+(If using a feature branch + PR per `feedback_release_workflow.md`, push the branch first and squash-merge after review; tag from main after merge.)
+
+---
+
+## Self-review checklist
+
+- [x] **Spec coverage** — every section of the spec maps to a task:
+  - 1.1 Move prune → T10
+  - 1.2 retrievalPrefix in budget → T3, T4
+  - 1.3 capMessageContent → T1; applied at seed (T8) and mra-result (T9)
+  - 1.4 MAX_SESSION_TOKENS lowered → T2
+  - 2.1 PmkContextTooLongError → T7
+  - 2.2 Force-prune + retry, both call sites → T11, T12
+  - 3 Three event types → T6 (declare), T8/T9/T11/T12 (emit), T13/T14 (audit)
+  - 4 Three env vars → T2
+  - Components touched (table) → covered by T1-T15
+  - Testing plan → covered as TDD inside each task; gateway-audit / gateway-audit-format tests in T13/T14
+  - Release plan → T15 (changelog/migration), T16 (verify + bump + tag)
+  - v0.12 forward-link → already in spec; no implementation step needed
+- [x] **No placeholders** — all code blocks contain real code; commands are runnable; no `// TODO`, no "implement later".
+- [x] **Type consistency** — `CapResult`, `PruneOpts`, `PmkContextTooLongError`, `ContextExceededEvent`, etc. are referenced consistently across tasks. Method names: `capMessageContent`, `forcePruneToMinimum`, `pruneSessionIfNeeded`, `approxTokensFor`, `isContextTooLongError`. Env-var names: `PMK_MAX_SESSION_TOKENS`, `PMK_SEED_CAP`, `PMK_MRA_RESULT_CAP`. Constants: `MAX_SESSION_TOKENS`, `SEED_CAP`, `MRA_RESULT_CAP`. Event-type strings: `context.exceeded`, `context.force-pruned`, `message.capped`.

--- a/apps/docs/docs/plans/2026-05-07-gateway-msg-too-long-hardening.md
+++ b/apps/docs/docs/plans/2026-05-07-gateway-msg-too-long-hardening.md
@@ -1,0 +1,329 @@
+# Gateway `msg_too_long` Hardening — Design Spec
+
+- Date: 2026-05-07
+- Target release: v0.11.1
+- Status: Draft (awaiting implementation plan)
+- Owner: Hanfour Huang
+
+## Background
+
+Production incident on 2026-05-07: a Slack thread under `#新頻道`
+(channel `C0AVD1XD946`, thread `1778139665.927099`) returned
+`pmk 內部錯誤：An API error occurred: msg_too_long` after several
+successful `mra-ask` rounds. Workaround was to delete the thread's
+`chat-session.json`. We want this class of failure to not reach
+production users again.
+
+Investigation surfaced four root causes:
+
+1. **Prune ordering bug** — `runFreeChatTurn` in
+   `packages/cli/src/gateway/slack/index.ts:545` calls
+   `pruneSessionIfNeeded` *after* the LLM call, not before. Once a
+   session is over budget, the next turn fails before pruning can
+   recover it. The error path also short-circuits the prune, so the
+   session stays bloated for every subsequent turn.
+2. **SDK overhead unaccounted-for** — `ClaudeAgentSdkProvider` spawns
+   the local `claude` CLI, which inherits the host's `~/.claude/`
+   config (skills, hooks, MCP server descriptions). On a heavy host
+   the inherited system context can add tens of thousands of tokens
+   on top of every request. The current `MAX_SESSION_TOKENS=60000`
+   default leaves no headroom for this.
+3. **Single-message bloat** — `defaultIngest: "mra:--all"` produces
+   an 88,292-char (~25k token) PKB seed that lives in `messages[0..1]`
+   forever (`PKB_SEED_PREFIX` bypasses prune). `mra-ask` results are
+   pushed into session history without size limits. A single one of
+   these can blow the budget on its own.
+4. **No graceful degradation** — when `msg_too_long` does fire, the
+   raw Anthropic error message is forwarded to Slack and the user is
+   stuck until an operator clears the session file by hand.
+
+## Goals
+
+- Eliminate `msg_too_long` from the user-visible failure surface in
+  v0.11.1.
+- Keep the existing `claude-agent-sdk` provider as default; do not
+  break auth flow or billing model.
+- Preserve operator visibility into context-safety events through
+  `events.log` and `pmk gateway audit`.
+- Lay forward link to a v0.12 effort that addresses cause #2
+  architecturally.
+
+## Non-goals (v0.11.1)
+
+- Switching gateway default provider to `anthropic-api`. (Tracked in
+  the v0.12 roadmap stub at the end of this spec.)
+- Reworking the PKB-seed mechanism into a retrieval-only model.
+- Reshaping `mra-ask` payloads.
+- Any change to Slack-facing UI beyond the new prefix/error strings.
+
+## Design
+
+### 1. Source-side fixes
+
+#### 1.1 Move `pruneSessionIfNeeded` before the LLM call
+
+In `packages/cli/src/gateway/slack/index.ts` (`runFreeChatTurn`,
+currently around line 525–605), reorder so that:
+
+1. The new user turn is composed (`text`).
+2. `retrievalPrefix` is built from `searchAtoms`.
+3. `session.approxTokens` is recomputed **including** `retrievalPrefix`
+   plus the new user text.
+4. `pruneSessionIfNeeded(session, { extra: retrievalPrefix, newUser: text })`
+   runs.
+5. Only then `llm.chat` is called with
+   `[...retrievalPrefix, ...session.messages, { role: "user", content: text }]`.
+6. Post-call: assistant reply pushed; `approxTokens` recomputed; save
+   session. (No second prune call here — it is now redundant.)
+
+This is the single most important change; it closes the "fails-then-
+fails-forever" loop.
+
+#### 1.2 Account for `retrievalPrefix` in the prune budget
+
+In `packages/cli/src/gateway/messaging.ts`:
+
+- Extend `approxTokensFor(messages: ChatMessage[])` to optionally
+  accept an `extra: ChatMessage[]` second argument and sum its content
+  too.
+- Extend `pruneSessionIfNeeded(session, opts?)` so callers can pass
+  `{ extra: ChatMessage[]; newUser?: string }` representing content
+  that will be sent to the model on the next call but is not stored
+  in `session.messages`. The function uses these for the budget check
+  but does not mutate them.
+
+This stops `retrievalPrefix` from being a hidden charge on every
+turn.
+
+#### 1.3 Cap individual messages at write-time
+
+New helper in `messaging.ts`:
+
+```ts
+export function capMessageContent(
+  content: string,
+  limit: number,
+  kind: "seed" | "mra-result",
+): { content: string; capped: boolean; originalChars: number };
+```
+
+When `content.length > limit`, return `content.slice(0, limit)` plus
+a marker line:
+
+```
+…（已自動截斷，原長度 N，超過 ${kind} cap ${limit}，完整內容仍在 host）
+```
+
+Apply at two sites in `slack/index.ts`:
+
+- `buildIngestSeed` result, before pushing to `session.messages[0]`
+  (cap = `PMK_SEED_CAP`, default 12000).
+- `buildMraSuccessMessage` result, before pushing to
+  `session.messages` inside `synthesiseAfterMra` (cap =
+  `PMK_MRA_RESULT_CAP`, default 16000).
+
+The cap is applied **once**, at write-time. Pruning later does not
+re-cap; sessions saved before this change keep their full historical
+content (no migration).
+
+#### 1.4 Lower `MAX_SESSION_TOKENS` default
+
+`messaging.ts`: change the default in the
+`PMK_MAX_SESSION_TOKENS` parser from `60_000` to `25_000`. The old
+60k value assumed ~70% of a 90k DM-context budget and ignored SDK
+overhead; 25k leaves explicit headroom for system prompt + retrieval
+prefix + SDK-inherited host context + the new turn + the model's
+reply.
+
+### 2. Retry path on `msg_too_long`
+
+#### 2.1 Provider-level: typed error
+
+In `packages/cli/src/llm/claude-agent.ts`, wrap the `query()` loop
+in try/catch. If the underlying error message matches
+`/msg_too_long|prompt is too long|context.+exceed/i`, throw a typed
+sentinel:
+
+```ts
+export class PmkContextTooLongError extends Error {
+  readonly cause: unknown;
+  constructor(cause: unknown) {
+    super("PmkContextTooLongError");
+    this.cause = cause;
+  }
+}
+```
+
+All other errors propagate unchanged.
+
+#### 2.2 Gateway-level: force-prune + retry
+
+In `slack/index.ts:runFreeChatTurn`, wrap the `llm.chat` call in
+try/catch:
+
+```
+try { full = await llm.chat(...) }
+catch (err) {
+  if (!(err instanceof PmkContextTooLongError)) throw err;
+  appendGatewayEvent({ type: "context.exceeded", actor: userId, ... });
+
+  const dropped = forcePruneToMinimum(session);
+  appendGatewayEvent({ type: "context.force-pruned", actor: userId, droppedPairs: dropped });
+
+  try {
+    full = await llm.chat(systemPrompt, [...retrievalPrefix, ...session.messages, { role: "user", content: text }], ...);
+    visiblePrefix = `:scissors: 對話過長，已自動裁掉 ${dropped} 輪舊訊息\n\n`;
+  } catch (err2) {
+    await this.web.chat.update({
+      channel: channelId,
+      ts: String(placeholder.ts),
+      text: ":x: 對話太長，請開新 thread 重新提問",
+    });
+    return;
+  }
+}
+```
+
+`forcePruneToMinimum(session)` (new export in `messaging.ts`):
+keeps the seed pair (if present) plus the most recent user/assistant
+pair, drops everything else, returns `droppedPairs`. It is idempotent
+and does not consult `MAX_SESSION_TOKENS` — this is the
+last-resort path.
+
+The visible prefix `:scissors: …` is prepended to `visible` only on
+the retry-success branch so users have an explanation for missing
+context. Slack `chat.update` is used as before.
+
+The same retry wrapper applies to the `synthesiseAfterMra`
+(mra-ask follow-up) call site, since that call is the most likely
+single trigger of `msg_too_long` in practice.
+
+### 3. Observability
+
+Three new event types append to `events-YYYY-MM.log` (existing
+JSONL format, no schema migration needed). Field semantics:
+
+- `at` — ISO-8601 timestamp string, matches existing log convention
+  (e.g. `2026-05-07T07:39:55.339Z`).
+- `type` — string literal: `context.exceeded` / `context.force-pruned`
+  / `message.capped`.
+- `actor` — Slack user ID (sample values redacted as `U…`).
+- `phase` — for `context.exceeded`: enum string `first-call` |
+  `synthesise`.
+- `kind` — for `message.capped`: enum string `seed` | `mra-result`.
+
+Sample lines (synthetic values):
+
+```jsonl
+{"at":"…","type":"context.exceeded","actor":"U…","sessionTokensBefore":31578,"retrievalAtoms":1,"phase":"first-call"}
+{"at":"…","type":"context.force-pruned","actor":"U…","droppedPairs":6,"tokensAfter":4200}
+{"at":"…","type":"message.capped","actor":"U…","kind":"seed","originalChars":88292,"cappedChars":12000}
+```
+
+`pmk gateway audit` rollup
+(`packages/cli/src/gateway/audit.ts` + `audit-format.ts`) gains a
+new `Context safety` section listing, for the requested window:
+
+- count of `context.exceeded` events (broken down by `phase`)
+- count of `context.force-pruned` events
+- count of `message.capped` events (broken down by `kind`)
+
+These give operators a feedback signal: if `context.exceeded` is
+non-zero in a week, lower the relevant cap env var.
+
+### 4. Tunables (env vars)
+
+| Env var | Default | Effect |
+|---|---|---|
+| `PMK_MAX_SESSION_TOKENS` | `25000` | Soft cap for session pruning. Existing var, default lowered from 60000. |
+| `PMK_SEED_CAP` | `12000` | Maximum chars for the PKB seed message. New. |
+| `PMK_MRA_RESULT_CAP` | `16000` | Maximum chars for any `mra-ask` result pushed into session history. New. |
+
+All three parse identically: positive integer or fall back to default.
+
+## Components touched
+
+| File | Change kind |
+|---|---|
+| `packages/cli/src/gateway/messaging.ts` | Add `capMessageContent`, `forcePruneToMinimum`, env-var parsers; extend `approxTokensFor` and `pruneSessionIfNeeded` signatures; lower default of `MAX_SESSION_TOKENS`. |
+| `packages/cli/src/gateway/slack/index.ts` | Reorder prune-before-call; apply `capMessageContent` at seed + mra-result write sites; wrap both LLM calls with retry path. |
+| `packages/cli/src/llm/claude-agent.ts` | Throw `PmkContextTooLongError` on matching errors. |
+| `packages/cli/src/gateway/events.ts` (or wherever `appendGatewayEvent` lives) | Add the three new event-type literals to the union; no runtime change needed if writer accepts arbitrary objects. |
+| `packages/cli/src/gateway/audit.ts` + `audit-format.ts` | Aggregate + render the new `Context safety` section. |
+| `packages/cli/test/messaging.test.ts` | Unit tests for new helpers + extended signatures. |
+| `packages/cli/test/llm-claude-agent.test.ts` (new) | Verify error wrapping. |
+| `packages/cli/test/gateway.test.ts` | Integration tests: prune-ordering, retry-path-success, retry-path-fail, single-message capping. |
+| `apps/docs/docs/changelog.md` | v0.11.1 entry. |
+| `apps/docs/docs/gateway/v0.11-migration.md` | Append a "v0.11.1: context-safety hardening" section pointing to env vars + new audit fields. |
+
+## Testing plan
+
+| Type | Coverage |
+|---|---|
+| Unit | `capMessageContent` boundary cases (length === limit, > limit, undefined limit, multibyte). |
+| Unit | `approxTokensFor(messages, extra)` includes `extra` content; backward-compatible when `extra` omitted. |
+| Unit | `pruneSessionIfNeeded` with new `extra`/`newUser` opts is idempotent and respects budget. |
+| Unit | `forcePruneToMinimum` keeps seed pair + last pair, drops middle, idempotent. |
+| Unit | `claude-agent.chat` throws `PmkContextTooLongError` for `msg_too_long`-shaped errors and propagates other errors unchanged. |
+| Integration | `runFreeChatTurn` happy path: prune is invoked **before** `llm.chat` (verify via spy call order). |
+| Integration | Retry path success: first `llm.chat` throws sentinel → session is force-pruned → second `llm.chat` succeeds → reply has `:scissors: …` prefix → `context.exceeded` and `context.force-pruned` events written. |
+| Integration | Retry path fail: both calls throw sentinel → user sees `:x: 對話太長，請開新 thread 重新提問` → no assistant message persisted. |
+| Integration | `mra-result` longer than `PMK_MRA_RESULT_CAP` is capped before being pushed to `session.messages` and writes a `message.capped` event. |
+| Integration | `audit.ts` `Context safety` section reports correct counts over a synthetic event log. |
+
+No e2e tests added — this is internal prompt-shaping; Slack-side
+behaviour for the happy path is unchanged, and the retry-path
+strings (`:scissors:`, `:x: …`) are short enough to be covered by
+integration assertions on Slack mock calls.
+
+## Release plan
+
+- Target version: **v0.11.1**.
+- Workflow: per `feedback_release_workflow.md`, v0.x.1 normally
+  goes via commit-on-main. This patch adds 3 new env vars + 3 new
+  event types — borderline minor surface — so it ships as a single
+  squash-merge feature PR with explicit review (not skipped).
+- Pre-tag verification:
+  1. Restart gateway against the previously-bloated thread
+     `1778139665.927099` (we already cleared it on 2026-05-07; let
+     it accumulate again to mid-budget) and confirm prune-before-call
+     fires without `msg_too_long`.
+  2. Force a synthetic `msg_too_long` (set `PMK_MAX_SESSION_TOKENS=1`
+     for one run) to exercise the retry path live.
+  3. Run `pmk gateway audit --days 1` and check the new `Context
+     safety` section renders.
+- Changelog entry under v0.11.1: `gateway: msg_too_long hardening
+  — prune-before-call, single-message caps for PKB seed and mra
+  results, auto-retry with abridged history, three new
+  PMK_*_CAP env vars, three new context.* event types, audit
+  rollup section`.
+
+## Forward link: v0.12 — anthropic-api provider as gateway default
+
+v0.11.1 absorbs the SDK-overhead unknown by lowering caps; it does
+not eliminate the unknown itself. v0.12 should let the gateway opt
+out of `claude-agent-sdk` and call Anthropic's API directly.
+
+Reasons:
+
+- Removes the "host's `~/.claude/` config bleeds into every gateway
+  request" variable, making token budgets predictable.
+- The gateway does not need agentic tools; the SDK is overkill.
+- Operator can monitor cost and rate limits at the API level.
+
+Costs (to be planned in v0.12 spec, not here):
+
+- Provider abstraction touchup; `gateway init` flow gains an API-key
+  step.
+- Auth & billing user experience changes (subscription → token
+  billing).
+- Migration guide for existing v0.11.x users.
+
+Cap mechanism from v0.11.1 stays in v0.12; only the budgets relax
+toward the model's true context window.
+
+## Open questions
+
+None at draft time. (Decisions on cap aggressiveness, retry UX, and
+roadmap scope were resolved during the brainstorming session that
+produced this spec on 2026-05-07.)

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmk/docs",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "description": "Docusaurus docs site for pm-workspace-kit",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-workspace-kit",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "description": "An opinionated PM/SA workspace kit — Docusaurus docs site, traceability scripts, CLI (pmk), and desktop app. Monorepo.",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmk/cli",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "pmk — command-line interface for pm-workspace-kit",
   "license": "MIT",
   "bin": {

--- a/packages/cli/src/gateway/audit-format.ts
+++ b/packages/cli/src/gateway/audit-format.ts
@@ -94,6 +94,20 @@ export function formatAuditReport(report: AuditReport): string {
       ),
   );
 
+  // context safety
+  lines.push("");
+  lines.push(chalk.bold("Context safety"));
+  const cs = report.contextSafety;
+  lines.push(
+    label("context.exceeded:") +
+      `${cs.contextExceeded.total} (first-call ${cs.contextExceeded.firstCall}, synthesise ${cs.contextExceeded.synthesise})`,
+  );
+  lines.push(label("force-pruned:") + cs.contextForcePruned);
+  lines.push(
+    label("messages capped:") +
+      `${cs.messageCapped.total} (seed ${cs.messageCapped.seed}, mra-result ${cs.messageCapped.mraResult})`,
+  );
+
   // flags
   if (report.flags.length > 0) {
     lines.push("");

--- a/packages/cli/src/gateway/audit.ts
+++ b/packages/cli/src/gateway/audit.ts
@@ -62,6 +62,16 @@ export interface AuditReport {
     /** Lifetime, by source.contributorUserId. */
     topContributors: Array<{ userId: string; count: number }>;
   };
+  /**
+   * v0.11.1: rollup of context-safety events written by the gateway
+   * when budget caps and the msg_too_long retry path fire. Operators
+   * use these counts to decide whether to tighten PMK_*_CAP env vars.
+   */
+  contextSafety: {
+    contextExceeded: { total: number; firstCall: number; synthesise: number };
+    contextForcePruned: number;
+    messageCapped: { total: number; seed: number; mraResult: number };
+  };
   flags: string[];
 }
 
@@ -109,6 +119,14 @@ export function buildAuditReport(
   const triggeredAt = new Map<string, number[]>();
   const replyDurations: number[] = [];
 
+  let ctxExc = 0,
+    ctxExcFirst = 0,
+    ctxExcSynth = 0;
+  let ctxForcePruned = 0;
+  let msgCap = 0,
+    msgCapSeed = 0,
+    msgCapMra = 0;
+
   for (const e of events) {
     switch (e.type) {
       case "turn.processed":
@@ -149,6 +167,19 @@ export function buildAuditReport(
         }
         break;
       }
+      case "context.exceeded":
+        ctxExc++;
+        if (e.phase === "first-call") ctxExcFirst++;
+        else if (e.phase === "synthesise") ctxExcSynth++;
+        break;
+      case "context.force-pruned":
+        ctxForcePruned++;
+        break;
+      case "message.capped":
+        msgCap++;
+        if (e.kind === "seed") msgCapSeed++;
+        else if (e.kind === "mra-result") msgCapMra++;
+        break;
     }
   }
 
@@ -211,6 +242,19 @@ export function buildAuditReport(
       retrievalInjections,
       medianAtomsInjectedPerTurn: median(injectedSamples),
       topContributors: rank(contributors, "userId", "count"),
+    },
+    contextSafety: {
+      contextExceeded: {
+        total: ctxExc,
+        firstCall: ctxExcFirst,
+        synthesise: ctxExcSynth,
+      },
+      contextForcePruned: ctxForcePruned,
+      messageCapped: {
+        total: msgCap,
+        seed: msgCapSeed,
+        mraResult: msgCapMra,
+      },
     },
     flags,
   };

--- a/packages/cli/src/gateway/events.ts
+++ b/packages/cli/src/gateway/events.ts
@@ -105,12 +105,62 @@ export interface GatewayPresenceEvent {
   offlineDurationMs?: number;
 }
 
+/**
+ * Emitted when the model returns a `prompt is too long` 400 at one of
+ * the two budget walls — the first call (seed + history + retrieval)
+ * or the synthesise call (mra-result fold-in). `sessionTokensBefore`
+ * is the gateway's pre-call estimate so audits can correlate against
+ * the model's effective limit and tune the safety margin.
+ * `retrievalAtoms` is captured separately because retrieval payload is
+ * the most common blow-up vector and must be visible without
+ * re-deriving it from elsewhere.
+ */
+export interface ContextExceededEvent {
+  type: "context.exceeded";
+  actor: string;
+  sessionTokensBefore: number;
+  retrievalAtoms: number;
+  phase: "first-call" | "synthesise";
+}
+
+/**
+ * Emitted when the retry-after-context-exceeded path force-prunes the
+ * session below the normal keep-N to make headroom. `droppedPairs`
+ * counts user/assistant pairs evicted; `tokensAfter` is the post-prune
+ * estimate — together they reveal whether the wall is repeatedly hit
+ * on already-small histories (a sign the seed/retrieval cap is the
+ * real culprit, not the rolling history).
+ */
+export interface ContextForcePrunedEvent {
+  type: "context.force-pruned";
+  actor: string;
+  droppedPairs: number;
+  tokensAfter: number;
+}
+
+/**
+ * Emitted when seed input or mra-result payload is hard-capped before
+ * being sent to the model. `originalChars`/`cappedChars` make the
+ * truncation ratio inspectable so operators can see when the cap is
+ * trimming meaningful content vs trailing noise.
+ */
+export interface MessageCappedEvent {
+  type: "message.capped";
+  actor: string;
+  kind: "seed" | "mra-result";
+  originalChars: number;
+  cappedChars: number;
+}
+
 export type GatewayEvent =
   | MraAskEndEvent
   | TurnProcessedEvent
   | EscalateTriggeredEvent
   | EscalateAbsorbedEvent
-  | GatewayPresenceEvent;
+  | GatewayPresenceEvent
+  | ContextExceededEvent
+  | ContextForcePrunedEvent
+  | MessageCappedEvent;
 
 /** What lands on disk: the event plus the ISO timestamp added at append time. */
 export type StoredGatewayEvent = GatewayEvent & { at: string };
@@ -122,6 +172,9 @@ const VALID_TYPES: ReadonlySet<string> = new Set([
   "escalate.absorbed",
   "gateway.online",
   "gateway.offline",
+  "context.exceeded",
+  "context.force-pruned",
+  "message.capped",
 ]);
 
 /**

--- a/packages/cli/src/gateway/messaging.ts
+++ b/packages/cli/src/gateway/messaging.ts
@@ -328,3 +328,28 @@ export function pruneSessionIfNeeded(
     tokensAfter: session.approxTokens,
   };
 }
+
+/**
+ * Last-resort prune for the msg_too_long retry path. Keeps PKB seed
+ * pair (if present) plus the most-recent user/assistant pair, drops
+ * everything between. Returns dropped (user,assistant) pair count.
+ * Idempotent. Does not consult MAX_SESSION_TOKENS — this is the
+ * absolute floor we'll fall back to when the model has already
+ * rejected the prior payload as too long.
+ */
+export function forcePruneToMinimum(session: SessionLike): number {
+  const msgs = session.messages;
+  const hasPkbSeed =
+    msgs.length >= 2 &&
+    msgs[0].role === "user" &&
+    msgs[0].content.startsWith(PKB_SEED_PREFIX) &&
+    msgs[1].role === "assistant";
+  const seedSlice = hasPkbSeed ? msgs.slice(0, 2) : [];
+  const seedEnd = hasPkbSeed ? 2 : 0;
+  if (msgs.length - seedEnd <= 2) return 0;
+  const droppedPairs = Math.floor((msgs.length - seedEnd - 2) / 2);
+  const tailSlice = msgs.slice(-2);
+  session.messages = [...seedSlice, ...tailSlice];
+  session.approxTokens = approxTokensFor(session.messages);
+  return droppedPairs;
+}

--- a/packages/cli/src/gateway/messaging.ts
+++ b/packages/cli/src/gateway/messaging.ts
@@ -229,6 +229,13 @@ export interface PruneResult {
   tokensAfter: number;
 }
 
+export interface PruneOpts {
+  /** Messages sent on next call but not in session.messages (e.g. retrievalPrefix). */
+  extra?: ChatMessage[];
+  /** New user turn that will be appended to the call payload. */
+  newUser?: string;
+}
+
 /**
  * If a session is approaching context-window saturation, drop the
  * oldest non-seed turns to bring it back under cap. Always preserves:
@@ -245,7 +252,17 @@ export interface PruneResult {
  * for the caller to log. Caller is responsible for calling
  * `saveSession()` afterward so the pruned state hits disk.
  */
-export function pruneSessionIfNeeded(session: SessionLike): PruneResult {
+export function pruneSessionIfNeeded(
+  session: SessionLike,
+  opts: PruneOpts = {},
+): PruneResult {
+  const extras: ChatMessage[] = [
+    ...(opts.extra ?? []),
+    ...(opts.newUser ? [{ role: "user" as const, content: opts.newUser }] : []),
+  ];
+  // Recompute INCLUDING extras so we don't undercount the next call.
+  session.approxTokens = approxTokensFor(session.messages, extras);
+
   if (session.approxTokens <= MAX_SESSION_TOKENS) {
     return {
       pruned: false,
@@ -302,7 +319,7 @@ export function pruneSessionIfNeeded(session: SessionLike): PruneResult {
   };
 
   session.messages = [...seedSlice, marker, ...recent];
-  session.approxTokens = approxTokensFor(session.messages);
+  session.approxTokens = approxTokensFor(session.messages, extras);
   return {
     pruned: true,
     droppedPairs,

--- a/packages/cli/src/gateway/messaging.ts
+++ b/packages/cli/src/gateway/messaging.ts
@@ -141,7 +141,7 @@ export function buildMraSuccessMessage(repo: string, stdout: string): string {
     `這是 \`mra ask ${repo}\` 的回傳結果（請依此 synthesise 最終答案；若這份結果不足，可再 emit 一次 mra-ask，但仍以 PKB + 這份結果優先）：`,
     "",
     "```mra-result",
-    truncate(stdout.trim(), 24_000),
+    stdout.trim(),
     "```",
   ].join("\n");
 }
@@ -179,10 +179,9 @@ export const SEED_CAP = parsePositiveIntEnv("PMK_SEED_CAP", 12_000);
 
 /**
  * Maximum chars for `mra-ask` stdout pushed into session history.
- * Wired into `buildMraSuccessMessage` by a follow-up task (T9 of the
- * v0.11.1 hardening plan); until then the function still uses its
- * pre-existing hard-coded 24_000. Setting `PMK_MRA_RESULT_CAP` only
- * takes effect once that wiring lands.
+ * Applied at the call site in `synthesiseAfterMra` (slack/index.ts)
+ * before passing to `buildMraSuccessMessage`. Override with
+ * `PMK_MRA_RESULT_CAP=…` per host.
  */
 export const MRA_RESULT_CAP = parsePositiveIntEnv(
   "PMK_MRA_RESULT_CAP",

--- a/packages/cli/src/gateway/messaging.ts
+++ b/packages/cli/src/gateway/messaging.ts
@@ -172,13 +172,17 @@ export const MAX_SESSION_TOKENS = parsePositiveIntEnv(
  * Maximum chars for the PKB seed message pushed at the start of a
  * fresh session. Defaults to 12_000 — generous enough for a multi-
  * repo summary, tight enough that the seed cannot single-handedly
- * exhaust the model's input window.
+ * exhaust the model's input window. Override with `PMK_SEED_CAP=…`
+ * per host.
  */
 export const SEED_CAP = parsePositiveIntEnv("PMK_SEED_CAP", 12_000);
 
 /**
  * Maximum chars for `mra-ask` stdout pushed into session history.
- * Replaces the prior hard-coded 24_000 in `buildMraSuccessMessage`.
+ * Wired into `buildMraSuccessMessage` by a follow-up task (T9 of the
+ * v0.11.1 hardening plan); until then the function still uses its
+ * pre-existing hard-coded 24_000. Setting `PMK_MRA_RESULT_CAP` only
+ * takes effect once that wiring lands.
  */
 export const MRA_RESULT_CAP = parsePositiveIntEnv(
   "PMK_MRA_RESULT_CAP",

--- a/packages/cli/src/gateway/messaging.ts
+++ b/packages/cli/src/gateway/messaging.ts
@@ -287,8 +287,10 @@ export function pruneSessionIfNeeded(
     msgs.length - seedEnd - 1 <= KEEP_RECENT_TURNS * 2
   ) {
     // We've already pruned and not enough new turns have accumulated
-    // to need another pass. Recompute tokens just in case.
-    session.approxTokens = approxTokensFor(msgs);
+    // to need another pass. Recompute tokens just in case — include
+    // extras so the post-call invariant is consistent across all
+    // return paths (downstream callers see a single, comparable value).
+    session.approxTokens = approxTokensFor(msgs, extras);
     return {
       pruned: false,
       droppedPairs: 0,

--- a/packages/cli/src/gateway/messaging.ts
+++ b/packages/cli/src/gateway/messaging.ts
@@ -22,6 +22,29 @@ export function truncate(s: string, max: number): string {
   return `${s.slice(0, max)}\n…(truncated ${s.length - max} chars)`;
 }
 
+export interface CapResult {
+  content: string;
+  capped: boolean;
+  originalChars: number;
+}
+
+/**
+ * Wraps `truncate` to additionally report whether truncation happened
+ * and the pre-truncation length. Callers (write sites for PKB seed and
+ * mra-results) use the metadata to write `message.capped` audit
+ * events without re-measuring.
+ */
+export function capMessageContent(content: string, limit: number): CapResult {
+  if (content.length <= limit) {
+    return { content, capped: false, originalChars: content.length };
+  }
+  return {
+    content: truncate(content, limit),
+    capped: true,
+    originalChars: content.length,
+  };
+}
+
 /**
  * Build a one-shot seed message containing PKB content for the
  * configured ingest spec. Returns undefined when no PKB is found

--- a/packages/cli/src/gateway/messaging.ts
+++ b/packages/cli/src/gateway/messaging.ts
@@ -206,13 +206,18 @@ interface SessionLike {
 const PKB_SEED_PREFIX = "我先把 workspace 的 PKB context 給你";
 
 /**
- * Estimate token count for a message-array using the same ~3.5
- * chars-per-token heuristic the rest of the gateway uses (matches
- * `approxTokensFor` in slack/index.ts).
+ * Estimate token count for a primary message-array, optionally adding
+ * the cost of an `extra` array (e.g. `retrievalPrefix` content that is
+ * sent to the model on the next call but not stored in
+ * `session.messages`). Uses the same ~3.5 chars-per-token heuristic.
  */
-function approxTokensFor(messages: ChatMessage[]): number {
+export function approxTokensFor(
+  messages: ChatMessage[],
+  extra: ChatMessage[] = [],
+): number {
   let total = 0;
   for (const m of messages) total += m.content.length;
+  for (const m of extra) total += m.content.length;
   return Math.ceil(total / 3.5);
 }
 

--- a/packages/cli/src/gateway/messaging.ts
+++ b/packages/cli/src/gateway/messaging.ts
@@ -148,21 +148,42 @@ export function buildMraSuccessMessage(repo: string, stdout: string): string {
 
 // ─────────────────── session pruning (v0.8.1, #18) ──────────────────────
 
-/**
- * Soft cap for `session.approxTokens` before pruning kicks in. Set to
- * about 70% of a typical 90k-token gateway-DM context budget — leaves
- * headroom for system prompt + retrieval prefix + the new user turn
- * and the model's reply.
- *
- * Tunable via `PMK_MAX_SESSION_TOKENS` env var so hosts can override
- * without rebuilding (e.g. drop to 30k for cheaper Haiku-tier models
- * or push higher for Opus-tier 200k budgets).
- */
-export const MAX_SESSION_TOKENS = (() => {
-  const raw = process.env.PMK_MAX_SESSION_TOKENS;
+function parsePositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
   const parsed = raw ? Number.parseInt(raw, 10) : NaN;
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 60_000;
-})();
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * Soft cap for `session.approxTokens` before pruning kicks in.
+ * v0.11.1: lowered default from 60_000 → 25_000. The 60k figure
+ * assumed ~70% of a 90k DM-context budget and ignored the host
+ * config that `claude-agent-sdk` inherits when it spawns the local
+ * `claude` CLI. 25k leaves explicit headroom for system prompt +
+ * retrieval prefix + SDK-inherited host context + new turn + reply.
+ * Override with `PMK_MAX_SESSION_TOKENS=…` per host.
+ */
+export const MAX_SESSION_TOKENS = parsePositiveIntEnv(
+  "PMK_MAX_SESSION_TOKENS",
+  25_000,
+);
+
+/**
+ * Maximum chars for the PKB seed message pushed at the start of a
+ * fresh session. Defaults to 12_000 — generous enough for a multi-
+ * repo summary, tight enough that the seed cannot single-handedly
+ * exhaust the model's input window.
+ */
+export const SEED_CAP = parsePositiveIntEnv("PMK_SEED_CAP", 12_000);
+
+/**
+ * Maximum chars for `mra-ask` stdout pushed into session history.
+ * Replaces the prior hard-coded 24_000 in `buildMraSuccessMessage`.
+ */
+export const MRA_RESULT_CAP = parsePositiveIntEnv(
+  "PMK_MRA_RESULT_CAP",
+  16_000,
+);
 
 /** How many recent (user, assistant) pairs to always keep across a prune. */
 export const KEEP_RECENT_TURNS = 10;

--- a/packages/cli/src/gateway/slack/context-retry.ts
+++ b/packages/cli/src/gateway/slack/context-retry.ts
@@ -1,0 +1,119 @@
+import type { ChatMessage } from "@pmk/shared";
+import { forcePruneToMinimum } from "../messaging";
+import { appendGatewayEvent } from "../events";
+import { PmkContextTooLongError } from "../../llm/claude-agent";
+import type { ChatOptions, LlmProvider } from "../../llm";
+
+/**
+ * Session shape this helper mutates. Mirrors the FreeChatSession subset we
+ * need without dragging in the full type from `slack/index.ts` so the
+ * helper stays unit-testable in isolation. `forcePruneToMinimum` rewrites
+ * `messages` and updates `approxTokens` in place.
+ */
+export interface ContextRetrySession {
+  messages: ChatMessage[];
+  approxTokens: number;
+}
+
+/**
+ * Which budget wall the retry is firing at. Recorded on the
+ * `context.exceeded` event so audits can tell "first call" prompt blow-ups
+ * apart from synthesise-round mra-result fold-in blow-ups.
+ */
+export type ContextRetryPhase = "first-call" | "synthesise";
+
+export interface ContextRetryArgs {
+  llm: Pick<LlmProvider, "chat">;
+  systemPrompt: string;
+  /**
+   * Builds the message array to send. Called twice — once for the initial
+   * attempt and once after force-prune. The second call must reflect the
+   * post-force-prune session state, which is why this is a closure rather
+   * than a pre-built array.
+   */
+  buildMessages: () => ChatMessage[];
+  session: ContextRetrySession;
+  actor: string;
+  retrievalAtoms: number;
+  phase: ContextRetryPhase;
+  chatOptions?: ChatOptions;
+}
+
+export type ContextRetryResult =
+  | { ok: true; full: string; scissorsPrefix: string }
+  | {
+      ok: false;
+      kind: "context";
+      firstError: PmkContextTooLongError;
+      secondError: unknown;
+    }
+  | { ok: false; kind: "other"; error: unknown };
+
+/**
+ * Wraps `llm.chat` with a context-too-long retry path. On
+ * `PmkContextTooLongError`: emits `context.exceeded`, force-prunes the
+ * session, emits `context.force-pruned`, then retries. On retry success
+ * returns the reply with a `:scissors: 對話過長，已自動裁掉 N 輪舊訊息\n\n`
+ * prefix the caller can prepend to the visible Slack reply. Other errors
+ * propagate as `{ ok: false, kind: "other" }` so the caller can keep its
+ * existing non-context error display.
+ *
+ * Note: this helper does NOT touch any Slack APIs. It owns only the
+ * audit-event side effects + the session mutation produced by
+ * `forcePruneToMinimum`. Slack `chat.update` for error display stays at
+ * the call site so the helper remains usable from non-Slack contexts.
+ */
+export async function chatWithContextRetry(
+  args: ContextRetryArgs,
+): Promise<ContextRetryResult> {
+  const {
+    llm,
+    systemPrompt,
+    buildMessages,
+    session,
+    actor,
+    retrievalAtoms,
+    phase,
+    chatOptions,
+  } = args;
+  const opts: ChatOptions = chatOptions ?? { onToken: () => {} };
+
+  try {
+    const full = await llm.chat(systemPrompt, buildMessages(), opts);
+    return { ok: true, full, scissorsPrefix: "" };
+  } catch (err) {
+    if (!(err instanceof PmkContextTooLongError)) {
+      return { ok: false, kind: "other", error: err };
+    }
+    appendGatewayEvent({
+      type: "context.exceeded",
+      actor,
+      sessionTokensBefore: session.approxTokens,
+      retrievalAtoms,
+      phase,
+    });
+    const dropped = forcePruneToMinimum(session);
+    appendGatewayEvent({
+      type: "context.force-pruned",
+      actor,
+      droppedPairs: dropped,
+      tokensAfter: session.approxTokens,
+    });
+
+    try {
+      const full = await llm.chat(systemPrompt, buildMessages(), opts);
+      return {
+        ok: true,
+        full,
+        scissorsPrefix: `:scissors: 對話過長，已自動裁掉 ${dropped} 輪舊訊息\n\n`,
+      };
+    } catch (err2) {
+      return {
+        ok: false,
+        kind: "context",
+        firstError: err,
+        secondError: err2,
+      };
+    }
+  }
+}

--- a/packages/cli/src/gateway/slack/context-retry.ts
+++ b/packages/cli/src/gateway/slack/context-retry.ts
@@ -102,10 +102,17 @@ export async function chatWithContextRetry(
 
     try {
       const full = await llm.chat(systemPrompt, buildMessages(), opts);
+      // Suppress the scissors marker when forcePrune had nothing to
+      // drop (degenerate case: very short session that still triggered
+      // msg_too_long, e.g. one giant message). Saying "已裁掉 0 輪"
+      // would be misleading.
       return {
         ok: true,
         full,
-        scissorsPrefix: `:scissors: 對話過長，已自動裁掉 ${dropped} 輪舊訊息\n\n`,
+        scissorsPrefix:
+          dropped > 0
+            ? `:scissors: 對話過長，已自動裁掉 ${dropped} 輪舊訊息\n\n`
+            : "",
       };
     } catch (err2) {
       return {

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -533,6 +533,21 @@ export class SlackAdapter {
           },
         ]
       : [];
+
+    // v0.11.1: prune BEFORE the LLM call so a bloated session can be
+    // trimmed on its way in, not after it has already triggered
+    // msg_too_long. Includes retrievalPrefix and the new user turn in
+    // the budget check so the prune reflects what we'll actually send.
+    const pruneReport = pruneSessionIfNeeded(session, {
+      extra: retrievalPrefix,
+      newUser: text,
+    });
+    if (pruneReport.pruned) {
+      this.onLog(
+        `pruned session: dropped ${pruneReport.droppedPairs} turn-pair(s); now ${pruneReport.tokensAfter} approx tokens`,
+      );
+    }
+
     const llmMessages: ChatMessage[] = [
       ...retrievalPrefix,
       ...session.messages,
@@ -602,16 +617,6 @@ export class SlackAdapter {
     session.messages.push({ role: "assistant", content: visible });
     session.approxTokens = approxTokensFor(session.messages);
 
-    // v0.8.1: trim long histories before persisting. Idempotent — only
-    // fires when over MAX_SESSION_TOKENS; preserves PKB seed + last
-    // KEEP_RECENT_TURNS pairs; inserts a "(此處省略...)" marker for
-    // the model to see there was earlier history.
-    const pruneReport = pruneSessionIfNeeded(session);
-    if (pruneReport.pruned) {
-      this.onLog(
-        `pruned session: dropped ${pruneReport.droppedPairs} turn-pair(s); now ${pruneReport.tokensAfter} approx tokens`,
-      );
-    }
     saveSession(session);
 
     appendGatewayEvent({

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -51,6 +51,7 @@ import { createLastLineThrottle } from "../throttle";
 import { sanitizeProgressLine } from "./progress";
 import { parseMraAsk, stripMraAskBlock } from "../mra-ask";
 import {
+  approxTokensFor,
   buildIngestSeed,
   buildMraFailureMessage,
   buildMraSuccessMessage,
@@ -126,14 +127,6 @@ export function slashCommandArgsFromBody(
  * noisy workspaces while keeping memory bounded for long-running hosts.
  */
 const SEEN_ENVELOPES_MAX = 2000;
-
-/** Approximate token cost from a list of messages. ~3.5 chars/token,
- * matching the existing per-turn heuristic. */
-function approxTokensFor(messages: ChatMessage[]): number {
-  let total = 0;
-  for (const m of messages) total += m.content.length;
-  return Math.ceil(total / 3.5);
-}
 
 export interface SlackBotInfo {
   botUserId: string;

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -34,6 +34,7 @@ import {
 import type { ChatMessage } from "@pmk/shared";
 import { pickGatewayPrompt } from "@pmk/shared";
 import { resolveProvider, type LlmProvider } from "../../llm";
+import { PmkContextTooLongError } from "../../llm/claude-agent";
 import { loadConfig as loadCliConfig } from "../../config";
 import { PROMPT_CASE } from "../../prompts";
 import {
@@ -596,22 +597,43 @@ export class SlackAdapter {
     session.turns += 1;
 
     let full = retryResult.full;
-    const scissorsPrefix = retryResult.scissorsPrefix;
+    let scissorsPrefix = retryResult.scissorsPrefix;
 
     // If the model asked us to delegate a deep code-search round to
     // mra, run it and feed the result back for synthesis.
     const askReq = parseMraAsk(full);
     if (askReq) {
-      full = await this.handleMraAskRound({
-        channelId,
-        placeholderTs: String(placeholder.ts),
-        session,
-        retrievalPrefix,
-        firstResponse: full,
-        request: askReq,
-        systemPrompt,
-        actor: userId,
-      });
+      try {
+        const mraResult = await this.handleMraAskRound({
+          channelId,
+          placeholderTs: String(placeholder.ts),
+          session,
+          retrievalPrefix,
+          retrievalAtoms: retrieved.length,
+          firstResponse: full,
+          request: askReq,
+          systemPrompt,
+          actor: userId,
+        });
+        full = mraResult.full;
+        // T12: if the synthesise round ALSO needed force-prune, the
+        // post-prune scissors notice more accurately reflects the final
+        // session state than the first-call notice. Two notices stacked
+        // would just confuse the user, so the latter wins.
+        if (mraResult.scissorsPrefix) {
+          scissorsPrefix = mraResult.scissorsPrefix;
+        }
+      } catch (err) {
+        if (err instanceof PmkContextTooLongError) {
+          await this.web.chat.update({
+            channel: channelId,
+            ts: String(placeholder.ts),
+            text: ":x: 對話太長，請開新 thread 重新提問",
+          });
+          return;
+        }
+        throw err;
+      }
     }
 
     // If the model asked to escalate to a human IT/domain expert, fan
@@ -988,18 +1010,23 @@ export class SlackAdapter {
     /** Retrieval atoms injected into the first LLM call; passed
      * through so the synthesis round still sees them. */
     retrievalPrefix: ChatMessage[];
+    /** Atom count corresponding to retrievalPrefix; threaded through
+     * to synthesiseAfterMra → chatWithContextRetry so the
+     * `context.exceeded` audit event records it accurately. */
+    retrievalAtoms: number;
     firstResponse: string;
     request: { repo: string; question: string };
     systemPrompt: string;
     /** Slack user ID that triggered this round — recorded in the
      * audit event so per-user mra-ask cost is attributable. */
     actor: string;
-  }): Promise<string> {
+  }): Promise<{ full: string; scissorsPrefix: string }> {
     const {
       channelId,
       placeholderTs,
       session,
       retrievalPrefix,
+      retrievalAtoms,
       firstResponse,
       request,
       systemPrompt,
@@ -1014,6 +1041,7 @@ export class SlackAdapter {
       return await this.synthesiseAfterMra({
         session,
         retrievalPrefix,
+        retrievalAtoms,
         firstResponse,
         request,
         systemPrompt,
@@ -1110,6 +1138,7 @@ export class SlackAdapter {
     return await this.synthesiseAfterMra({
       session,
       retrievalPrefix,
+      retrievalAtoms,
       firstResponse,
       request,
       result,
@@ -1123,19 +1152,27 @@ export class SlackAdapter {
    * user message into the session, then re-call the LLM. The mra
    * result message is later kept in session history so follow-up
    * turns can reference it.
+   *
+   * T12: wrapped in `chatWithContextRetry` (phase="synthesise") so a
+   * post-mra-ask blow-up triggers the same force-prune-and-scissors
+   * recovery path as the first-call site. Throws `PmkContextTooLongError`
+   * when even the post-prune retry can't fit, letting the caller decide
+   * how to surface the failure to Slack (see runFreeChatTurn).
    */
   private async synthesiseAfterMra(args: {
     session: FreeChatSession;
     retrievalPrefix: ChatMessage[];
+    retrievalAtoms: number;
     firstResponse: string;
     request: { repo: string; question: string };
     result: { ok: boolean; stdout: string; stderr: string; reason?: string };
     systemPrompt: string;
     actor: string;
-  }): Promise<string> {
+  }): Promise<{ full: string; scissorsPrefix: string }> {
     const {
       session,
       retrievalPrefix,
+      retrievalAtoms,
       firstResponse,
       request,
       result,
@@ -1164,11 +1201,28 @@ export class SlackAdapter {
 
     // Retrieval atoms come back here too — synthesis benefits from
     // both the retrieved knowledge AND the fresh mra-result.
-    return await this.llm.chat(
+    const retryResult = await chatWithContextRetry({
+      llm: this.llm,
       systemPrompt,
-      [...retrievalPrefix, ...session.messages],
-      { onToken: () => {} },
-    );
+      buildMessages: () => [...retrievalPrefix, ...session.messages],
+      session,
+      actor,
+      retrievalAtoms,
+      phase: "synthesise",
+      chatOptions: { onToken: () => {} },
+    });
+
+    if (!retryResult.ok) {
+      // Bubble up so the caller (runFreeChatTurn) can post the friendly
+      // ":x: 對話太長…" message. Other (non-context) errors are
+      // re-thrown as-is and caught by the outer Slack handler.
+      if (retryResult.kind === "context") {
+        throw new PmkContextTooLongError(retryResult.secondError);
+      }
+      throw retryResult.error;
+    }
+
+    return { full: retryResult.full, scissorsPrefix: retryResult.scissorsPrefix };
   }
 
   // ────────────────────────── channel logic ──────────────────────────

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -55,7 +55,9 @@ import {
   buildIngestSeed,
   buildMraFailureMessage,
   buildMraSuccessMessage,
+  capMessageContent,
   pruneSessionIfNeeded,
+  SEED_CAP,
   truncate,
 } from "../messaging";
 import { parseEscalate, stripEscalateBlock } from "../escalate";
@@ -487,13 +489,28 @@ export class SlackAdapter {
     // config.defaultIngest (e.g. mra:--all). Without this the model
     // truthfully says it has no idea about the user's codebase even
     // though we configured the ingest spec at gateway init.
+    //
+    // v0.11.1: cap the seed at SEED_CAP chars so an `mra:--all` against a
+    // large multi-repo workspace can't single-handedly exhaust the
+    // model's input window. Emits a `message.capped` event when capping
+    // fires so operators can see how often the cap is biting.
     if (session.messages.length === 0 && this.config.defaultIngest) {
-      const seed = buildIngestSeed(
+      const seedRaw = buildIngestSeed(
         this.config.defaultIngest,
         this.config.mraWorkspace,
       );
-      if (seed) {
-        session.messages.push({ role: "user", content: seed });
+      if (seedRaw) {
+        const cap = capMessageContent(seedRaw, SEED_CAP);
+        if (cap.capped) {
+          appendGatewayEvent({
+            type: "message.capped",
+            actor: userId,
+            kind: "seed",
+            originalChars: cap.originalChars,
+            cappedChars: cap.content.length,
+          });
+        }
+        session.messages.push({ role: "user", content: cap.content });
         session.messages.push({
           role: "assistant",
           content: "了解，已載入 workspace PKB context。請繼續。",

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -56,6 +56,7 @@ import {
   buildMraFailureMessage,
   buildMraSuccessMessage,
   capMessageContent,
+  MRA_RESULT_CAP,
   pruneSessionIfNeeded,
   SEED_CAP,
   truncate,
@@ -993,6 +994,7 @@ export class SlackAdapter {
         firstResponse,
         request,
         systemPrompt,
+        actor,
         result: {
           ok: false,
           stdout: "",
@@ -1089,6 +1091,7 @@ export class SlackAdapter {
       request,
       result,
       systemPrompt,
+      actor,
     });
   }
 
@@ -1105,6 +1108,7 @@ export class SlackAdapter {
     request: { repo: string; question: string };
     result: { ok: boolean; stdout: string; stderr: string; reason?: string };
     systemPrompt: string;
+    actor: string;
   }): Promise<string> {
     const {
       session,
@@ -1113,11 +1117,26 @@ export class SlackAdapter {
       request,
       result,
       systemPrompt,
+      actor,
     } = args;
     session.messages.push({ role: "assistant", content: firstResponse });
-    const mraMessage = result.ok
-      ? buildMraSuccessMessage(request.repo, result.stdout)
-      : buildMraFailureMessage(request.repo, result);
+
+    let mraMessage: string;
+    if (result.ok) {
+      const cap = capMessageContent(result.stdout, MRA_RESULT_CAP);
+      if (cap.capped) {
+        appendGatewayEvent({
+          type: "message.capped",
+          actor,
+          kind: "mra-result",
+          originalChars: cap.originalChars,
+          cappedChars: cap.content.length,
+        });
+      }
+      mraMessage = buildMraSuccessMessage(request.repo, cap.content);
+    } else {
+      mraMessage = buildMraFailureMessage(request.repo, result);
+    }
     session.messages.push({ role: "user", content: mraMessage });
 
     // Retrieval atoms come back here too — synthesis benefits from

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -8,6 +8,7 @@ import {
   pickEscalationPool,
 } from "../config";
 import { handleAdminSlash } from "./admin";
+import { chatWithContextRetry } from "./context-retry";
 import {
   formatBackOnlineNotice,
   formatOfflineNotice,
@@ -548,15 +549,6 @@ export class SlackAdapter {
       );
     }
 
-    const llmMessages: ChatMessage[] = [
-      ...retrievalPrefix,
-      ...session.messages,
-      { role: "user", content: text },
-    ];
-
-    session.messages.push({ role: "user", content: text });
-    session.turns += 1;
-
     const placeholder = await this.web.chat.postMessage({
       channel: channelId,
       thread_ts: threadTs,
@@ -566,19 +558,45 @@ export class SlackAdapter {
     const audience = pickAudience(this.config, userId, channelId);
     const systemPrompt = pickGatewayPrompt(audience);
 
-    let full = "";
-    try {
-      full = await this.llm.chat(systemPrompt, llmMessages, {
-        onToken: () => {},
-      });
-    } catch (err) {
+    // T11: wrap llm.chat in the context-too-long retry helper. The
+    // buildMessages closure includes the new user turn at the tail so
+    // the LLM sees it on both attempts; we deliberately do NOT push it
+    // onto session.messages until AFTER the retry succeeds, so a failed
+    // turn doesn't pollute persisted history (and so forcePruneToMinimum
+    // operates on a coherent paired-history shape).
+    const retryResult = await chatWithContextRetry({
+      llm: this.llm,
+      systemPrompt,
+      buildMessages: () => [
+        ...retrievalPrefix,
+        ...session.messages,
+        { role: "user", content: text },
+      ],
+      session,
+      actor: userId,
+      retrievalAtoms: retrieved.length,
+      phase: "first-call",
+    });
+
+    if (!retryResult.ok) {
+      const errText =
+        retryResult.kind === "context"
+          ? ":x: 對話太長，請開新 thread 重新提問"
+          : `:warning: ${(retryResult.error as Error).message}`;
       await this.web.chat.update({
         channel: channelId,
         ts: String(placeholder.ts),
-        text: `:warning: ${(err as Error).message}`,
+        text: errText,
       });
       return;
     }
+
+    // Retry succeeded — NOW commit the new user turn to session history.
+    session.messages.push({ role: "user", content: text });
+    session.turns += 1;
+
+    let full = retryResult.full;
+    const scissorsPrefix = retryResult.scissorsPrefix;
 
     // If the model asked us to delegate a deep code-search round to
     // mra, run it and feed the result back for synthesis.
@@ -630,7 +648,7 @@ export class SlackAdapter {
     await this.web.chat.update({
       channel: channelId,
       ts: String(placeholder.ts),
-      text: truncateForSlack(markdownToMrkdwn(visible)),
+      text: scissorsPrefix + truncateForSlack(markdownToMrkdwn(visible)),
     });
   }
 

--- a/packages/cli/src/llm/claude-agent.ts
+++ b/packages/cli/src/llm/claude-agent.ts
@@ -3,6 +3,28 @@ import type { ChatMessage, PmkConfig } from "@pmk/shared";
 import type { ChatOptions, LlmProvider } from "./provider";
 
 /**
+ * Typed error wrapper for context-window-exhaustion failures coming out
+ * of the underlying SDK. The gateway-level retry path uses this to
+ * trigger a forced prune without relying on string-matching at a
+ * distance.
+ */
+export class PmkContextTooLongError extends Error {
+  readonly cause: unknown;
+  constructor(cause: unknown) {
+    super("PmkContextTooLongError");
+    this.name = "PmkContextTooLongError";
+    this.cause = cause;
+  }
+}
+
+const CONTEXT_TOO_LONG_RE = /msg_too_long|prompt is too long|context.+exceed/i;
+
+export function isContextTooLongError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return CONTEXT_TOO_LONG_RE.test(err.message);
+}
+
+/**
  * Delegates to the local `claude` CLI via the Claude Agent SDK, so we
  * inherit whatever auth the user already has (OAuth, subscription, API
  * key, Bedrock, Vertex) without requiring a separate ANTHROPIC_API_KEY.
@@ -29,57 +51,62 @@ export class ClaudeAgentSdkProvider implements LlmProvider {
     messages: ChatMessage[],
     opts: ChatOptions = {},
   ): Promise<string> {
-    const prompt = serialiseHistory(messages);
+    try {
+      const prompt = serialiseHistory(messages);
 
-    // Pass our own systemPrompt as a string — this replaces Claude
-    // Code's `claude_code` preset entirely, so the model should not
-    // think of itself as an agent with tools. `allowedTools: []` is
-    // belt-and-braces: even if a tool sneaks in, it can't execute.
-    //
-    // Note: we previously scoped the main thread to a custom
-    // AgentDefinition to suppress user-skill bleed (e.g. superpowers),
-    // but that *reinforced* agent/tool framing in the model's mind —
-    // responses started announcing "Skill tool → requirement-intake"
-    // instead of just answering. Removing the agent wrapper and
-    // relying on the systemPrompt + prompt discipline produces cleaner
-    // chat turns, at the cost of occasionally seeing a superpowers
-    // banner in the opener. Acceptable trade.
-    const q = query({
-      prompt,
-      options: {
-        model: this.config.model,
-        systemPrompt,
-        includePartialMessages: true,
-        allowedTools: [],
-        permissionMode: "default",
-        ...(this.executablePath
-          ? { pathToClaudeCodeExecutable: this.executablePath }
-          : {}),
-      },
-    });
+      // Pass our own systemPrompt as a string — this replaces Claude
+      // Code's `claude_code` preset entirely, so the model should not
+      // think of itself as an agent with tools. `allowedTools: []` is
+      // belt-and-braces: even if a tool sneaks in, it can't execute.
+      //
+      // Note: we previously scoped the main thread to a custom
+      // AgentDefinition to suppress user-skill bleed (e.g. superpowers),
+      // but that *reinforced* agent/tool framing in the model's mind —
+      // responses started announcing "Skill tool → requirement-intake"
+      // instead of just answering. Removing the agent wrapper and
+      // relying on the systemPrompt + prompt discipline produces cleaner
+      // chat turns, at the cost of occasionally seeing a superpowers
+      // banner in the opener. Acceptable trade.
+      const q = query({
+        prompt,
+        options: {
+          model: this.config.model,
+          systemPrompt,
+          includePartialMessages: true,
+          allowedTools: [],
+          permissionMode: "default",
+          ...(this.executablePath
+            ? { pathToClaudeCodeExecutable: this.executablePath }
+            : {}),
+        },
+      });
 
-    let full = "";
-    for await (const msg of q) {
-      if (msg.type === "stream_event") {
-        const event = msg.event;
-        if (
-          event.type === "content_block_delta" &&
-          event.delta.type === "text_delta"
-        ) {
-          const chunk = event.delta.text;
-          full += chunk;
-          opts.onToken?.(chunk);
+      let full = "";
+      for await (const msg of q) {
+        if (msg.type === "stream_event") {
+          const event = msg.event;
+          if (
+            event.type === "content_block_delta" &&
+            event.delta.type === "text_delta"
+          ) {
+            const chunk = event.delta.text;
+            full += chunk;
+            opts.onToken?.(chunk);
+          }
+        } else if (msg.type === "result") {
+          if (msg.subtype !== "success") {
+            throw new Error(
+              `[pmk] claude-agent returned non-success: ${msg.subtype}`,
+            );
+          }
+          break;
         }
-      } else if (msg.type === "result") {
-        if (msg.subtype !== "success") {
-          throw new Error(
-            `[pmk] claude-agent returned non-success: ${msg.subtype}`,
-          );
-        }
-        break;
       }
+      return full;
+    } catch (err) {
+      if (isContextTooLongError(err)) throw new PmkContextTooLongError(err);
+      throw err;
     }
-    return full;
   }
 }
 

--- a/packages/cli/test/context-retry.test.ts
+++ b/packages/cli/test/context-retry.test.ts
@@ -166,4 +166,45 @@ describe("chatWithContextRetry (T11)", () => {
       assert.fail("expected kind=context");
     }
   });
+
+  it("dropped=0 (degenerate session): scissorsPrefix is empty even on retry success", async () => {
+    const { chatWithContextRetry } = await import(
+      "../src/gateway/slack/context-retry"
+    );
+    const { PmkContextTooLongError } = await import(
+      "../src/llm/claude-agent"
+    );
+    let calls = 0;
+    const llm = {
+      chat: async () => {
+        calls++;
+        if (calls === 1) throw new PmkContextTooLongError(new Error("msg_too_long"));
+        return "after retry";
+      },
+    };
+    // Session too short for forcePruneToMinimum to drop anything
+    // (only one user/assistant pair, no seed) — should still retry
+    // but suppress the misleading "已裁掉 0 輪" marker.
+    const session = {
+      messages: [
+        { role: "user" as const, content: "Q" },
+        { role: "assistant" as const, content: "A" },
+      ],
+      approxTokens: 1_000,
+    };
+    const r = await chatWithContextRetry({
+      llm,
+      systemPrompt: "sys",
+      buildMessages: () => session.messages,
+      session,
+      actor: "Uabc",
+      retrievalAtoms: 0,
+      phase: "first-call",
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.full, "after retry");
+      assert.equal(r.scissorsPrefix, "");
+    }
+  });
 });

--- a/packages/cli/test/context-retry.test.ts
+++ b/packages/cli/test/context-retry.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const ORIG_HOME = process.env.HOME;
+
+describe("chatWithContextRetry (T11)", () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-retry-test-"));
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    else delete process.env.HOME;
+  });
+
+  it("happy path: returns full + empty scissorsPrefix", async () => {
+    const { chatWithContextRetry } = await import(
+      "../src/gateway/slack/context-retry"
+    );
+    const llm = { chat: async () => "hello" };
+    const session = { messages: [], approxTokens: 0 };
+    const r = await chatWithContextRetry({
+      llm,
+      systemPrompt: "sys",
+      buildMessages: () => [{ role: "user", content: "hi" }],
+      session,
+      actor: "Uabc",
+      retrievalAtoms: 0,
+      phase: "first-call",
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.full, "hello");
+      assert.equal(r.scissorsPrefix, "");
+    }
+  });
+
+  it("non-context error returns {ok:false, kind:'other'}", async () => {
+    const { chatWithContextRetry } = await import(
+      "../src/gateway/slack/context-retry"
+    );
+    const orig = new Error("rate limit");
+    const llm = {
+      chat: async () => {
+        throw orig;
+      },
+    };
+    const session = { messages: [], approxTokens: 0 };
+    const r = await chatWithContextRetry({
+      llm,
+      systemPrompt: "sys",
+      buildMessages: () => [{ role: "user", content: "hi" }],
+      session,
+      actor: "Uabc",
+      retrievalAtoms: 0,
+      phase: "first-call",
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok && r.kind === "other") {
+      assert.equal(r.error, orig);
+    } else {
+      assert.fail("expected kind=other");
+    }
+  });
+
+  it("context error → force-prune → retry success → scissorsPrefix populated + events written", async () => {
+    const { chatWithContextRetry } = await import(
+      "../src/gateway/slack/context-retry"
+    );
+    const { PmkContextTooLongError } = await import(
+      "../src/llm/claude-agent"
+    );
+    const { readGatewayEvents } = await import("../src/gateway/events");
+
+    let calls = 0;
+    const llm = {
+      chat: async () => {
+        calls++;
+        if (calls === 1)
+          throw new PmkContextTooLongError(new Error("msg_too_long"));
+        return "after retry";
+      },
+    };
+    // PKB seed prefix from messaging.ts; force-prune detects this exact
+    // string at messages[0].content.startsWith(...).
+    const SEED = "我先把 workspace 的 PKB context 給你 …";
+    const session = {
+      messages: [
+        { role: "user" as const, content: SEED },
+        { role: "assistant" as const, content: "ok" },
+        { role: "user" as const, content: "Q1" },
+        { role: "assistant" as const, content: "A1" },
+        { role: "user" as const, content: "Q2" },
+        { role: "assistant" as const, content: "A2" },
+      ],
+      approxTokens: 12345,
+    };
+    const r = await chatWithContextRetry({
+      llm,
+      systemPrompt: "sys",
+      buildMessages: () => session.messages,
+      session,
+      actor: "Uabc",
+      retrievalAtoms: 2,
+      phase: "first-call",
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.full, "after retry");
+      assert.match(
+        r.scissorsPrefix,
+        /^:scissors: 對話過長，已自動裁掉 \d+ 輪舊訊息\n\n$/,
+      );
+    }
+    assert.equal(calls, 2);
+    // Force-prune kept seed pair (2 msgs) + last user/assistant pair (2 msgs).
+    assert.equal(session.messages.length, 4);
+    // Events landed.
+    const events = readGatewayEvents({}).map((e) => e.type);
+    assert.ok(events.includes("context.exceeded"));
+    assert.ok(events.includes("context.force-pruned"));
+  });
+
+  it("context error → force-prune → retry also fails → {ok:false, kind:'context'}", async () => {
+    const { chatWithContextRetry } = await import(
+      "../src/gateway/slack/context-retry"
+    );
+    const { PmkContextTooLongError } = await import(
+      "../src/llm/claude-agent"
+    );
+    const llm = {
+      chat: async () => {
+        throw new PmkContextTooLongError(new Error("msg_too_long"));
+      },
+    };
+    const session = {
+      messages: [
+        { role: "user" as const, content: "Q1" },
+        { role: "assistant" as const, content: "A1" },
+        { role: "user" as const, content: "Q2" },
+        { role: "assistant" as const, content: "A2" },
+      ],
+      approxTokens: 5_000,
+    };
+    const r = await chatWithContextRetry({
+      llm,
+      systemPrompt: "sys",
+      buildMessages: () => session.messages,
+      session,
+      actor: "Uabc",
+      retrievalAtoms: 0,
+      phase: "first-call",
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok && r.kind === "context") {
+      assert.ok(r.firstError instanceof PmkContextTooLongError);
+      assert.ok(r.secondError instanceof PmkContextTooLongError);
+    } else {
+      assert.fail("expected kind=context");
+    }
+  });
+});

--- a/packages/cli/test/context-retry.test.ts
+++ b/packages/cli/test/context-retry.test.ts
@@ -167,6 +167,53 @@ describe("chatWithContextRetry (T11)", () => {
     }
   });
 
+  it("phase=synthesise: emits context.exceeded with phase='synthesise' (T12)", async () => {
+    const { chatWithContextRetry } = await import(
+      "../src/gateway/slack/context-retry"
+    );
+    const { PmkContextTooLongError } = await import(
+      "../src/llm/claude-agent"
+    );
+    const { readGatewayEvents } = await import("../src/gateway/events");
+    let calls = 0;
+    const llm = {
+      chat: async () => {
+        calls++;
+        if (calls === 1)
+          throw new PmkContextTooLongError(new Error("msg_too_long"));
+        return "synth ok";
+      },
+    };
+    const SEED = "我先把 workspace 的 PKB context 給你 …";
+    const session = {
+      messages: [
+        { role: "user" as const, content: SEED },
+        { role: "assistant" as const, content: "ok" },
+        { role: "user" as const, content: "Q1" },
+        { role: "assistant" as const, content: "A1" },
+        { role: "user" as const, content: "Q2" },
+        { role: "assistant" as const, content: "A2" },
+      ],
+      approxTokens: 8_000,
+    };
+    const r = await chatWithContextRetry({
+      llm,
+      systemPrompt: "sys",
+      buildMessages: () => session.messages,
+      session,
+      actor: "Uabc",
+      retrievalAtoms: 1,
+      phase: "synthesise",
+    });
+    assert.equal(r.ok, true);
+    const events = readGatewayEvents({});
+    const exc = events.find((e) => e.type === "context.exceeded");
+    assert.ok(exc, "expected context.exceeded event");
+    if (exc && exc.type === "context.exceeded") {
+      assert.equal(exc.phase, "synthesise");
+    }
+  });
+
   it("dropped=0 (degenerate session): scissorsPrefix is empty even on retry success", async () => {
     const { chatWithContextRetry } = await import(
       "../src/gateway/slack/context-retry"

--- a/packages/cli/test/gateway-audit-format.test.ts
+++ b/packages/cli/test/gateway-audit-format.test.ts
@@ -175,6 +175,29 @@ describe("formatAuditReport", () => {
     assert.match(out, /U_IT1 ×11.*U_IT2 ×8.*U_IT3 ×5/);
   });
 
+  it("renders Context safety section with non-zero counts", () => {
+    const report = emptyReport();
+    report.contextSafety = {
+      contextExceeded: { total: 2, firstCall: 1, synthesise: 1 },
+      contextForcePruned: 2,
+      messageCapped: { total: 3, seed: 2, mraResult: 1 },
+    };
+    const out = stripAnsi(formatAuditReport(report));
+    assert.match(out, /Context safety/);
+    assert.match(out, /context\.exceeded:\s+2 \(first-call 1, synthesise 1\)/);
+    assert.match(out, /force-pruned:\s+2/);
+    assert.match(out, /messages capped:\s+3 \(seed 2, mra-result 1\)/);
+  });
+
+  it("renders Context safety section with zero counts (always shown)", () => {
+    const report = emptyReport(); // contextSafety already zero from emptyReport helper
+    const out = stripAnsi(formatAuditReport(report));
+    assert.match(out, /Context safety/);
+    assert.match(out, /context\.exceeded:\s+0 \(first-call 0, synthesise 0\)/);
+    assert.match(out, /force-pruned:\s+0/);
+    assert.match(out, /messages capped:\s+0 \(seed 0, mra-result 0\)/);
+  });
+
   it("renders flags section only when there are flags", () => {
     const report = emptyReport({
       flags: [

--- a/packages/cli/test/gateway-audit-format.test.ts
+++ b/packages/cli/test/gateway-audit-format.test.ts
@@ -36,6 +36,11 @@ function emptyReport(overrides: Partial<AuditReport> = {}): AuditReport {
       medianAtomsInjectedPerTurn: undefined,
       topContributors: [],
     },
+    contextSafety: {
+      contextExceeded: { total: 0, firstCall: 0, synthesise: 0 },
+      contextForcePruned: 0,
+      messageCapped: { total: 0, seed: 0, mraResult: 0 },
+    },
     flags: [],
     ...overrides,
   };

--- a/packages/cli/test/gateway-audit.test.ts
+++ b/packages/cli/test/gateway-audit.test.ts
@@ -443,6 +443,64 @@ describe("gateway audit aggregator (#24)", () => {
     );
   });
 
+  it("contextSafety counts the new context.* and message.capped events", async () => {
+    const at = new Date().toISOString();
+    seedEvent(tmpHome, at, {
+      type: "context.exceeded",
+      actor: "Uabc",
+      sessionTokensBefore: 30000,
+      retrievalAtoms: 1,
+      phase: "first-call",
+    });
+    seedEvent(tmpHome, at, {
+      type: "context.exceeded",
+      actor: "Udef",
+      sessionTokensBefore: 28000,
+      retrievalAtoms: 0,
+      phase: "synthesise",
+    });
+    seedEvent(tmpHome, at, {
+      type: "context.force-pruned",
+      actor: "Uabc",
+      droppedPairs: 4,
+      tokensAfter: 1200,
+    });
+    seedEvent(tmpHome, at, {
+      type: "context.force-pruned",
+      actor: "Udef",
+      droppedPairs: 3,
+      tokensAfter: 1500,
+    });
+    seedEvent(tmpHome, at, {
+      type: "message.capped",
+      actor: "Uabc",
+      kind: "seed",
+      originalChars: 88292,
+      cappedChars: 12000,
+    });
+    seedEvent(tmpHome, at, {
+      type: "message.capped",
+      actor: "Uabc",
+      kind: "seed",
+      originalChars: 70000,
+      cappedChars: 12000,
+    });
+    seedEvent(tmpHome, at, {
+      type: "message.capped",
+      actor: "Udef",
+      kind: "mra-result",
+      originalChars: 30000,
+      cappedChars: 16000,
+    });
+    const { buildAuditReport } = await import("../src/gateway/audit");
+    const report = buildAuditReport({ days: 30 });
+    assert.deepEqual(report.contextSafety, {
+      contextExceeded: { total: 2, firstCall: 1, synthesise: 1 },
+      contextForcePruned: 2,
+      messageCapped: { total: 3, seed: 2, mraResult: 1 },
+    });
+  });
+
   it("days option must be a positive integer; bad input falls back to 7", async () => {
     const { buildAuditReport } = await import("../src/gateway/audit");
     assert.equal(buildAuditReport({ days: 0 }).windowDays, 7);

--- a/packages/cli/test/gateway-events.test.ts
+++ b/packages/cli/test/gateway-events.test.ts
@@ -367,6 +367,36 @@ describe("gateway events log (#24)", () => {
     assert.ok(allMarkers.includes("IN_WINDOW"));
   });
 
+  it("round-trips context.exceeded / context.force-pruned / message.capped", async () => {
+    const { appendGatewayEvent, readGatewayEvents } =
+      await import("../src/gateway/events");
+    appendGatewayEvent({
+      type: "context.exceeded",
+      actor: "Uabc",
+      sessionTokensBefore: 31578,
+      retrievalAtoms: 1,
+      phase: "first-call",
+    });
+    appendGatewayEvent({
+      type: "context.force-pruned",
+      actor: "Uabc",
+      droppedPairs: 4,
+      tokensAfter: 1200,
+    });
+    appendGatewayEvent({
+      type: "message.capped",
+      actor: "Uabc",
+      kind: "seed",
+      originalChars: 88292,
+      cappedChars: 12000,
+    });
+    const events = readGatewayEvents({});
+    const types = events.map((e) => e.type);
+    assert.ok(types.includes("context.exceeded"));
+    assert.ok(types.includes("context.force-pruned"));
+    assert.ok(types.includes("message.capped"));
+  });
+
   it("legacy events.log with mixed valid + malformed lines: malformed are skipped, valid still parse", async () => {
     const { readGatewayEvents } = await import("../src/gateway/events");
     const gatewayDir = path.join(tmpHome, ".pmk", "gateway");

--- a/packages/cli/test/gateway.test.ts
+++ b/packages/cli/test/gateway.test.ts
@@ -588,11 +588,15 @@ describe("messaging helpers", () => {
     assert.match(m, /app\/models\/x\.rb/);
   });
 
-  it("buildMraSuccessMessage truncates very long stdout", () => {
+  it("buildMraSuccessMessage no longer truncates internally (caller caps via MRA_RESULT_CAP)", () => {
+    // T9: hardcoded 24_000 cap removed from buildMraSuccessMessage; the
+    // call site in synthesiseAfterMra now applies capMessageContent
+    // with MRA_RESULT_CAP before passing stdout in. The builder itself
+    // is now passthrough — verify it preserves the full payload.
     const big = "x".repeat(40_000);
     const m = buildMraSuccessMessage("erp", big);
-    assert.ok(m.length < 30_000);
-    assert.match(m, /truncated/);
+    assert.ok(m.length >= 40_000);
+    assert.ok(!m.includes("truncated"));
   });
 
   it("buildMraFailureMessage uses 'unknown' when reason missing", () => {

--- a/packages/cli/test/gateway.test.ts
+++ b/packages/cli/test/gateway.test.ts
@@ -682,7 +682,9 @@ describe("pruneSessionIfNeeded (#18)", () => {
   });
 
   it("prunes oldest pairs when over cap, preserves PKB seed + last K pairs", () => {
-    // 60 pairs × 4 000 chars each ≈ 137k tokens — well over the 60k cap.
+    // 60 pairs × 4 000 chars each ≈ 137k tokens — well over the cap
+    // (which was 60k pre-v0.11.1, 25k from v0.11.1 onward; either way
+    // this fixture exceeds it).
     const session = makeSession({
       pairs: 60,
       contentSize: 4_000,

--- a/packages/cli/test/llm-claude-agent.test.ts
+++ b/packages/cli/test/llm-claude-agent.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import {
+  PmkContextTooLongError,
+  isContextTooLongError,
+} from "../src/llm/claude-agent";
+
+describe("PmkContextTooLongError detection", () => {
+  it("matches msg_too_long error message", () => {
+    assert.equal(
+      isContextTooLongError(new Error("An API error occurred: msg_too_long")),
+      true,
+    );
+  });
+  it("matches 'prompt is too long'", () => {
+    assert.equal(
+      isContextTooLongError(new Error("prompt is too long for the model")),
+      true,
+    );
+  });
+  it("matches 'context window exceeded'", () => {
+    assert.equal(
+      isContextTooLongError(new Error("context window exceeded")),
+      true,
+    );
+  });
+  it("does not match unrelated errors", () => {
+    assert.equal(isContextTooLongError(new Error("rate limit hit")), false);
+  });
+  it("preserves cause", () => {
+    const cause = new Error("msg_too_long");
+    const err = new PmkContextTooLongError(cause);
+    assert.equal(err.cause, cause);
+    assert.ok(err instanceof Error);
+  });
+});

--- a/packages/cli/test/messaging.test.ts
+++ b/packages/cli/test/messaging.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import { capMessageContent } from "../src/gateway/messaging";
+
+describe("capMessageContent", () => {
+  it("returns content unchanged when within limit", () => {
+    const r = capMessageContent("hello", 10);
+    assert.deepEqual(r, { content: "hello", capped: false, originalChars: 5 });
+  });
+  it("truncates over-limit content and reports originalChars", () => {
+    const r = capMessageContent("x".repeat(100), 20);
+    assert.equal(r.capped, true);
+    assert.equal(r.originalChars, 100);
+    assert.ok(r.content.startsWith("x".repeat(20)));
+    assert.ok(r.content.includes("truncated"));
+  });
+  it("boundary: length === limit returns unchanged", () => {
+    assert.equal(capMessageContent("12345", 5).capped, false);
+  });
+  it("counts chars not bytes (multibyte safe)", () => {
+    assert.equal(capMessageContent("你好你好你好", 10).originalChars, 6);
+  });
+});

--- a/packages/cli/test/messaging.test.ts
+++ b/packages/cli/test/messaging.test.ts
@@ -1,6 +1,11 @@
 import { describe, it } from "node:test";
 import * as assert from "node:assert/strict";
-import { capMessageContent } from "../src/gateway/messaging";
+import {
+  capMessageContent,
+  MAX_SESSION_TOKENS,
+  SEED_CAP,
+  MRA_RESULT_CAP,
+} from "../src/gateway/messaging";
 
 describe("capMessageContent", () => {
   it("returns content unchanged when within limit", () => {
@@ -19,5 +24,17 @@ describe("capMessageContent", () => {
   });
   it("counts chars not bytes (multibyte safe)", () => {
     assert.equal(capMessageContent("你好你好你好", 10).originalChars, 6);
+  });
+});
+
+describe("messaging cap defaults", () => {
+  it("MAX_SESSION_TOKENS default is 25_000 (v0.11.1)", () => {
+    assert.equal(MAX_SESSION_TOKENS, 25_000);
+  });
+  it("SEED_CAP default is 12_000", () => {
+    assert.equal(SEED_CAP, 12_000);
+  });
+  it("MRA_RESULT_CAP default is 16_000", () => {
+    assert.equal(MRA_RESULT_CAP, 16_000);
   });
 });

--- a/packages/cli/test/messaging.test.ts
+++ b/packages/cli/test/messaging.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import * as assert from "node:assert/strict";
 import {
+  approxTokensFor,
   capMessageContent,
   MAX_SESSION_TOKENS,
   SEED_CAP,
@@ -36,5 +37,23 @@ describe("messaging cap defaults", () => {
   });
   it("MRA_RESULT_CAP default is 16_000", () => {
     assert.equal(MRA_RESULT_CAP, 16_000);
+  });
+});
+
+describe("approxTokensFor", () => {
+  it("sums primary message content / 3.5", () => {
+    assert.equal(approxTokensFor([{ role: "user", content: "x".repeat(35) }]), 10);
+  });
+  it("includes extra in total", () => {
+    const got = approxTokensFor(
+      [{ role: "user", content: "x".repeat(35) }],
+      [{ role: "user", content: "y".repeat(35) }],
+    );
+    assert.equal(got, 20);
+  });
+  it("backward-compatible: omitted extra ≡ []", () => {
+    const a = approxTokensFor([{ role: "user", content: "ab" }]);
+    const b = approxTokensFor([{ role: "user", content: "ab" }], []);
+    assert.equal(a, b);
   });
 });

--- a/packages/cli/test/messaging.test.ts
+++ b/packages/cli/test/messaging.test.ts
@@ -3,11 +3,14 @@ import * as assert from "node:assert/strict";
 import {
   approxTokensFor,
   capMessageContent,
+  forcePruneToMinimum,
   MAX_SESSION_TOKENS,
   SEED_CAP,
   MRA_RESULT_CAP,
   pruneSessionIfNeeded,
 } from "../src/gateway/messaging";
+
+const SEED = "我先把 workspace 的 PKB context 給你 xxx";
 
 describe("capMessageContent", () => {
   it("returns content unchanged when within limit", () => {
@@ -84,5 +87,46 @@ describe("pruneSessionIfNeeded with opts", () => {
     };
     const r = pruneSessionIfNeeded(session);
     assert.equal(r.pruned, false);
+  });
+});
+
+describe("forcePruneToMinimum", () => {
+  it("keeps seed pair + last pair, returns droppedPairs", () => {
+    const session = {
+      messages: [
+        { role: "user" as const, content: SEED }, { role: "assistant" as const, content: "ok" },
+        { role: "user" as const, content: "Q1" }, { role: "assistant" as const, content: "A1" },
+        { role: "user" as const, content: "Q2" }, { role: "assistant" as const, content: "A2" },
+        { role: "user" as const, content: "Q3" }, { role: "assistant" as const, content: "A3" },
+      ],
+      approxTokens: 0,
+    };
+    const dropped = forcePruneToMinimum(session);
+    assert.equal(dropped, 2);
+    assert.equal(session.messages.length, 4);
+    assert.ok(session.messages[0].content.startsWith("我先把"));
+    assert.equal(session.messages[3].content, "A3");
+  });
+  it("works without seed pair", () => {
+    const session = {
+      messages: [
+        { role: "user" as const, content: "Q1" }, { role: "assistant" as const, content: "A1" },
+        { role: "user" as const, content: "Q2" }, { role: "assistant" as const, content: "A2" },
+      ],
+      approxTokens: 0,
+    };
+    assert.equal(forcePruneToMinimum(session), 1);
+    assert.equal(session.messages[0].content, "Q2");
+  });
+  it("idempotent on already-minimal sessions", () => {
+    const session = {
+      messages: [
+        { role: "user" as const, content: SEED }, { role: "assistant" as const, content: "ok" },
+        { role: "user" as const, content: "Q" }, { role: "assistant" as const, content: "A" },
+      ],
+      approxTokens: 0,
+    };
+    assert.equal(forcePruneToMinimum(session), 0);
+    assert.equal(session.messages.length, 4);
   });
 });

--- a/packages/cli/test/messaging.test.ts
+++ b/packages/cli/test/messaging.test.ts
@@ -6,6 +6,7 @@ import {
   MAX_SESSION_TOKENS,
   SEED_CAP,
   MRA_RESULT_CAP,
+  pruneSessionIfNeeded,
 } from "../src/gateway/messaging";
 
 describe("capMessageContent", () => {
@@ -55,5 +56,33 @@ describe("approxTokensFor", () => {
     const a = approxTokensFor([{ role: "user", content: "ab" }]);
     const b = approxTokensFor([{ role: "user", content: "ab" }], []);
     assert.equal(a, b);
+  });
+});
+
+describe("pruneSessionIfNeeded with opts", () => {
+  it("recomputes approxTokens including extra+newUser", () => {
+    const session = {
+      messages: [
+        { role: "user" as const, content: "Q" },
+        { role: "assistant" as const, content: "A" },
+      ],
+      approxTokens: 0,
+    };
+    pruneSessionIfNeeded(session, {
+      extra: [{ role: "user", content: "x".repeat(7000) }],
+      newUser: "y".repeat(7000),
+    });
+    assert.ok(session.approxTokens > 3000);
+  });
+  it("backward-compatible: omitted opts behaves like before", () => {
+    const session = {
+      messages: [
+        { role: "user" as const, content: "hi" },
+        { role: "assistant" as const, content: "ok" },
+      ],
+      approxTokens: 0,
+    };
+    const r = pruneSessionIfNeeded(session);
+    assert.equal(r.pruned, false);
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmk/core",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Core scripts — traceability matrix, Confluence sync, shared utilities",
   "license": "MIT",
   "main": "src/index.js",

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmk/rag",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "RAG engine for pmk — pure-JS TF-IDF retrieval over pm-workspace-kit docs (no native deps)",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmk/shared",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Shared types and utilities for pm-workspace-kit packages",
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Closes the v0.8.1 fail-loop where `pruneSessionIfNeeded` ran AFTER the LLM call: a session over budget would throw `msg_too_long` before prune could recover, then loop on every subsequent turn until an operator manually deleted the session file. Live incident on 2026-05-07 in `#新頻道` thread `1778139665.927099` triggered this work.
- Layered defense in three places: prune-before-call ordering, write-time content caps for PKB seed (12k chars) and `mra-ask` results (16k chars, replaces a hardcoded 24k), and an automatic `forcePruneToMinimum` + retry path on any residual `PmkContextTooLongError` with a `:scissors: 對話過長，已自動裁掉 N 輪舊訊息` user-visible marker.
- New observability: three event types (`context.exceeded` / `context.force-pruned` / `message.capped`) appended to `events-YYYY-MM.log`; `pmk gateway audit` gains a `Context safety` section.

Spec: `apps/docs/docs/plans/2026-05-07-gateway-msg-too-long-hardening.md` (commit 6773eae).
Plan: `apps/docs/docs/plans/2026-05-07-gateway-msg-too-long-hardening-implementation.md` (commit 27a9f9e, 16 TDD-shaped tasks).

## Changes

### Source

- `packages/cli/src/gateway/messaging.ts` — new `capMessageContent`, `forcePruneToMinimum`; exported `approxTokensFor` with optional `extra` arg; extended `pruneSessionIfNeeded` with `{extra, newUser}` opts; lowered `MAX_SESSION_TOKENS` default 60_000 → 25_000; added `SEED_CAP` (12_000) and `MRA_RESULT_CAP` (16_000) env-tunable constants. `buildMraSuccessMessage` no longer truncates internally — the cap is applied at the call site so a `message.capped` event can be emitted with `originalChars`.
- `packages/cli/src/gateway/events.ts` — three new interfaces (`ContextExceededEvent`, `ContextForcePrunedEvent`, `MessageCappedEvent`) added to the `GatewayEvent` union and `VALID_TYPES` set.
- `packages/cli/src/llm/claude-agent.ts` — typed `PmkContextTooLongError` + `isContextTooLongError` helper; `chat()` body wrapped in try/catch that re-throws on `msg_too_long`-shaped errors.
- `packages/cli/src/gateway/slack/context-retry.ts` — new file. Free function `chatWithContextRetry` with discriminated-union return type. Owns the retry+force-prune+events pattern in isolation so it's unit-testable without a `SlackGateway` harness.
- `packages/cli/src/gateway/slack/index.ts` — applied seed cap and mra-result cap at the two write sites; reordered `pruneSessionIfNeeded` to run BEFORE `llm.chat` (this is the load-bearing fix); wrapped both LLM call sites with `chatWithContextRetry`; threaded `actor` and `retrievalAtoms` through `handleMraAskRound` → `synthesiseAfterMra`; `runFreeChatTurn` now destructures `{full, scissorsPrefix}` and prepends the scissors marker to the visible Slack reply; `:x: 對話太長，請開新 thread 重新提問` replaces raw API errors on hard failure.
- `packages/cli/src/gateway/audit.ts` + `audit-format.ts` — `AuditReport.contextSafety` rollup of the three new event types; `Context safety` section always rendered (even when zero).

### Tests

`@pmk/cli` 274 → **304** (+30):

- `messaging.test.ts` — new helpers + extended signatures (15 tests).
- `llm-claude-agent.test.ts` (new) — `PmkContextTooLongError` regex detection + `cause` preservation (5 tests).
- `gateway-events.test.ts` — round-trip for the three new event types.
- `context-retry.test.ts` (new) — six discriminants of `chatWithContextRetry` (happy / non-context error / context→success-with-scissors / context→retry-fails / `dropped=0` degenerate / `phase=synthesise` audit), exercising the retry+force-prune+events path end-to-end without needing a full Slack mock.
- `gateway-audit.test.ts` + `gateway-audit-format.test.ts` — `Context safety` aggregation + rendering (non-zero + always-render zero-count cases).

### Docs

- `apps/docs/docs/changelog.md` — v0.11.1 entry.
- `apps/docs/docs/gateway/v0.11-migration.md` — appended additive v0.11.1 section: env vars table, JSONL event samples (synthetic, redacted `actor: U…`), `Context safety` section preview, user-visible Slack-string changes, upgrade checklist.
- `apps/docs/docs/plans/2026-05-07-gateway-msg-too-long-hardening.md` — design spec (already committed at 6773eae).
- `apps/docs/docs/plans/2026-05-07-gateway-msg-too-long-hardening-implementation.md` — TDD plan (already committed at 27a9f9e).

### New env vars

| Env var | Default |
|---|---|
| `PMK_MAX_SESSION_TOKENS` | `25000` (was 60000) |
| `PMK_SEED_CAP` | `12000` (new) |
| `PMK_MRA_RESULT_CAP` | `16000` (new) |

## Coverage gaps (deliberate, tracked)

No `SlackGateway` integration harness exists today, so the cap-emit and retry-prefix wiring sites in `slack/index.ts` are not directly integration-tested. The constituent helpers (`capMessageContent`, `appendGatewayEvent`, `chatWithContextRetry`, `forcePruneToMinimum`, `pruneSessionIfNeeded`, `PmkContextTooLongError`) are unit-tested. The retry path itself is fully unit-tested via `chatWithContextRetry`. The wiring is verified by the test plan below + ongoing live use.

## Forward link

v0.12 is planned to switch the gateway provider from `claude-agent-sdk` to `anthropic-api`, removing the SDK-inherited host-context (skills/hooks/MCP) as a budget unknown. The cap mechanism from v0.11.1 stays; only the budgets relax. Documented at the end of the spec.

## Test plan

- [x] `npm --workspace packages/cli test` → 304/304 pass
- [x] `npm --workspace packages/cli run typecheck:test` → clean
- [x] `npm run cli:build` → clean
- [ ] Live verify: restart gateway against any thread, send a few messages, confirm no `msg_too_long`. Tail `tail -f ~/.pmk/gateway/events-2026-05.log | grep -E 'context\.|message\.capped'` to see `message.capped` fire on the first turn (seed > 12k).
- [ ] Live verify retry path: restart with `PMK_MAX_SESSION_TOKENS=1 npm --workspace packages/cli run start -- gateway start`, send any DM, confirm `:scissors: …` prefix on the reply and `context.exceeded` + `context.force-pruned` events in the log.
- [ ] Live verify audit: `npm --workspace packages/cli run start -- gateway audit --days 1` shows the new `Context safety` section.
- [ ] Tag `v0.11.1` after merge.