### PR TITLE
v0.12.0: gateway anthropic-api as default provider

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmk/desktop",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "private": true,
   "description": "Desktop app for pm-workspace-kit — Electron + Vite + React",
   "license": "MIT",

--- a/apps/docs/docs/changelog.md
+++ b/apps/docs/docs/changelog.md
@@ -8,6 +8,39 @@ All notable changes to **pm-workspace-kit** are documented here.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each release also has a longer narrative on [GitHub Releases](https://github.com/hanfour/pm-workspace-kit/releases) with rationale, dogfood notes, and test plans.
 
+## [v0.12.0] — 2026-05-08 — gateway: anthropic-api as default provider
+
+### Why
+
+v0.11.1 hardened the gateway against `msg_too_long` by lowering caps and adding an auto-retry path, but cause #2 from the 2026-05-07 incident — `claude-agent-sdk` spawning the local `claude` CLI and inheriting the host's `~/.claude/` config (skills/hooks/MCP descriptions) as un-budgeted system context — was absorbed by tighter caps, not eliminated. v0.12.0 flips the default to the direct Anthropic SDK so SDK overhead is no longer a budget unknown, and restores cap headroom.
+
+Spec: [`apps/docs/docs/plans/2026-05-08-gateway-anthropic-api-default.md`](./plans/2026-05-08-gateway-anthropic-api-default.md). Migration: [v0.12 migration notes](./gateway/v0.12-migration.md).
+
+### Changed
+
+- **Default LLM provider auto-resolves to `anthropic-api` first** (was `claude-agent`). Soft flip — users with `ANTHROPIC_API_KEY` set auto-switch; users without it stay on `claude-agent` with no behavioural change. `PMK_PROVIDER=claude-agent` still pins the legacy path explicitly.
+- **Cap defaults restored to operationally useful values** now that SDK overhead is gone on the default path:
+  - `PMK_MAX_SESSION_TOKENS` 25_000 → 60_000
+  - `PMK_SEED_CAP` 12_000 → 30_000
+  - `PMK_MRA_RESULT_CAP` 16_000 → 40_000
+- **`gateway init` prompts for `ANTHROPIC_API_KEY`** after Slack tokens; stored in `~/.pmk/gateway.json` `apiKey` field at mode 0600. Empty input keeps existing value or falls back to env var. The running gateway daemon needs a graceful restart to pick up a newly-set apiKey (matches the existing audience/escalation config-mutation pattern).
+
+### Added
+
+- **`token.usage` event** in `events-YYYY-MM.log` — emitted by `AnthropicApiKeyProvider.chat()` after each successful stream completion, when an `actor` is provided in `ChatOptions`. Fields: `actor`, `provider`, `model`, `inputTokens`, `outputTokens`, optional `cacheReadTokens` / `cacheCreationTokens`. Best-effort write — failures don't break the chat.
+- **`Token usage` section** in `pmk gateway audit` rolls up the new events: total in/out, cache read (when non-zero), top-3 per-actor by input tokens, per-model breakdown.
+- **`ChatOptions.actor`** optional field on the `LlmProvider.chat()` interface for usage attribution. Threaded through `chatWithContextRetry` automatically; CLI command-side wiring is future work.
+
+### Tests
+
+`@pmk/cli` 304 → **312** (+8): `resolver.ts` autoResolve order (apiKey-preferred + fail path), `AnthropicApiKeyProvider.chat()` token-usage emission with mocked stream + `finalMessage()`, no-emission when actor undefined, `events.ts` round-trip for `token.usage`, `audit.ts` aggregation, `audit-format.ts` `Token usage` rendering for non-zero + zero cases. Cap-default test assertions flipped from v0.11.1 values to v0.12.0 values.
+
+### Forward-looking
+
+`claude-agent` provider stays as a soft-flip fallback indefinitely. Re-evaluate deprecation in v0.13+ based on usage data from the new `Token usage` audit section. $-cost calculation is a v0.13+ candidate, gated on a stable price-table source. SlackGateway integration harness remains tracked as a v0.11.2 follow-up.
+
+---
+
 ## [v0.11.1] — 2026-05-07 — gateway `msg_too_long` hardening
 
 ### Why

--- a/apps/docs/docs/gateway/v0.12-migration.md
+++ b/apps/docs/docs/gateway/v0.12-migration.md
@@ -1,0 +1,92 @@
+---
+sidebar_position: 3
+---
+
+# v0.12 migration notes
+
+Operator-facing summary of what changes when you upgrade `pmk gateway` from v0.11.x to v0.12.0.
+
+## TL;DR
+
+```
+✅ Zero config changes required if you already have ANTHROPIC_API_KEY set.
+✅ Existing ~/.pmk/gateway.json is back-fill-compatible (apiKey field
+   is optional and additive).
+✅ Users without an API key keep running on the claude-agent fallback —
+   no behavioural change.
+✅ Cap defaults bumped 25k/12k/16k → 60k/30k/40k. PMK_*_CAP still
+   overrides per host.
+```
+
+## What changed
+
+### Provider auto-resolution
+
+Before (v0.11.x):
+
+```
+1. local `claude` binary → ClaudeAgentSdkProvider
+2. ANTHROPIC_API_KEY → AnthropicApiKeyProvider
+3. fail
+```
+
+After (v0.12.0):
+
+```
+1. ANTHROPIC_API_KEY (or config.apiKey) → AnthropicApiKeyProvider
+2. local `claude` binary → ClaudeAgentSdkProvider (fallback)
+3. fail
+```
+
+Why: `ClaudeAgentSdkProvider` spawns the local `claude` CLI and inherits the host's `~/.claude/` config (skills/hooks/MCP descriptions) as un-budgeted system context. On a heavy host this can add 10s of thousands of tokens to every API call. `AnthropicApiKeyProvider` calls the API directly with a clean system prompt — no overhead, predictable budgets.
+
+### `gateway init` prompts for the API key
+
+After the Slack token prompts, init now asks for `ANTHROPIC_API_KEY`. The value is stored in `~/.pmk/gateway.json` at mode 0600 alongside Slack tokens. Skip with empty input to fall back to the env var.
+
+Already-running gateway daemons do not pick up a newly-saved apiKey until they restart. This matches the existing audience/escalation config-mutation pattern. Restart with the standard `kill $(cat ~/.pmk/gateway/gateway.pid) && nohup pmk gateway start &`; the v0.11.0 marker mechanism keeps the restart silent in Slack within the 5-minute window.
+
+### New `token.usage` event in events log
+
+JSONL line (synthetic sample — `actor: "U…"` is a redacted Slack user ID; `at` is ISO-8601):
+
+```jsonl
+{"at":"…","type":"token.usage","actor":"U…","provider":"anthropic-api","model":"claude-sonnet-4-6","inputTokens":12345,"outputTokens":678,"cacheReadTokens":9000}
+```
+
+`cacheReadTokens` / `cacheCreationTokens` present only when prompt caching was active. The `claude-agent` fallback path does not emit `token.usage` (the SDK does not surface per-call usage in a comparable way) — this event is anthropic-api-only.
+
+### `pmk gateway audit` `Token usage` section
+
+```
+Token usage
+  total in / out:                12.3k / 0.7k tokens
+  cache read:                    9.0k tokens
+  per-actor (top 3):             U… 8.2k in, U… 3.1k in, U… 1.0k in
+  per-model:                     claude-sonnet-4-6 (12.3k in / 0.7k out)
+```
+
+Always rendered (zero counts visible as `(none)`). `cache read` line shown only when non-zero. No `$` calculation — that's deferred to a future release.
+
+### Cap defaults bumped
+
+| Env var | v0.11.1 default | v0.12.0 default |
+|---|---|---|
+| `PMK_MAX_SESSION_TOKENS` | 25_000 | 60_000 |
+| `PMK_SEED_CAP` | 12_000 | 30_000 |
+| `PMK_MRA_RESULT_CAP` | 16_000 | 40_000 |
+
+If you're on the `claude-agent` fallback (no API key), tighten these back down — the SDK overhead is still in play on that path.
+
+## Upgrade checklist (v0.11.x → v0.12.0)
+
+1. `git pull && npm run cli:build` — no schema migration.
+2. **If you have `ANTHROPIC_API_KEY` set:** restart the gateway. v0.12 auto-switches to `anthropic-api`. Verify with `tail -f ~/.pmk/gateway/events-$(date -u +%Y-%m).log | grep token.usage`.
+3. **If you don't:** nothing to do — v0.12 invisible except for the bumped caps. Optionally run `pmk gateway init` to set the API key (writes to `gateway.json`).
+4. After a week, run `pmk gateway audit --days 7` and check the `Token usage` section.
+5. **To stay on `claude-agent`** explicitly: `export PMK_PROVIDER=claude-agent` (overrides auto). The fallback path is supported indefinitely.
+
+## See also
+
+- [v0.11 migration notes](./v0.11-migration.md) — preceding milestone
+- [Changelog](../changelog.md)

--- a/apps/docs/docs/plans/2026-05-08-gateway-anthropic-api-default-implementation.md
+++ b/apps/docs/docs/plans/2026-05-08-gateway-anthropic-api-default-implementation.md
@@ -1,0 +1,1038 @@
+# Gateway `anthropic-api` as Default Provider — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Switch the gateway's default LLM provider from `claude-agent-sdk` to the direct Anthropic SDK so SDK-inherited host context is no longer a budget unknown, restore cap headroom, and add per-call `token.usage` telemetry.
+
+**Architecture:** Soft-flip in `resolver.ts:autoResolve` (apiKey present → anthropic-api; else claude binary → claude-agent fallback). New `token.usage` event emitted by `AnthropicApiKeyProvider.chat()` after stream completion; `actor` threaded via a new optional `ChatOptions.actor` field. New `Token usage` section in `pmk gateway audit`. Cap defaults bumped: 25k → 60k session, 12k → 30k seed, 16k → 40k mra-result.
+
+**Tech Stack:** TypeScript, `node:test` runner via `tsx`, `@anthropic-ai/sdk` (already a dependency).
+
+**Source spec:** `apps/docs/docs/plans/2026-05-08-gateway-anthropic-api-default.md` (commit e5114b8).
+
+---
+
+## File map
+
+| Path | Touched by |
+|---|---|
+| `packages/cli/src/llm/provider.ts` | T1, T4 |
+| `packages/cli/src/gateway/events.ts` | T2 |
+| `packages/cli/src/gateway/messaging.ts` | T3 |
+| `packages/cli/src/llm/resolver.ts` | T4 |
+| `packages/cli/src/llm/anthropic-api.ts` | T5 |
+| `packages/cli/src/gateway/slack/index.ts` | T6 |
+| `packages/cli/src/gateway/slack/context-retry.ts` | T6 |
+| `packages/cli/src/gateway/audit.ts` | T7 |
+| `packages/cli/src/gateway/audit-format.ts` | T8 |
+| `packages/cli/src/commands/gateway.ts` | T9 |
+| `packages/cli/src/llm/claude-agent.ts` | T10 |
+| `packages/cli/test/messaging.test.ts` (extend) | T3 |
+| `packages/cli/test/resolver.test.ts` (new) | T4 |
+| `packages/cli/test/llm-anthropic-api.test.ts` (new) | T5 |
+| `packages/cli/test/gateway-events.test.ts` (extend) | T2 |
+| `packages/cli/test/gateway-audit.test.ts` (extend) | T7 |
+| `packages/cli/test/gateway-audit-format.test.ts` (extend) | T8 |
+| `apps/docs/docs/changelog.md` | T11 |
+| `apps/docs/docs/gateway/v0.12-migration.md` (new) | T11 |
+
+## Conventions
+
+- TDD: write failing test → run (FAIL) → minimal impl → run (PASS) → commit.
+- Single-file run: `cd packages/cli && node --import tsx --test test/<file>.test.ts`.
+- Full suite: `npm --workspace packages/cli test`.
+- Commit style: `<type>(<scope>): <description>`, no Co-Authored-By trailer.
+- Each commit must leave the suite green.
+- No version bump in individual tasks — T12 only.
+- Branch: per `feedback_release_workflow.md` v0.x.0 = squash-merge feature PR. Suggested name `feat/gateway-anthropic-api-default`.
+
+---
+
+## Task 1: Add `actor?: string` to `ChatOptions`
+
+**Files:** `packages/cli/src/llm/provider.ts`. No standalone test (interface-only; T5 exercises it).
+
+- [ ] **Edit** `provider.ts`:
+
+```ts
+export interface ChatOptions {
+  onToken?: (chunk: string) => void;
+  /**
+   * Slack user ID (or "cli:<name>" for CLI invocations) the call is on
+   * behalf of. Used by AnthropicApiKeyProvider to attribute the
+   * `token.usage` audit event. Optional — providers that don't emit
+   * usage events ignore it; if undefined no event is written.
+   */
+  actor?: string;
+}
+```
+
+- [ ] **Verify:** `cd packages/cli && npm run typecheck:test` — clean.
+- [ ] **Commit:** `git commit -am "feat(llm): add optional actor field to ChatOptions for usage attribution"`
+
+---
+
+## Task 2: `TokenUsageEvent` in `events.ts`
+
+**Files:** `packages/cli/src/gateway/events.ts`; extend `packages/cli/test/gateway-events.test.ts`.
+
+- [ ] **Test** (append to gateway-events.test.ts inside the existing top-level describe):
+
+```ts
+it("round-trips token.usage event (T2 / v0.12.0)", () => {
+  appendGatewayEvent({
+    type: "token.usage",
+    actor: "Uabc",
+    provider: "anthropic-api",
+    model: "claude-sonnet-4-6",
+    inputTokens: 12345,
+    outputTokens: 678,
+    cacheReadTokens: 9000,
+    cacheCreationTokens: 0,
+  });
+  const types = readGatewayEvents({}).map((e) => e.type);
+  assert.ok(types.includes("token.usage"));
+});
+```
+
+- [ ] **Impl** in `events.ts`. Add interface near other event interfaces:
+
+```ts
+export interface TokenUsageEvent {
+  type: "token.usage";
+  actor: string;
+  provider: "anthropic-api" | "claude-agent";
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  /** Present only when prompt caching was active. */
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
+}
+```
+
+Extend `GatewayEvent` union to append `| TokenUsageEvent`.
+
+Extend `VALID_TYPES`:
+
+```ts
+const VALID_TYPES: ReadonlySet<string> = new Set([
+  "mra-ask.end", "turn.processed", "escalate.triggered", "escalate.absorbed",
+  "gateway.online", "gateway.offline",
+  "context.exceeded", "context.force-pruned", "message.capped",
+  "token.usage",
+]);
+```
+
+- [ ] **Commit:** `git commit -am "feat(gateway): add token.usage event type"`
+
+---
+
+## Task 3: Bump cap defaults in `messaging.ts`
+
+**Files:** `packages/cli/src/gateway/messaging.ts`; extend `packages/cli/test/messaging.test.ts`.
+
+- [ ] **Test** — flip the existing `describe("messaging cap defaults", …)` assertions to v0.12.0 values:
+
+```ts
+describe("messaging cap defaults (v0.12.0)", () => {
+  it("MAX_SESSION_TOKENS default is 60_000", () => {
+    assert.equal(MAX_SESSION_TOKENS, 60_000);
+  });
+  it("SEED_CAP default is 30_000", () => {
+    assert.equal(SEED_CAP, 30_000);
+  });
+  it("MRA_RESULT_CAP default is 40_000", () => {
+    assert.equal(MRA_RESULT_CAP, 40_000);
+  });
+});
+```
+
+- [ ] **Impl** in `messaging.ts` — change the three `parsePositiveIntEnv` defaults and rewrite each JSDoc:
+
+```ts
+/**
+ * Soft cap for `session.approxTokens` before pruning kicks in.
+ * v0.11.1 lowered to 25_000 to absorb claude-agent-sdk host-context
+ * overhead. v0.12.0: raised back to 60_000 — anthropic-api is now the
+ * default provider and SDK overhead is no longer in play. Tighten with
+ * PMK_MAX_SESSION_TOKENS for hosts on the claude-agent fallback.
+ */
+export const MAX_SESSION_TOKENS = parsePositiveIntEnv(
+  "PMK_MAX_SESSION_TOKENS",
+  60_000,
+);
+
+/**
+ * Maximum chars for the PKB seed message. v0.12.0: raised 12_000 →
+ * 30_000 with anthropic-api default. Override with PMK_SEED_CAP=… per
+ * host.
+ */
+export const SEED_CAP = parsePositiveIntEnv("PMK_SEED_CAP", 30_000);
+
+/**
+ * Maximum chars for `mra-ask` stdout pushed into session history.
+ * v0.12.0: raised 16_000 → 40_000. Wired into capMessageContent at
+ * the synthesiseAfterMra call site (slack/index.ts). Override with
+ * PMK_MRA_RESULT_CAP=… per host.
+ */
+export const MRA_RESULT_CAP = parsePositiveIntEnv(
+  "PMK_MRA_RESULT_CAP",
+  40_000,
+);
+```
+
+- [ ] **Verify** existing prune fixture (`gateway.test.ts:684` — 60 pairs × 4_000 chars ≈ 137k tokens) still exceeds the new 60k cap. Should — 137k > 60k. Run full suite to confirm.
+- [ ] **Commit:** `git commit -am "feat(gateway): bump v0.12.0 cap defaults — MAX_SESSION_TOKENS 25k->60k, SEED_CAP 12k->30k, MRA_RESULT_CAP 16k->40k"`
+
+---
+
+## Task 4: Resolver `autoResolve` order swap
+
+**Files:** `packages/cli/src/llm/resolver.ts`, `packages/cli/src/llm/provider.ts`; create `packages/cli/test/resolver.test.ts`.
+
+- [ ] **Test** (new file `packages/cli/test/resolver.test.ts`):
+
+```ts
+import { describe, it, beforeEach, afterEach } from "node:test";
+import * as assert from "node:assert/strict";
+import { resolveProvider } from "../src/llm/resolver";
+import type { PmkConfig } from "@pmk/shared";
+
+const ORIG_PMK = process.env.PMK_PROVIDER;
+const ORIG_SKIP = process.env.PMK_SKIP_CLAUDE_PROBE;
+
+function baseConfig(overrides: Partial<PmkConfig> = {}): PmkConfig {
+  return {
+    provider: "auto",
+    model: "claude-sonnet-4-6",
+    maxTokens: 4096,
+    ...overrides,
+  } as PmkConfig;
+}
+
+describe("resolveProvider autoResolve order (v0.12.0)", () => {
+  beforeEach(() => {
+    delete process.env.PMK_PROVIDER;
+    process.env.PMK_SKIP_CLAUDE_PROBE = "1";
+  });
+  afterEach(() => {
+    if (ORIG_PMK !== undefined) process.env.PMK_PROVIDER = ORIG_PMK;
+    else delete process.env.PMK_PROVIDER;
+    if (ORIG_SKIP !== undefined) process.env.PMK_SKIP_CLAUDE_PROBE = ORIG_SKIP;
+    else delete process.env.PMK_SKIP_CLAUDE_PROBE;
+  });
+
+  it("apiKey present → anthropic-api (preferred over claude-agent)", () => {
+    const provider = resolveProvider(baseConfig({ apiKey: "sk-ant-xxx" }));
+    assert.equal(provider.name, "anthropic-api");
+  });
+
+  it("apiKey absent + no claude binary → throws NoProviderAvailableError", () => {
+    assert.throws(
+      () => resolveProvider(baseConfig({ apiKey: undefined })),
+      /no usable LLM provider/,
+    );
+  });
+});
+```
+
+- [ ] **Impl** in `resolver.ts` — replace `autoResolve` body:
+
+```ts
+function autoResolve(config: PmkConfig): LlmProvider {
+  // v0.12.0: prefer anthropic-api when apiKey is available — eliminates
+  // claude-agent-sdk host-context overhead. Falls through to claude-agent
+  // for users without an API key (zero-touch upgrade for that branch).
+  if (config.apiKey) {
+    return new AnthropicApiKeyProvider({ ...config, apiKey: config.apiKey });
+  }
+  const claudePath = findClaudeExecutable();
+  if (claudePath) {
+    return new ClaudeAgentSdkProvider(config, claudePath);
+  }
+  throw new NoProviderAvailableError(["anthropic-api", "claude-agent"]);
+}
+```
+
+Update `resolveProvider` JSDoc (lines 13-16) to reflect new order:
+
+```ts
+/**
+ * Find a usable LLM provider.
+ *
+ * Order (`config.provider: "auto"`, v0.12.0+):
+ *   1. ANTHROPIC_API_KEY (or config.apiKey) → AnthropicApiKeyProvider
+ *   2. local `claude` binary on PATH → ClaudeAgentSdkProvider (fallback)
+ *   3. fail with actionable error
+ *
+ * `PMK_PROVIDER` env var overrides `config.provider`.
+ */
+```
+
+In `provider.ts` `NoProviderAvailableError`, lead with the API key path:
+
+```ts
+super(
+  `[pmk] no usable LLM provider found (tried: ${attempted.join(", ")}).\n` +
+    "  Try one of:\n" +
+    "    • set ANTHROPIC_API_KEY in your environment — https://console.anthropic.com\n" +
+    "    • install Claude Code and run `claude login` — https://claude.com/product/claude-code (legacy fallback)\n" +
+    "  Or pin a provider with PMK_PROVIDER=<anthropic-api|claude-agent>.",
+);
+```
+
+- [ ] **Commit:** `git add packages/cli/src/llm/resolver.ts packages/cli/src/llm/provider.ts packages/cli/test/resolver.test.ts && git commit -m "feat(llm): swap autoResolve to prefer anthropic-api over claude-agent"`
+
+---
+
+## Task 5: `AnthropicApiKeyProvider` emits `token.usage` event
+
+**Files:** `packages/cli/src/llm/anthropic-api.ts`; create `packages/cli/test/llm-anthropic-api.test.ts`.
+
+The Anthropic SDK exposes per-message usage via `message_start.message.usage` (input + cache fields known at start) and `message_delta.usage` (output_tokens, updated as the stream progresses). After the stream completes, both are merged for the final tally. Use `stream.finalMessage()` for clarity.
+
+- [ ] **Test** (new file `packages/cli/test/llm-anthropic-api.test.ts`):
+
+```ts
+import { describe, it, beforeEach, afterEach } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const ORIG_HOME = process.env.HOME;
+
+describe("AnthropicApiKeyProvider token.usage emission (T5 / v0.12.0)", () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-anthropic-test-"));
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    else delete process.env.HOME;
+  });
+
+  it("emits token.usage event after stream completes (when actor is provided)", async () => {
+    const { AnthropicApiKeyProvider } = await import(
+      "../src/llm/anthropic-api"
+    );
+    const { readGatewayEvents } = await import("../src/gateway/events");
+
+    // Stub the underlying SDK by overriding the private `client` after
+    // construction. The provider's chat() awaits client.messages.stream()
+    // and iterates events; we need an async iterable that yields a
+    // text_delta then exposes finalMessage() with usage fields.
+    const provider = new AnthropicApiKeyProvider({
+      provider: "anthropic-api",
+      model: "claude-sonnet-4-6",
+      maxTokens: 4096,
+      apiKey: "sk-ant-test",
+    } as never);
+
+    const fakeStream = {
+      [Symbol.asyncIterator]: async function* () {
+        yield {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "hello" },
+        };
+      },
+      finalMessage: async () => ({
+        usage: {
+          input_tokens: 1234,
+          output_tokens: 56,
+          cache_read_input_tokens: 100,
+          cache_creation_input_tokens: 0,
+        },
+      }),
+    };
+    (provider as unknown as { client: unknown }).client = {
+      messages: { stream: async () => fakeStream },
+    };
+
+    const result = await provider.chat("sys", [{ role: "user", content: "hi" }], { actor: "Uabc" });
+    assert.equal(result, "hello");
+
+    const events = readGatewayEvents({});
+    const usage = events.find((e) => e.type === "token.usage");
+    assert.ok(usage, "expected token.usage event");
+    if (usage && usage.type === "token.usage") {
+      assert.equal(usage.actor, "Uabc");
+      assert.equal(usage.provider, "anthropic-api");
+      assert.equal(usage.model, "claude-sonnet-4-6");
+      assert.equal(usage.inputTokens, 1234);
+      assert.equal(usage.outputTokens, 56);
+      assert.equal(usage.cacheReadTokens, 100);
+      assert.equal(usage.cacheCreationTokens, 0);
+    }
+  });
+
+  it("does NOT emit token.usage when actor is undefined", async () => {
+    const { AnthropicApiKeyProvider } = await import(
+      "../src/llm/anthropic-api"
+    );
+    const { readGatewayEvents } = await import("../src/gateway/events");
+
+    const provider = new AnthropicApiKeyProvider({
+      provider: "anthropic-api",
+      model: "claude-sonnet-4-6",
+      maxTokens: 4096,
+      apiKey: "sk-ant-test",
+    } as never);
+
+    const fakeStream = {
+      [Symbol.asyncIterator]: async function* () {
+        yield {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "ok" },
+        };
+      },
+      finalMessage: async () => ({
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }),
+    };
+    (provider as unknown as { client: unknown }).client = {
+      messages: { stream: async () => fakeStream },
+    };
+
+    await provider.chat("sys", [{ role: "user", content: "hi" }]);
+
+    const events = readGatewayEvents({});
+    assert.equal(
+      events.filter((e) => e.type === "token.usage").length,
+      0,
+      "no token.usage event when actor missing",
+    );
+  });
+});
+```
+
+- [ ] **Impl** in `anthropic-api.ts` — extend `chat()` to emit the event after stream completion:
+
+```ts
+import Anthropic from "@anthropic-ai/sdk";
+import type { ChatMessage, PmkConfig } from "@pmk/shared";
+import type { ChatOptions, LlmProvider } from "./provider";
+import { appendGatewayEvent } from "../gateway/events";
+
+export class AnthropicApiKeyProvider implements LlmProvider {
+  readonly name = "anthropic-api" as const;
+  readonly displayName = "Anthropic API (api key)";
+  private readonly client: Anthropic;
+  private readonly config: PmkConfig;
+
+  constructor(config: PmkConfig & { apiKey: string }) {
+    this.client = new Anthropic({ apiKey: config.apiKey });
+    this.config = config;
+  }
+
+  async chat(
+    systemPrompt: string,
+    messages: ChatMessage[],
+    opts: ChatOptions = {},
+  ): Promise<string> {
+    const stream = await this.client.messages.stream({
+      model: this.config.model,
+      max_tokens: this.config.maxTokens,
+      system: systemPrompt,
+      messages: messages.map((m) => ({ role: m.role, content: m.content })),
+    });
+
+    let full = "";
+    for await (const event of stream) {
+      if (
+        event.type === "content_block_delta" &&
+        event.delta.type === "text_delta"
+      ) {
+        const chunk = event.delta.text;
+        full += chunk;
+        opts.onToken?.(chunk);
+      }
+    }
+
+    // v0.12.0: emit token.usage audit event for the call. Only fires
+    // when caller provided an actor (Slack user ID or "cli:<name>").
+    // Best-effort — failures here must not break the chat() return.
+    if (opts.actor) {
+      try {
+        const final = await stream.finalMessage();
+        const usage = final.usage;
+        appendGatewayEvent({
+          type: "token.usage",
+          actor: opts.actor,
+          provider: "anthropic-api",
+          model: this.config.model,
+          inputTokens: usage.input_tokens,
+          outputTokens: usage.output_tokens,
+          ...(usage.cache_read_input_tokens !== undefined && usage.cache_read_input_tokens !== null
+            ? { cacheReadTokens: usage.cache_read_input_tokens }
+            : {}),
+          ...(usage.cache_creation_input_tokens !== undefined && usage.cache_creation_input_tokens !== null
+            ? { cacheCreationTokens: usage.cache_creation_input_tokens }
+            : {}),
+        });
+      } catch {
+        // Swallow — audit-event failures shouldn't surface as chat errors.
+      }
+    }
+
+    return full;
+  }
+}
+```
+
+- [ ] **Commit:** `git add packages/cli/src/llm/anthropic-api.ts packages/cli/test/llm-anthropic-api.test.ts && git commit -m "feat(llm): AnthropicApiKeyProvider emits token.usage audit event when actor provided"`
+
+---
+
+## Task 6: Wire `actor: userId` into both LLM call sites in `slack/index.ts`
+
+**Files:** `packages/cli/src/gateway/slack/index.ts`, `packages/cli/src/gateway/slack/context-retry.ts`. No new tests (existing context-retry tests don't assert on actor pass-through; T5 covers the emission side).
+
+The `chatWithContextRetry` helper today builds `opts: ChatOptions = chatOptions ?? { onToken: () => {} }` internally. T6 needs `actor` to flow from the runFreeChatTurn / synthesiseAfterMra call sites all the way through to `llm.chat(opts)`.
+
+- [ ] **Edit** `packages/cli/src/gateway/slack/context-retry.ts` — extend the inner opts construction to pass actor through:
+
+Locate the line `const opts: ChatOptions = chatOptions ?? { onToken: () => {} };` (around line 79). Change to:
+
+```ts
+const opts: ChatOptions = {
+  ...(chatOptions ?? { onToken: () => {} }),
+  actor,
+};
+```
+
+(`actor` is already destructured from `args` in this function — verify around line 75. The merge ensures `actor` is always present in the opts object passed to `llm.chat()`, regardless of what the caller supplied via `chatOptions`.)
+
+- [ ] **Edit** `packages/cli/src/gateway/slack/index.ts` — verify both `chatWithContextRetry` call sites pass `actor: userId` (first-call) and `actor: actor` (synthesise round). Both already do via the existing `actor` field in `ContextRetryArgs`.
+
+That means slack/index.ts requires **no edit for T6** — context-retry.ts forwards `actor` automatically once the opts merge is in place.
+
+- [ ] **Verify:** `cd packages/cli && npm test` — 305+/305+ pass (T5 added 2 tests; this task adds 0).
+- [ ] **Commit:** `git commit -am "feat(gateway): forward actor through chatWithContextRetry to llm.chat opts"`
+
+---
+
+## Task 7: Audit `tokenUsage` aggregation in `audit.ts`
+
+**Files:** `packages/cli/src/gateway/audit.ts`; extend `packages/cli/test/gateway-audit.test.ts`.
+
+- [ ] **Test** (extend gateway-audit.test.ts):
+
+```ts
+it("tokenUsage aggregates token.usage events (T7 / v0.12.0)", () => {
+  const now = Date.now();
+  appendGatewayEvent({ type: "token.usage", actor: "Uabc", provider: "anthropic-api", model: "claude-sonnet-4-6", inputTokens: 1000, outputTokens: 100 });
+  appendGatewayEvent({ type: "token.usage", actor: "Uabc", provider: "anthropic-api", model: "claude-sonnet-4-6", inputTokens: 2000, outputTokens: 200, cacheReadTokens: 500 });
+  appendGatewayEvent({ type: "token.usage", actor: "Udef", provider: "anthropic-api", model: "claude-sonnet-4-6", inputTokens: 3000, outputTokens: 300 });
+
+  const report = buildAuditReport({ days: 30, nowMs: now });
+  assert.equal(report.tokenUsage.total.inputTokens, 6000);
+  assert.equal(report.tokenUsage.total.outputTokens, 600);
+  assert.equal(report.tokenUsage.total.cacheReadTokens, 500);
+  assert.equal(report.tokenUsage.total.cacheCreationTokens, 0);
+
+  const top = report.tokenUsage.perActor;
+  assert.equal(top[0].actor, "Udef");
+  assert.equal(top[0].inputTokens, 3000);
+  assert.equal(top[1].actor, "Uabc");
+  assert.equal(top[1].inputTokens, 3000);
+
+  assert.equal(report.tokenUsage.perModel.length, 1);
+  assert.equal(report.tokenUsage.perModel[0].model, "claude-sonnet-4-6");
+  assert.equal(report.tokenUsage.perModel[0].inputTokens, 6000);
+});
+```
+
+- [ ] **Impl** in `audit.ts`. Extend `AuditReport` interface (after `contextSafety`, before `flags`):
+
+```ts
+tokenUsage: {
+  total: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreationTokens: number;
+  };
+  /** Top actors by inputTokens, descending. */
+  perActor: Array<{ actor: string; inputTokens: number; outputTokens: number }>;
+  /** Per-model breakdown. */
+  perModel: Array<{ model: string; inputTokens: number; outputTokens: number }>;
+};
+```
+
+In `buildAuditReport`, add per-actor and per-model accumulators before the for-loop:
+
+```ts
+let tuTotalIn = 0, tuTotalOut = 0, tuCacheRead = 0, tuCacheCreate = 0;
+const tuPerActor = new Map<string, { in: number; out: number }>();
+const tuPerModel = new Map<string, { in: number; out: number }>();
+```
+
+Add a switch case:
+
+```ts
+case "token.usage": {
+  tuTotalIn += e.inputTokens;
+  tuTotalOut += e.outputTokens;
+  tuCacheRead += e.cacheReadTokens ?? 0;
+  tuCacheCreate += e.cacheCreationTokens ?? 0;
+  const actorAcc = tuPerActor.get(e.actor) ?? { in: 0, out: 0 };
+  actorAcc.in += e.inputTokens;
+  actorAcc.out += e.outputTokens;
+  tuPerActor.set(e.actor, actorAcc);
+  const modelAcc = tuPerModel.get(e.model) ?? { in: 0, out: 0 };
+  modelAcc.in += e.inputTokens;
+  modelAcc.out += e.outputTokens;
+  tuPerModel.set(e.model, modelAcc);
+  break;
+}
+```
+
+In the returned object, add `tokenUsage` (place between `contextSafety` and `flags`):
+
+```ts
+tokenUsage: {
+  total: {
+    inputTokens: tuTotalIn,
+    outputTokens: tuTotalOut,
+    cacheReadTokens: tuCacheRead,
+    cacheCreationTokens: tuCacheCreate,
+  },
+  perActor: Array.from(tuPerActor.entries())
+    .map(([actor, v]) => ({ actor, inputTokens: v.in, outputTokens: v.out }))
+    .sort((a, b) => b.inputTokens - a.inputTokens),
+  perModel: Array.from(tuPerModel.entries())
+    .map(([model, v]) => ({ model, inputTokens: v.in, outputTokens: v.out }))
+    .sort((a, b) => b.inputTokens - a.inputTokens),
+},
+```
+
+- [ ] **`emptyReport` helper update:** `gateway-audit-format.test.ts`'s `emptyReport()` will fail typecheck once the new field is required. Add zero-value defaults in that helper:
+
+```ts
+tokenUsage: {
+  total: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 },
+  perActor: [],
+  perModel: [],
+},
+```
+
+- [ ] **Commit:** `git commit -am "feat(gateway): aggregate token.usage events into AuditReport.tokenUsage"`
+
+---
+
+## Task 8: Audit `Token usage` section in `audit-format.ts`
+
+**Files:** `packages/cli/src/gateway/audit-format.ts`; extend `packages/cli/test/gateway-audit-format.test.ts`.
+
+- [ ] **Test:**
+
+```ts
+it("renders Token usage section with non-zero counts (T8 / v0.12.0)", () => {
+  const report = emptyReport();
+  report.tokenUsage = {
+    total: { inputTokens: 12300, outputTokens: 700, cacheReadTokens: 9000, cacheCreationTokens: 0 },
+    perActor: [
+      { actor: "Uabc", inputTokens: 8200, outputTokens: 500 },
+      { actor: "Udef", inputTokens: 3100, outputTokens: 150 },
+      { actor: "Uxyz", inputTokens: 1000, outputTokens: 50 },
+    ],
+    perModel: [{ model: "claude-sonnet-4-6", inputTokens: 12300, outputTokens: 700 }],
+  };
+  const out = stripAnsi(formatAuditReport(report));
+  assert.match(out, /Token usage/);
+  assert.match(out, /total in \/ out:\s+12\.3k \/ 0\.7k tokens/);
+  assert.match(out, /cache read:\s+9\.0k tokens/);
+  assert.match(out, /per-actor.*Uabc 8\.2k in.*Udef 3\.1k in/);
+  assert.match(out, /per-model:\s+claude-sonnet-4-6 \(12\.3k in \/ 0\.7k out\)/);
+});
+
+it("renders Token usage section with zero counts (always shown, no cache line)", () => {
+  const report = emptyReport();
+  const out = stripAnsi(formatAuditReport(report));
+  assert.match(out, /Token usage/);
+  assert.match(out, /total in \/ out:\s+0 \/ 0 tokens/);
+  assert.doesNotMatch(out, /cache read:/);
+  assert.match(out, /per-actor.*\(none\)/);
+});
+```
+
+- [ ] **Impl** in `audit-format.ts`. Insert the section after the `// context safety` block, before the optional `// flags` block (around line 110):
+
+```ts
+// token usage
+lines.push("");
+lines.push(chalk.bold("Token usage"));
+const tu = report.tokenUsage;
+lines.push(label("total in / out:") + `${formatTokens(tu.total.inputTokens)} / ${formatTokens(tu.total.outputTokens)} tokens`);
+if (tu.total.cacheReadTokens > 0) {
+  lines.push(label("cache read:") + `${formatTokens(tu.total.cacheReadTokens)} tokens`);
+}
+lines.push(
+  label("per-actor (top 3):") +
+    (tu.perActor.length === 0
+      ? chalk.dim("(none)")
+      : tu.perActor
+          .slice(0, 3)
+          .map((e) => `${e.actor} ${formatTokens(e.inputTokens)} in`)
+          .join(", ")),
+);
+lines.push(
+  label("per-model:") +
+    (tu.perModel.length === 0
+      ? chalk.dim("(none)")
+      : tu.perModel
+          .map((e) => `${e.model} (${formatTokens(e.inputTokens)} in / ${formatTokens(e.outputTokens)} out)`)
+          .join(", ")),
+);
+```
+
+Add `formatTokens` helper at the bottom of the file (next to `formatDurationMs`):
+
+```ts
+/**
+ * Render a token count in compact form. Below 1000 → bare integer.
+ * 1k–999k → "X.Yk" (one decimal). >= 1M → "X.YM".
+ */
+export function formatTokens(n: number): string {
+  if (!Number.isFinite(n) || n < 0) return "0";
+  if (n < 1000) return `${n}`;
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}
+```
+
+- [ ] **Commit:** `git commit -am "feat(gateway): render Token usage section in pmk gateway audit"`
+
+---
+
+## Task 9: `gateway init` API-key prompt
+
+**Files:** `packages/cli/src/commands/gateway.ts`. Manual verify only (interactive prompt; T12 step 1 covers).
+
+- [ ] **Edit** `gateway.ts`'s `initCmd` (line 104+). After the existing Slack token prompts (App-Level Token, then Bot User OAuth Token), add a v0.12 explanation banner and an API-key prompt before `saveGatewayConfig`.
+
+Locate the section that currently saves the config after both Slack tokens. Just before `saveGatewayConfig({...})`, insert:
+
+```ts
+println("");
+println(
+  chalk.dim(
+    "  v0.12+: pmk gateway prefers the Anthropic API directly (no SDK overhead).",
+  ),
+);
+println(
+  chalk.dim(
+    "    If you skip this prompt, set ANTHROPIC_API_KEY in your environment, or",
+  ),
+);
+println(
+  chalk.dim(
+    "    keep the legacy claude-agent path with PMK_PROVIDER=claude-agent.",
+  ),
+);
+const apiKeyInput = (
+  await rl.question(
+    chalk.cyan(
+      `Anthropic API key (sk-ant-...) ${existing.apiKey ? "[unchanged on enter]" : "[blank to use env var]"}: `,
+    ),
+  )
+).trim();
+const apiKey = apiKeyInput || existing.apiKey;
+```
+
+Then in the `saveGatewayConfig({...})` call, add `apiKey` to the persisted object:
+
+```ts
+saveGatewayConfig({
+  ...existing,
+  slack: { appToken, botToken },
+  ...(apiKey ? { apiKey } : {}),
+});
+```
+
+(The conditional spread avoids writing `apiKey: undefined` when both `existing.apiKey` and the new input are empty — keeps the file slim for users who never opt in.)
+
+Verify `loadGatewayConfig()` already returns `apiKey?: string` on its result type. If not, add it to the type definition in `packages/cli/src/gateway/config.ts`.
+
+- [ ] **Verify** typecheck clean: `cd packages/cli && npm run typecheck:test`.
+- [ ] **Verify** existing init tests (in `gateway.test.ts` if any cover initCmd) still pass — the prompt is additive, no behavioural break for existing config files.
+- [ ] **Commit:** `git commit -am "feat(gateway): init prompts for ANTHROPIC_API_KEY (v0.12 default-provider switch)"`
+
+---
+
+## Task 10: Comment in `claude-agent.ts` about fallback role
+
+**Files:** `packages/cli/src/llm/claude-agent.ts`. No tests — comment-only change.
+
+- [ ] **Edit** `claude-agent.ts` — replace the existing top-of-file JSDoc (lines 5-15) with:
+
+```ts
+/**
+ * Delegates to the local `claude` CLI via the Claude Agent SDK, so we
+ * inherit whatever auth the user already has (OAuth, subscription, API
+ * key, Bedrock, Vertex) without requiring a separate ANTHROPIC_API_KEY.
+ *
+ * As of v0.12.0 this provider is the FALLBACK path — `autoResolve`
+ * prefers `AnthropicApiKeyProvider` when an API key is available
+ * because that path does not inherit the host's `~/.claude/` config
+ * (skills/hooks/MCP descriptions) into every system prompt, which
+ * v0.11.x had to absorb via tighter PMK_*_CAP defaults. This provider
+ * still works without code changes; it just no longer defaults.
+ *
+ * The SDK is stateful per `query()` call. To keep `LlmProvider.chat`
+ * stateless from the caller's perspective, each turn serialises the full
+ * history into a single prompt wrapped with transcript markers. This is
+ * slightly wasteful but keeps the caller interface identical to
+ * `AnthropicApiKeyProvider`.
+ */
+```
+
+- [ ] **Verify:** `cd packages/cli && npm test` — 305+/305+ pass (no behavioural change).
+- [ ] **Commit:** `git commit -am "docs(llm): note v0.12 fallback role in claude-agent provider header"`
+
+---
+
+## Task 11: Changelog + v0.12 migration doc
+
+**Files:** `apps/docs/docs/changelog.md`; create `apps/docs/docs/gateway/v0.12-migration.md`.
+
+- [ ] **Edit** `apps/docs/docs/changelog.md` — insert a new `## [v0.12.0]` heading above the existing `## [v0.11.1]` block. Body:
+
+```md
+## [v0.12.0] — 2026-05-DD — gateway: anthropic-api as default provider
+
+### Why
+
+v0.11.1 hardened the gateway against `msg_too_long` by lowering caps and adding an auto-retry path, but cause #2 from the 2026-05-07 incident — `claude-agent-sdk` spawning the local `claude` CLI and inheriting the host's `~/.claude/` config (skills/hooks/MCP descriptions) as un-budgeted system context — was absorbed by tighter caps, not eliminated. v0.12.0 flips the default to the direct Anthropic SDK so SDK overhead is no longer a budget unknown, and restores cap headroom.
+
+Spec: [`apps/docs/docs/plans/2026-05-08-gateway-anthropic-api-default.md`](./plans/2026-05-08-gateway-anthropic-api-default.md). Migration: [v0.12 migration notes](./gateway/v0.12-migration.md).
+
+### Changed
+
+- **Default LLM provider auto-resolves to `anthropic-api` first** (was `claude-agent`). Soft flip — users with `ANTHROPIC_API_KEY` set auto-switch; users without it stay on `claude-agent` with no behavioural change. `PMK_PROVIDER=claude-agent` still pins the legacy path explicitly.
+- **Cap defaults restored to operationally useful values** now that SDK overhead is gone on the default path:
+  - `PMK_MAX_SESSION_TOKENS` 25_000 → 60_000
+  - `PMK_SEED_CAP` 12_000 → 30_000
+  - `PMK_MRA_RESULT_CAP` 16_000 → 40_000
+- **`gateway init` prompts for `ANTHROPIC_API_KEY`** after Slack tokens; stored in `~/.pmk/gateway.json` `apiKey` field at mode 0600. Empty input keeps existing value or falls back to env var.
+
+### Added
+
+- **`token.usage` event** in `events-YYYY-MM.log` — emitted by `AnthropicApiKeyProvider.chat()` after each successful stream completion, when an `actor` is provided in `ChatOptions`. Fields: `actor`, `provider`, `model`, `inputTokens`, `outputTokens`, optional `cacheReadTokens` / `cacheCreationTokens`. Best-effort write — failures don't break the chat.
+- **`Token usage` section** in `pmk gateway audit` rolls up the new events: total in/out, cache read (when non-zero), top-3 per-actor by input tokens, per-model breakdown.
+- **`ChatOptions.actor`** optional field on the `LlmProvider.chat()` interface for usage attribution. Other CLI commands not yet plumbed in this release — future work.
+
+### Tests
+
+`@pmk/cli` 304 → **313** (+9): `resolver.ts` autoResolve order (apiKey-preferred, fallback, both-missing), `AnthropicApiKeyProvider.chat()` token-usage emission with mocked stream + `finalMessage()`, no-emission when actor undefined, `events.ts` round-trip for `token.usage`, `audit.ts` aggregation, `audit-format.ts` `Token usage` rendering for non-zero + zero cases.
+
+### Forward-looking
+
+`claude-agent` provider stays as a soft-flip fallback indefinitely. Re-evaluate deprecation in v0.13+ based on usage data from the new `Token usage` audit section. $-cost calculation is a v0.13+ candidate, gated on a stable price-table source.
+
+---
+
+```
+
+(The trailing `---` separates from the v0.11.1 block below.)
+
+- [ ] **Create** `apps/docs/docs/gateway/v0.12-migration.md`:
+
+```md
+---
+sidebar_position: 3
+---
+
+# v0.12 migration notes
+
+Operator-facing summary of what changes when you upgrade `pmk gateway` from v0.11.x to v0.12.0.
+
+## TL;DR
+
+```
+✅ Zero config changes required if you already have ANTHROPIC_API_KEY set.
+✅ Existing ~/.pmk/gateway.json is back-fill-compatible (apiKey field
+   is optional and additive).
+✅ Users without an API key keep running on the claude-agent fallback —
+   no behavioural change.
+✅ Cap defaults bumped 25k/12k/16k → 60k/30k/40k. PMK_*_CAP still
+   overrides per host.
+```
+
+## What changed
+
+### Provider auto-resolution
+
+Before (v0.11.x):
+
+```
+1. local `claude` binary → ClaudeAgentSdkProvider
+2. ANTHROPIC_API_KEY → AnthropicApiKeyProvider
+3. fail
+```
+
+After (v0.12.0):
+
+```
+1. ANTHROPIC_API_KEY (or config.apiKey) → AnthropicApiKeyProvider
+2. local `claude` binary → ClaudeAgentSdkProvider (fallback)
+3. fail
+```
+
+Why: `ClaudeAgentSdkProvider` spawns the local `claude` CLI and inherits the host's `~/.claude/` config (skills/hooks/MCP descriptions) as un-budgeted system context. On a heavy host this can add 10s of thousands of tokens to every API call. `AnthropicApiKeyProvider` calls the API directly with a clean system prompt — no overhead, predictable budgets.
+
+### `gateway init` prompts for the API key
+
+After the Slack token prompts, init now asks for `ANTHROPIC_API_KEY`. The value is stored in `~/.pmk/gateway.json` at mode 0600 alongside Slack tokens. Skip with empty input to fall back to the env var.
+
+### New `token.usage` event in events log
+
+JSONL line (synthetic sample — `actor: "U…"` is a redacted Slack user ID; `at` is ISO-8601):
+
+```jsonl
+{"at":"…","type":"token.usage","actor":"U…","provider":"anthropic-api","model":"claude-sonnet-4-6","inputTokens":12345,"outputTokens":678,"cacheReadTokens":9000}
+```
+
+`cacheReadTokens` / `cacheCreationTokens` present only when prompt caching was active.
+
+### `pmk gateway audit` `Token usage` section
+
+```
+Token usage
+  total in / out:                12.3k / 0.7k tokens
+  cache read:                    9.0k tokens
+  per-actor (top 3):             U… 8.2k in, U… 3.1k in, U… 1.0k in
+  per-model:                     claude-sonnet-4-6 (12.3k in / 0.7k out)
+```
+
+Always rendered (zero counts visible as `(none)`). `cache read` line shown only when non-zero. No `$` calculation — that's deferred to a future release.
+
+### Cap defaults bumped
+
+| Env var | v0.11.1 default | v0.12.0 default |
+|---|---|---|
+| `PMK_MAX_SESSION_TOKENS` | 25_000 | 60_000 |
+| `PMK_SEED_CAP` | 12_000 | 30_000 |
+| `PMK_MRA_RESULT_CAP` | 16_000 | 40_000 |
+
+If you're on the `claude-agent` fallback (no API key), tighten these back down — the SDK overhead is still in play on that path.
+
+## Upgrade checklist (v0.11.x → v0.12.0)
+
+1. `git pull && npm run cli:build` — no schema migration.
+2. **If you have `ANTHROPIC_API_KEY` set:** restart the gateway. v0.12 auto-switches to `anthropic-api`. Verify with `tail -f ~/.pmk/gateway/events-$(date -u +%Y-%m).log | grep token.usage`.
+3. **If you don't:** nothing to do — v0.12 invisible except for the bumped caps. Optionally run `pmk gateway init` to set the API key (writes to `gateway.json`).
+4. After a week, run `pmk gateway audit --days 7` and check the `Token usage` section.
+5. **To stay on `claude-agent`** explicitly: `export PMK_PROVIDER=claude-agent` (overrides auto). The fallback path is supported indefinitely.
+
+## See also
+
+- [v0.11 migration notes](./v0.11-migration.md) — preceding milestone
+- [Changelog](../changelog.md)
+```
+
+- [ ] **Commit:** `git add apps/docs/docs/changelog.md apps/docs/docs/gateway/v0.12-migration.md && git commit -m "docs: changelog + migration notes for v0.12.0 anthropic-api default"`
+
+---
+
+## Task 12: Pre-tag verification + version bump + tag
+
+**Files:** `package.json` × 7 via `scripts/bump-version.mjs`; tags + remote.
+
+- [ ] **Step 1: Restart gateway with `ANTHROPIC_API_KEY` set, verify provider switch**
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...   # use a real key
+npm --workspace packages/cli run start -- gateway start
+```
+
+Send any DM in Slack. Confirm reply works. Tail events log:
+
+```bash
+tail -f ~/.pmk/gateway/events-$(date -u +%Y-%m).log | grep token.usage
+```
+
+Expect ≥1 `token.usage` event per turn with non-zero `inputTokens`.
+
+- [ ] **Step 2: Run audit**
+
+```bash
+npm --workspace packages/cli run start -- gateway audit --days 1
+```
+
+Confirm `Token usage` section renders with totals + per-actor + per-model breakdowns.
+
+- [ ] **Step 3: Verify fallback path still works**
+
+```bash
+unset ANTHROPIC_API_KEY
+# kill the running gateway, then:
+npm --workspace packages/cli run start -- gateway start
+```
+
+Send any DM. Confirm reply still works (now via claude-agent). Tail events log — should see NO new `token.usage` events from this branch.
+
+- [ ] **Step 4: Re-export the API key for production use**
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+# restart gateway again to land on the v0.12 default path
+```
+
+- [ ] **Step 5: Bump version**
+
+```bash
+node scripts/bump-version.mjs 0.12.0
+```
+
+(Expects 7 package.json files updated: root + 4 packages + 2 apps.)
+
+- [ ] **Step 6: Commit + push branch + open PR**
+
+```bash
+git add -A
+git commit -m "chore(release): bump workspace versions to 0.12.0"
+git push -u origin feat/gateway-anthropic-api-default
+gh pr create --base main --head feat/gateway-anthropic-api-default \
+  --title "v0.12.0: gateway anthropic-api as default provider" \
+  --body "..."  # body draft from changelog v0.12.0 entry
+```
+
+- [ ] **Step 7: After review + squash-merge**
+
+```bash
+git fetch origin
+git tag -a v0.12.0 origin/main -m "v0.12.0: gateway anthropic-api as default provider
+
+..." # body from changelog
+git push origin v0.12.0
+gh release create v0.12.0 --title "v0.12.0 — gateway anthropic-api as default provider" --notes "..." # from changelog
+```
+
+(Same tagging pattern as v0.11.1 — tag points at the squash commit on origin/main, avoiding the destructive `git reset --hard` if local main is diverged from a separate workflow.)
+
+---
+
+## Self-review checklist
+
+- [x] **Spec coverage** — every section of the spec maps to a task:
+  - 1 Resolver default flip → T4
+  - 2 `gateway init` API-key prompt → T9
+  - 3 Token-usage telemetry → T1 (ChatOptions field), T5 (emission), T6 (actor wiring)
+  - 4 `TokenUsageEvent` type → T2
+  - 5 Audit `Token usage` section → T7 (aggregator), T8 (formatter)
+  - 6 Cap defaults bumped → T3
+  - Components touched table → covered by T1-T11
+  - Testing plan → covered as TDD inside each task
+  - Release plan → T11 (changelog/migration), T12 (verify + bump + PR + tag)
+  - Forward link (v0.11.2 harness, v0.13 deprecation, $-cost) → no implementation needed
+- [x] **No placeholders** — every code block is real code; commands are runnable; no `// TODO`.
+- [x] **Type consistency** — `ChatOptions.actor`, `TokenUsageEvent` fields (`inputTokens`/`outputTokens`/`cacheReadTokens`/`cacheCreationTokens`), env var names (`PMK_MAX_SESSION_TOKENS`/`PMK_SEED_CAP`/`PMK_MRA_RESULT_CAP`/`PMK_PROVIDER`/`ANTHROPIC_API_KEY`), constants (`MAX_SESSION_TOKENS`/`SEED_CAP`/`MRA_RESULT_CAP`), `AuditReport.tokenUsage` shape, formatter helper `formatTokens` — all referenced consistently across tasks.
+
+

--- a/apps/docs/docs/plans/2026-05-08-gateway-anthropic-api-default.md
+++ b/apps/docs/docs/plans/2026-05-08-gateway-anthropic-api-default.md
@@ -1,0 +1,304 @@
+# Gateway `anthropic-api` as Default Provider — Design Spec
+
+- Date: 2026-05-08
+- Target release: v0.12.0
+- Status: Draft (awaiting implementation plan)
+- Owner: Hanfour Huang
+
+## Background
+
+v0.11.1 hardened the gateway against `msg_too_long` by lowering caps,
+fixing the prune-ordering bug, and adding an auto-retry path. Cause #2
+from the 2026-05-07 incident — `claude-agent-sdk` spawning the local
+`claude` CLI and inheriting the host's `~/.claude/` config (skills,
+hooks, MCP server descriptions) as un-budgeted system context — was
+absorbed in v0.11.1 by lowering `MAX_SESSION_TOKENS` 60_000 → 25_000,
+not eliminated.
+
+The forward-link in
+`apps/docs/docs/plans/2026-05-07-gateway-msg-too-long-hardening.md`
+identified a v0.12 follow-up: switch the gateway provider default from
+`claude-agent-sdk` to the Anthropic SDK (`@anthropic-ai/sdk`),
+eliminating the SDK-inherited host context as a budget unknown so caps
+can return to operationally useful values.
+
+A scope discovery during brainstorming surfaced that
+`AnthropicApiKeyProvider` already exists, fully wired into the
+resolver, with proper streaming and role-separated messages. v0.12 is
+therefore much smaller than the original forward-link suggested — it
+is primarily a default-flip + cost telemetry release, not a build-the-
+new-provider release.
+
+## Goals
+
+- Make `anthropic-api` the auto-resolved default provider when an
+  Anthropic API key is available.
+- Keep `claude-agent-sdk` as a soft-flip fallback for users without an
+  API key (zero breakage on upgrade for that branch).
+- Restore cap defaults to operationally useful values
+  (`MAX_SESSION_TOKENS` back to 60_000, single-message caps relaxed)
+  now that SDK overhead is no longer in play on the default path.
+- Surface per-call token usage in `events.log` and `pmk gateway audit`
+  so operators can see what they're spending without doing math.
+
+## Non-goals (v0.12.0)
+
+- Calculating cost in dollars (pricing changes; not our job).
+- Deprecating the `claude-agent` provider — it stays as a soft-flip
+  fallback indefinitely. Re-evaluate in v0.13+ based on usage data
+  from the new `token.usage` audit section.
+- Changing the default model (`claude-sonnet-4-6` stays).
+- Reworking `pmk apply` / `pmk discuss` / `pmk explore` / `pmk ask` /
+  `pmk debug` / `pmk case` — they share `resolveProvider`, so they
+  automatically benefit from the default flip with no CLI command
+  surface changes.
+- Building a `SlackGateway` integration harness (still tracked as a
+  separate v0.11.2 follow-up; orthogonal to the provider switch).
+
+## Design
+
+### 1. Resolver default flip (soft-flip)
+
+In `packages/cli/src/llm/resolver.ts`'s `autoResolve(config)`, swap
+the order:
+
+Before (v0.11.x):
+
+```
+1. local `claude` binary on PATH → ClaudeAgentSdkProvider
+2. ANTHROPIC_API_KEY (or config.apiKey) → AnthropicApiKeyProvider
+3. fail
+```
+
+After (v0.12.0):
+
+```
+1. ANTHROPIC_API_KEY (or config.apiKey) → AnthropicApiKeyProvider
+2. local `claude` binary on PATH → ClaudeAgentSdkProvider
+3. fail
+```
+
+Migration semantics — zero-touch for both branches:
+
+| Existing user state | After v0.12 upgrade |
+|---|---|
+| Has `ANTHROPIC_API_KEY` set | Auto-switches to `anthropic-api`. Sees `Token usage` section in audit. SDK overhead gone, may see fewer `context.exceeded` events. |
+| No API key, has `claude` CLI | Stays on `claude-agent`. No behavior change. v0.12 is invisible to them except for the bumped cap defaults. |
+| Neither | Same `NoProviderAvailableError`, with updated message recommending the API-key path first. |
+
+`PMK_PROVIDER=claude-agent` continues to force the legacy path
+explicitly. `PMK_PROVIDER=anthropic-api` continues to require the API
+key. Both remain unchanged.
+
+### 2. `gateway init` API-key prompt
+
+In `packages/cli/src/commands/gateway.ts`'s `initCmd`, after the
+existing Slack token prompts (App-Level Token, Bot User OAuth Token),
+add an Anthropic API-key prompt:
+
+```
+Anthropic API key (sk-ant-...) [unchanged on enter; leave blank to use ANTHROPIC_API_KEY env var]:
+```
+
+Stored in `~/.pmk/gateway.json` `apiKey` field at mode 0600 (same as
+Slack tokens, since the file's permissions are already set on the
+existing init path). Empty input keeps the existing `apiKey` value if
+one is already in the file, otherwise leaves it `undefined` so env
+var resolution continues to work.
+
+Init copy gains a one-time explanation banner above the prompt:
+
+```
+v0.12+: pmk gateway prefers the Anthropic API directly (no SDK overhead).
+If you skip this prompt, set ANTHROPIC_API_KEY in your environment, or
+keep the legacy claude-agent path with PMK_PROVIDER=claude-agent.
+```
+
+### 3. Token-usage telemetry
+
+In `packages/cli/src/llm/anthropic-api.ts`'s `chat()` method, after
+the existing `for await (const event of stream)` loop completes,
+extract usage tokens from `stream.finalMessage()` (or accumulate
+`message_start.message.usage` and `message_delta.usage` during the
+loop) and emit a `token.usage` event:
+
+```ts
+appendGatewayEvent({
+  type: "token.usage",
+  actor,                 // threaded from caller (similar to T9 actor threading)
+  provider: "anthropic-api",
+  model: this.config.model,
+  inputTokens: usage.input_tokens,
+  outputTokens: usage.output_tokens,
+  cacheReadTokens: usage.cache_read_input_tokens,        // optional, when prompt-caching active
+  cacheCreationTokens: usage.cache_creation_input_tokens, // optional
+});
+```
+
+This requires threading `actor` into `LlmProvider.chat()`'s options
+(currently `ChatOptions` only has `onToken`). Add an optional
+`actor?: string` field to `ChatOptions`. Existing call sites in CLI
+commands that don't have a Slack-actor concept pass `actor:
+"cli:hanfourhuang"` or similar — or pass `undefined` and the event is
+suppressed (no actor → no event, since the audit aggregator buckets
+per-actor).
+
+`ClaudeAgentSdkProvider.chat()` does NOT emit `token.usage` events —
+the SDK doesn't surface per-call usage in a comparable way, and the
+goal of the event is to instrument the new default path. The audit
+aggregator handles a missing or zero `tokenUsage` rollup gracefully
+(renders `(none)`).
+
+### 4. New `TokenUsageEvent` type
+
+In `packages/cli/src/gateway/events.ts`:
+
+```ts
+export interface TokenUsageEvent {
+  type: "token.usage";
+  actor: string;
+  provider: "anthropic-api" | "claude-agent";
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  /** Present only when prompt caching was active. */
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
+}
+```
+
+Add to `GatewayEvent` union and `VALID_TYPES` set. JSDoc explains
+operator intent (per-call usage, no $-conversion in pmk).
+
+### 5. Audit `Token usage` section
+
+In `packages/cli/src/gateway/audit.ts`, extend `AuditReport`:
+
+```ts
+tokenUsage: {
+  total: { inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheCreationTokens: number };
+  perActor: Array<{ actor: string; inputTokens: number; outputTokens: number }>;
+  perModel: Array<{ model: string; inputTokens: number; outputTokens: number }>;
+};
+```
+
+Aggregate by switching on `e.type === "token.usage"` inside the
+existing event for-loop. Top-3 per-actor (with `OTHER` tail bucket
+mirroring the existing `formatTopWithOther` pattern).
+
+In `audit-format.ts`, render the section after `Context safety`:
+
+```
+Token usage
+  total in / out:                12.3k / 0.7k tokens
+  cache read:                    9.0k tokens
+  per-actor (top 3):             U… 8.2k in, U… 3.1k in, U… 1.0k in
+  per-model:                     claude-sonnet-4-6 (12.3k in / 0.7k out)
+```
+
+Section always rendered (zero-counts visible as `(none)`), matching
+the v0.11.1 `Context safety` section convention. `cache read` line
+shown only when non-zero (cache may not always be active).
+
+### 6. Cap defaults bumped
+
+In `packages/cli/src/gateway/messaging.ts`, lift the env-var fallback
+defaults (env var override behavior unchanged):
+
+| Constant | v0.11.1 default | v0.12.0 default |
+|---|---|---|
+| `MAX_SESSION_TOKENS` | 25_000 | **60_000** (back to pre-v0.11.1 value) |
+| `SEED_CAP` | 12_000 | **30_000** |
+| `MRA_RESULT_CAP` | 16_000 | **40_000** |
+
+JSDoc on each constant updated to note "v0.12.0 raised default with
+anthropic-api default — SDK overhead removed; tighten with
+PMK_*_CAP for hosts on the claude-agent fallback path".
+
+The retry path (`forcePruneToMinimum`, scissors marker, `:x:` hard-
+fail) remains untouched. All v0.11.1 layered defenses stay in place;
+only the budgets relax.
+
+## Components touched
+
+| File | Change kind |
+|---|---|
+| `packages/cli/src/llm/resolver.ts` | `autoResolve()` order swap; updated `NoProviderAvailableError` message |
+| `packages/cli/src/llm/anthropic-api.ts` | Token-usage event emission after stream completion; thread `actor` from `ChatOptions` |
+| `packages/cli/src/llm/provider.ts` | Add optional `actor?: string` to `ChatOptions` |
+| `packages/cli/src/commands/gateway.ts` | Add API-key prompt + explanation banner to `initCmd` |
+| `packages/cli/src/gateway/events.ts` | Add `TokenUsageEvent` interface, extend union and `VALID_TYPES` |
+| `packages/cli/src/gateway/audit.ts` | Add `tokenUsage` field to `AuditReport`, aggregate from event log |
+| `packages/cli/src/gateway/audit-format.ts` | Render `Token usage` section after `Context safety` |
+| `packages/cli/src/gateway/messaging.ts` | Lift `MAX_SESSION_TOKENS` / `SEED_CAP` / `MRA_RESULT_CAP` defaults; JSDoc rewrites |
+| `packages/cli/src/gateway/slack/index.ts` | Pass `actor: userId` in `ChatOptions` for both `chatWithContextRetry` and `synthesiseAfterMra` LLM calls |
+| `packages/cli/src/llm/claude-agent.ts` | Add a brief comment at the top noting v0.12 fallback role; no behavioral change |
+| `packages/cli/test/resolver.test.ts` (new) | Auto-resolve order tests |
+| `packages/cli/test/llm-anthropic-api.test.ts` (new) | Token-usage emission unit tests |
+| `packages/cli/test/messaging.test.ts` (extend) | Update cap-default assertions to v0.12 values |
+| `packages/cli/test/gateway-events.test.ts` (extend) | `token.usage` round-trip |
+| `packages/cli/test/gateway-audit.test.ts` (extend) | `tokenUsage` aggregation test |
+| `packages/cli/test/gateway-audit-format.test.ts` (extend) | `Token usage` section rendering (non-zero + zero cases) |
+| `apps/docs/docs/changelog.md` | v0.12.0 entry |
+| `apps/docs/docs/gateway/v0.12-migration.md` (new) | Operator-facing summary mirroring v0.11 migration doc shape |
+
+## Testing plan
+
+| Type | Coverage |
+|---|---|
+| Unit | `resolver.ts` autoResolve order: apiKey present → anthropic-api; apiKey absent + claude binary → claude-agent; both missing → NoProviderAvailableError. |
+| Unit | `anthropic-api.ts` token-usage emission: mock `client.messages.stream()` to yield `message_start` + `message_delta` events with usage fields; assert `appendGatewayEvent` called with the right shape; verify no event when `actor` is undefined. |
+| Unit | `events.ts` round-trip for `token.usage` (extends `gateway-events.test.ts`). |
+| Unit | `messaging.ts` cap defaults — flip the existing v0.11.1 default-value assertions to v0.12.0 values (60k / 30k / 40k). |
+| Unit | `audit.ts` `tokenUsage` aggregation: seed N `token.usage` events with mixed actors / models / cache fields; assert totals, top-3 per-actor, per-model breakdown. |
+| Unit | `audit-format.ts` `Token usage` section: non-zero rendering with cache line; zero rendering with `(none)`; cache line suppressed when zero. |
+
+No new e2e tests. Live verification path covered in the release plan.
+
+The `gateway init` API-key prompt is interactive and exercised by the
+release-plan manual verification step. If a prompt-helper extraction
+(e.g. `promptForApiKey()`) lands naturally during implementation, a
+unit test for it should be added; if not, manual verify is acceptable.
+
+## Release plan
+
+- Target version: **v0.12.0** (minor bump — auto-resolution semantics
+  change is user-visible, even though most existing users see no
+  behavior change).
+- Workflow: per `feedback_release_workflow.md`, v0.x.0 ships as a
+  squash-merge feature PR with explicit review (matches v0.11.1
+  pattern even though that was technically a patch).
+- Pre-tag verification:
+  1. Set `ANTHROPIC_API_KEY` in env, restart gateway. Confirm startup
+     log says provider=anthropic-api (or absence of "claude path
+     found" line). Send any DM, verify reply works.
+  2. Tail `events-2026-MM.log | grep token.usage` — expect one event
+     per turn with non-zero `inputTokens`.
+  3. Run `pmk gateway audit --days 1` — expect `Token usage` section
+     populated with per-actor + per-model breakdowns.
+  4. Unset `ANTHROPIC_API_KEY` and restart gateway. Confirm fallback
+     to `claude-agent` path runs normally (smoke test for the soft-
+     flip fallback). No `token.usage` events should be emitted from
+     this branch.
+- Changelog entry for v0.12.0:
+  `gateway: anthropic-api as default provider — eliminates claude-agent-sdk's host-context overhead, restores cap headroom (MAX_SESSION_TOKENS 25k → 60k, SEED_CAP 12k → 30k, MRA_RESULT_CAP 16k → 40k), adds per-call token.usage telemetry with new audit Token usage section, gateway init now prompts for ANTHROPIC_API_KEY. claude-agent stays as soft-flip fallback for users without an API key — zero breakage.`
+
+## Forward link: post-v0.12
+
+- **v0.11.2 (parallel track):** SlackGateway integration harness so
+  the seed-cap / mra-result-cap / prune-ordering / retry-prefix
+  wiring sites get direct integration coverage. Orthogonal to v0.12.
+- **v0.13+ candidate:** evaluate deprecating `claude-agent` based on
+  3-6 months of `token.usage` audit data. If users have de-facto
+  migrated, mark deprecated; remove in a later major.
+- **v0.13+ candidate:** $-cost calculation in audit, gated on
+  Anthropic publishing a stable price-table API or pmk maintaining a
+  manually-updated table.
+
+## Open questions
+
+None at draft time. Decisions on scope (full default flip), migration
+UX (soft flip), init prompt (write to gateway.json), cap aggressiveness
+(medium relaxation back to v0.11.0 levels), and cost telemetry depth
+(token counts, no $-math) were resolved during the brainstorming
+session that produced this spec on 2026-05-08.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmk/docs",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "private": true,
   "description": "Docusaurus docs site for pm-workspace-kit",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-workspace-kit",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "private": true,
   "description": "An opinionated PM/SA workspace kit — Docusaurus docs site, traceability scripts, CLI (pmk), and desktop app. Monorepo.",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmk/cli",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "pmk — command-line interface for pm-workspace-kit",
   "license": "MIT",
   "bin": {

--- a/packages/cli/src/commands/gateway.ts
+++ b/packages/cli/src/commands/gateway.ts
@@ -206,6 +206,31 @@ async function initCmd(): Promise<void> {
       );
     }
 
+    println("");
+    println(
+      chalk.dim(
+        "  v0.12+: pmk gateway prefers the Anthropic API directly (no SDK overhead).",
+      ),
+    );
+    println(
+      chalk.dim(
+        "    If you skip this prompt, set ANTHROPIC_API_KEY in your environment, or",
+      ),
+    );
+    println(
+      chalk.dim(
+        "    keep the legacy claude-agent path with PMK_PROVIDER=claude-agent.",
+      ),
+    );
+    const apiKeyInput = (
+      await rl.question(
+        chalk.cyan(
+          `Anthropic API key (sk-ant-...) ${existing.apiKey ? "[unchanged on enter]" : "[blank to use env var]"}: `,
+        ),
+      )
+    ).trim();
+    const apiKey = apiKeyInput || existing.apiKey;
+
     const cfg = {
       version: 1 as const,
       blocklist: existing.blocklist,
@@ -214,6 +239,7 @@ async function initCmd(): Promise<void> {
       mraWorkspace,
       audience: existing.audience,
       escalation: existing.escalation,
+      ...(apiKey ? { apiKey } : {}),
       slack: { appToken, botToken },
     };
     if (!hasValidSlackTokens(cfg)) {

--- a/packages/cli/src/gateway/audit-format.ts
+++ b/packages/cli/src/gateway/audit-format.ts
@@ -108,6 +108,32 @@ export function formatAuditReport(report: AuditReport): string {
       `${cs.messageCapped.total} (seed ${cs.messageCapped.seed}, mra-result ${cs.messageCapped.mraResult})`,
   );
 
+  // token usage
+  lines.push("");
+  lines.push(chalk.bold("Token usage"));
+  const tu = report.tokenUsage;
+  lines.push(label("total in / out:") + `${formatTokens(tu.total.inputTokens)} / ${formatTokens(tu.total.outputTokens)} tokens`);
+  if (tu.total.cacheReadTokens > 0) {
+    lines.push(label("cache read:") + `${formatTokens(tu.total.cacheReadTokens)} tokens`);
+  }
+  lines.push(
+    label("per-actor (top 3):") +
+      (tu.perActor.length === 0
+        ? chalk.dim("(none)")
+        : tu.perActor
+            .slice(0, 3)
+            .map((e) => `${e.actor} ${formatTokens(e.inputTokens)} in`)
+            .join(", ")),
+  );
+  lines.push(
+    label("per-model:") +
+      (tu.perModel.length === 0
+        ? chalk.dim("(none)")
+        : tu.perModel
+            .map((e) => `${e.model} (${formatTokens(e.inputTokens)} in / ${formatTokens(e.outputTokens)} out)`)
+            .join(", ")),
+  );
+
   // flags
   if (report.flags.length > 0) {
     lines.push("");
@@ -141,6 +167,18 @@ export function formatDurationMs(ms: number | undefined): string {
   const days = Math.floor(hours / 24);
   const remHours = hours % 24;
   return remHours === 0 ? `${days}d` : `${days}d ${remHours}h`;
+}
+
+/**
+ * Render a token count in compact form. 0 → "0" (so empty audits read
+ * naturally). Otherwise sub-1M → "X.Yk" (one decimal, including sub-1k
+ * counts like 700 → "0.7k" for visual alignment with thousands-scale
+ * peers in the same line). >= 1M → "X.YM".
+ */
+export function formatTokens(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return "0";
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
 }
 
 function label(text: string): string {

--- a/packages/cli/src/gateway/audit.ts
+++ b/packages/cli/src/gateway/audit.ts
@@ -72,6 +72,32 @@ export interface AuditReport {
     contextForcePruned: number;
     messageCapped: { total: number; seed: number; mraResult: number };
   };
+  /**
+   * v0.12.0: per-call token accounting aggregated from `token.usage`
+   * events. Operators use this to attribute spend to actors and gauge
+   * cache effectiveness — high `cacheReadTokens` relative to
+   * `inputTokens` indicates prompt caching is paying off.
+   */
+  tokenUsage: {
+    total: {
+      inputTokens: number;
+      outputTokens: number;
+      cacheReadTokens: number;
+      cacheCreationTokens: number;
+    };
+    /** Top actors by inputTokens, descending. */
+    perActor: Array<{
+      actor: string;
+      inputTokens: number;
+      outputTokens: number;
+    }>;
+    /** Per-model breakdown, sorted by inputTokens descending. */
+    perModel: Array<{
+      model: string;
+      inputTokens: number;
+      outputTokens: number;
+    }>;
+  };
   flags: string[];
 }
 
@@ -127,6 +153,16 @@ export function buildAuditReport(
     msgCapSeed = 0,
     msgCapMra = 0;
 
+  // v0.12.0: token.usage accumulators. Cache fields are optional on the
+  // event (absence ≠ zero), but we collapse "not reported" to 0 in the
+  // rollup since operators just want totals.
+  let tuTotalIn = 0,
+    tuTotalOut = 0,
+    tuCacheRead = 0,
+    tuCacheCreate = 0;
+  const tuPerActor = new Map<string, { in: number; out: number }>();
+  const tuPerModel = new Map<string, { in: number; out: number }>();
+
   for (const e of events) {
     switch (e.type) {
       case "turn.processed":
@@ -180,6 +216,21 @@ export function buildAuditReport(
         if (e.kind === "seed") msgCapSeed++;
         else if (e.kind === "mra-result") msgCapMra++;
         break;
+      case "token.usage": {
+        tuTotalIn += e.inputTokens;
+        tuTotalOut += e.outputTokens;
+        tuCacheRead += e.cacheReadTokens ?? 0;
+        tuCacheCreate += e.cacheCreationTokens ?? 0;
+        const actorAcc = tuPerActor.get(e.actor) ?? { in: 0, out: 0 };
+        actorAcc.in += e.inputTokens;
+        actorAcc.out += e.outputTokens;
+        tuPerActor.set(e.actor, actorAcc);
+        const modelAcc = tuPerModel.get(e.model) ?? { in: 0, out: 0 };
+        modelAcc.in += e.inputTokens;
+        modelAcc.out += e.outputTokens;
+        tuPerModel.set(e.model, modelAcc);
+        break;
+      }
     }
   }
 
@@ -255,6 +306,28 @@ export function buildAuditReport(
         seed: msgCapSeed,
         mraResult: msgCapMra,
       },
+    },
+    tokenUsage: {
+      total: {
+        inputTokens: tuTotalIn,
+        outputTokens: tuTotalOut,
+        cacheReadTokens: tuCacheRead,
+        cacheCreationTokens: tuCacheCreate,
+      },
+      perActor: Array.from(tuPerActor.entries())
+        .map(([actor, v]) => ({
+          actor,
+          inputTokens: v.in,
+          outputTokens: v.out,
+        }))
+        .sort((a, b) => b.inputTokens - a.inputTokens),
+      perModel: Array.from(tuPerModel.entries())
+        .map(([model, v]) => ({
+          model,
+          inputTokens: v.in,
+          outputTokens: v.out,
+        }))
+        .sort((a, b) => b.inputTokens - a.inputTokens),
     },
     flags,
   };

--- a/packages/cli/src/gateway/config.ts
+++ b/packages/cli/src/gateway/config.ts
@@ -81,6 +81,13 @@ export interface GatewayConfig {
   audience: AudienceConfig;
   /** Pool of IT/domain contacts pmk can @-mention on `escalate`. */
   escalation: EscalationConfig;
+  /**
+   * Anthropic API key. v0.12.0+: written by `pmk gateway init` so the
+   * gateway can prefer the anthropic-api provider without requiring
+   * the operator to also set ANTHROPIC_API_KEY in env. Env var still
+   * takes precedence at runtime (loadCliConfig() reads env first).
+   */
+  apiKey?: string;
   slack: SlackConfig;
 }
 

--- a/packages/cli/src/gateway/events.ts
+++ b/packages/cli/src/gateway/events.ts
@@ -152,6 +152,25 @@ export interface MessageCappedEvent {
   cappedChars: number;
 }
 
+/**
+ * Per-call token accounting (v0.12.0). Emitted once per model round so
+ * audits can attribute spend to the actor and reveal cache effectiveness
+ * (cache reads are billed at a fraction of input tokens). The cache
+ * fields are optional because not every provider/model surfaces them —
+ * absence means "not reported", not "zero".
+ */
+export interface TokenUsageEvent {
+  type: "token.usage";
+  actor: string;
+  provider: "anthropic-api" | "claude-agent";
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  /** Present only when prompt caching was active. */
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
+}
+
 export type GatewayEvent =
   | MraAskEndEvent
   | TurnProcessedEvent
@@ -160,7 +179,8 @@ export type GatewayEvent =
   | GatewayPresenceEvent
   | ContextExceededEvent
   | ContextForcePrunedEvent
-  | MessageCappedEvent;
+  | MessageCappedEvent
+  | TokenUsageEvent;
 
 /** What lands on disk: the event plus the ISO timestamp added at append time. */
 export type StoredGatewayEvent = GatewayEvent & { at: string };
@@ -175,6 +195,7 @@ const VALID_TYPES: ReadonlySet<string> = new Set([
   "context.exceeded",
   "context.force-pruned",
   "message.capped",
+  "token.usage",
 ]);
 
 /**

--- a/packages/cli/src/gateway/messaging.ts
+++ b/packages/cli/src/gateway/messaging.ts
@@ -156,36 +156,32 @@ function parsePositiveIntEnv(name: string, fallback: number): number {
 
 /**
  * Soft cap for `session.approxTokens` before pruning kicks in.
- * v0.11.1: lowered default from 60_000 → 25_000. The 60k figure
- * assumed ~70% of a 90k DM-context budget and ignored the host
- * config that `claude-agent-sdk` inherits when it spawns the local
- * `claude` CLI. 25k leaves explicit headroom for system prompt +
- * retrieval prefix + SDK-inherited host context + new turn + reply.
- * Override with `PMK_MAX_SESSION_TOKENS=…` per host.
+ * v0.11.1 lowered to 25_000 to absorb claude-agent-sdk host-context
+ * overhead. v0.12.0: raised back to 60_000 — anthropic-api is now the
+ * default provider and SDK overhead is no longer in play. Tighten with
+ * PMK_MAX_SESSION_TOKENS for hosts on the claude-agent fallback.
  */
 export const MAX_SESSION_TOKENS = parsePositiveIntEnv(
   "PMK_MAX_SESSION_TOKENS",
-  25_000,
+  60_000,
 );
 
 /**
- * Maximum chars for the PKB seed message pushed at the start of a
- * fresh session. Defaults to 12_000 — generous enough for a multi-
- * repo summary, tight enough that the seed cannot single-handedly
- * exhaust the model's input window. Override with `PMK_SEED_CAP=…`
- * per host.
+ * Maximum chars for the PKB seed message. v0.12.0: raised 12_000 →
+ * 30_000 with anthropic-api default. Override with PMK_SEED_CAP=… per
+ * host.
  */
-export const SEED_CAP = parsePositiveIntEnv("PMK_SEED_CAP", 12_000);
+export const SEED_CAP = parsePositiveIntEnv("PMK_SEED_CAP", 30_000);
 
 /**
  * Maximum chars for `mra-ask` stdout pushed into session history.
- * Applied at the call site in `synthesiseAfterMra` (slack/index.ts)
- * before passing to `buildMraSuccessMessage`. Override with
- * `PMK_MRA_RESULT_CAP=…` per host.
+ * v0.12.0: raised 16_000 → 40_000. Wired into capMessageContent at
+ * the synthesiseAfterMra call site (slack/index.ts). Override with
+ * PMK_MRA_RESULT_CAP=… per host.
  */
 export const MRA_RESULT_CAP = parsePositiveIntEnv(
   "PMK_MRA_RESULT_CAP",
-  16_000,
+  40_000,
 );
 
 /** How many recent (user, assistant) pairs to always keep across a prune. */

--- a/packages/cli/src/gateway/slack/context-retry.ts
+++ b/packages/cli/src/gateway/slack/context-retry.ts
@@ -76,7 +76,13 @@ export async function chatWithContextRetry(
     phase,
     chatOptions,
   } = args;
-  const opts: ChatOptions = chatOptions ?? { onToken: () => {} };
+  // v0.12.0: forward actor through to llm.chat() so AnthropicApiKeyProvider
+  // can attribute the token.usage audit event without the helper having
+  // to know which provider is in play.
+  const opts: ChatOptions = {
+    ...(chatOptions ?? { onToken: () => {} }),
+    actor,
+  };
 
   try {
     const full = await llm.chat(systemPrompt, buildMessages(), opts);

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -206,7 +206,16 @@ export class SlackAdapter {
       logLevel: "warn" as never, // Avoid noisy stdout in normal operation.
     });
     this.web = new WebClient(opts.config.slack.botToken);
-    this.llm = resolveProvider(loadCliConfig());
+    // v0.12.0: prefer ANTHROPIC_API_KEY from env (already merged by
+    // loadCliConfig()), then ~/.pmk/config.json, then gateway.json.
+    // The merge happens once at adapter init — running daemons need a
+    // restart to pick up a freshly-written gateway.json apiKey, same
+    // caveat as audience/escalation config.
+    const baseCliConfig = loadCliConfig();
+    const mergedConfig = baseCliConfig.apiKey
+      ? baseCliConfig
+      : { ...baseCliConfig, apiKey: this.config.apiKey };
+    this.llm = resolveProvider(mergedConfig);
   }
 
   async start(): Promise<SlackBotInfo> {

--- a/packages/cli/src/llm/anthropic-api.ts
+++ b/packages/cli/src/llm/anthropic-api.ts
@@ -1,9 +1,14 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type { ChatMessage, PmkConfig } from "@pmk/shared";
 import type { ChatOptions, LlmProvider } from "./provider";
+import { appendGatewayEvent } from "../gateway/events";
 
 /**
  * Uses a raw Anthropic API key. Requires ANTHROPIC_API_KEY (or config.apiKey).
+ *
+ * v0.12.0+: when ChatOptions.actor is provided, emits a `token.usage`
+ * audit event after each successful stream completion. Best-effort —
+ * audit-event failures don't surface as chat errors.
  */
 export class AnthropicApiKeyProvider implements LlmProvider {
   readonly name = "anthropic-api" as const;
@@ -39,6 +44,41 @@ export class AnthropicApiKeyProvider implements LlmProvider {
         opts.onToken?.(chunk);
       }
     }
+
+    // v0.12.0: emit token.usage audit event for the call. Only fires
+    // when caller provided an actor (Slack user ID or "cli:<name>").
+    // Best-effort — failures here must not break the chat() return.
+    if (opts.actor) {
+      try {
+        const final = await stream.finalMessage();
+        // The pinned SDK's `Usage` type only declares input/output_tokens;
+        // newer Anthropic API responses also surface cache_*_input_tokens
+        // at runtime. Widen here so we can record them when present.
+        const usage = final.usage as typeof final.usage & {
+          cache_read_input_tokens?: number | null;
+          cache_creation_input_tokens?: number | null;
+        };
+        appendGatewayEvent({
+          type: "token.usage",
+          actor: opts.actor,
+          provider: "anthropic-api",
+          model: this.config.model,
+          inputTokens: usage.input_tokens,
+          outputTokens: usage.output_tokens,
+          ...(usage.cache_read_input_tokens !== undefined &&
+          usage.cache_read_input_tokens !== null
+            ? { cacheReadTokens: usage.cache_read_input_tokens }
+            : {}),
+          ...(usage.cache_creation_input_tokens !== undefined &&
+          usage.cache_creation_input_tokens !== null
+            ? { cacheCreationTokens: usage.cache_creation_input_tokens }
+            : {}),
+        });
+      } catch {
+        // Swallow — audit-event failures shouldn't surface as chat errors.
+      }
+    }
+
     return full;
   }
 }

--- a/packages/cli/src/llm/claude-agent.ts
+++ b/packages/cli/src/llm/claude-agent.ts
@@ -29,6 +29,13 @@ export function isContextTooLongError(err: unknown): boolean {
  * inherit whatever auth the user already has (OAuth, subscription, API
  * key, Bedrock, Vertex) without requiring a separate ANTHROPIC_API_KEY.
  *
+ * As of v0.12.0 this provider is the FALLBACK path — `autoResolve`
+ * prefers `AnthropicApiKeyProvider` when an API key is available
+ * because that path does not inherit the host's `~/.claude/` config
+ * (skills/hooks/MCP descriptions) into every system prompt, which
+ * v0.11.x had to absorb via tighter PMK_*_CAP defaults. This provider
+ * still works without code changes; it just no longer defaults.
+ *
  * The SDK is stateful per `query()` call. To keep `LlmProvider.chat`
  * stateless from the caller's perspective, each turn serialises the full
  * history into a single prompt wrapped with transcript markers. This is

--- a/packages/cli/src/llm/provider.ts
+++ b/packages/cli/src/llm/provider.ts
@@ -26,9 +26,9 @@ export class NoProviderAvailableError extends Error {
     super(
       `[pmk] no usable LLM provider found (tried: ${attempted.join(", ")}).\n` +
         "  Try one of:\n" +
-        "    • install Claude Code and run `claude login` — https://claude.com/product/claude-code\n" +
         "    • set ANTHROPIC_API_KEY in your environment — https://console.anthropic.com\n" +
-        "  Or pin a provider with PMK_PROVIDER=<claude-agent|anthropic-api>.",
+        "    • install Claude Code and run `claude login` — https://claude.com/product/claude-code (legacy fallback)\n" +
+        "  Or pin a provider with PMK_PROVIDER=<anthropic-api|claude-agent>.",
     );
     this.name = "NoProviderAvailableError";
   }

--- a/packages/cli/src/llm/provider.ts
+++ b/packages/cli/src/llm/provider.ts
@@ -2,6 +2,13 @@ import type { ChatMessage, LlmProviderName } from "@pmk/shared";
 
 export interface ChatOptions {
   onToken?: (chunk: string) => void;
+  /**
+   * Slack user ID (or "cli:<name>" for CLI invocations) the call is on
+   * behalf of. Used by AnthropicApiKeyProvider to attribute the
+   * `token.usage` audit event. Optional — providers that don't emit
+   * usage events ignore it; if undefined no event is written.
+   */
+  actor?: string;
 }
 
 export interface LlmProvider {

--- a/packages/cli/src/llm/resolver.ts
+++ b/packages/cli/src/llm/resolver.ts
@@ -10,9 +10,9 @@ import { NoProviderAvailableError, type LlmProvider } from "./provider";
 /**
  * Find a usable LLM provider.
  *
- * Order (`config.provider: "auto"`):
- *   1. local `claude` binary on PATH → ClaudeAgentSdkProvider
- *   2. ANTHROPIC_API_KEY (or config.apiKey) → AnthropicApiKeyProvider
+ * Order (`config.provider: "auto"`, v0.12.0+):
+ *   1. ANTHROPIC_API_KEY (or config.apiKey) → AnthropicApiKeyProvider
+ *   2. local `claude` binary on PATH → ClaudeAgentSdkProvider (fallback)
  *   3. fail with actionable error
  *
  * `PMK_PROVIDER` env var overrides `config.provider`.
@@ -47,14 +47,17 @@ export function resolveProvider(config: PmkConfig): LlmProvider {
 }
 
 function autoResolve(config: PmkConfig): LlmProvider {
+  // v0.12.0: prefer anthropic-api when apiKey is available — eliminates
+  // claude-agent-sdk host-context overhead. Falls through to claude-agent
+  // for users without an API key (zero-touch upgrade for that branch).
+  if (config.apiKey) {
+    return new AnthropicApiKeyProvider({ ...config, apiKey: config.apiKey });
+  }
   const claudePath = findClaudeExecutable();
   if (claudePath) {
     return new ClaudeAgentSdkProvider(config, claudePath);
   }
-  if (config.apiKey) {
-    return new AnthropicApiKeyProvider({ ...config, apiKey: config.apiKey });
-  }
-  throw new NoProviderAvailableError(["claude-agent", "anthropic-api"]);
+  throw new NoProviderAvailableError(["anthropic-api", "claude-agent"]);
 }
 
 /**

--- a/packages/cli/test/gateway-audit-format.test.ts
+++ b/packages/cli/test/gateway-audit-format.test.ts
@@ -41,6 +41,16 @@ function emptyReport(overrides: Partial<AuditReport> = {}): AuditReport {
       contextForcePruned: 0,
       messageCapped: { total: 0, seed: 0, mraResult: 0 },
     },
+    tokenUsage: {
+      total: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      },
+      perActor: [],
+      perModel: [],
+    },
     flags: [],
     ...overrides,
   };

--- a/packages/cli/test/gateway-audit-format.test.ts
+++ b/packages/cli/test/gateway-audit-format.test.ts
@@ -208,6 +208,34 @@ describe("formatAuditReport", () => {
     assert.match(out, /messages capped:\s+0 \(seed 0, mra-result 0\)/);
   });
 
+  it("renders Token usage section with non-zero counts (T8 / v0.12.0)", () => {
+    const report = emptyReport();
+    report.tokenUsage = {
+      total: { inputTokens: 12300, outputTokens: 700, cacheReadTokens: 9000, cacheCreationTokens: 0 },
+      perActor: [
+        { actor: "Uabc", inputTokens: 8200, outputTokens: 500 },
+        { actor: "Udef", inputTokens: 3100, outputTokens: 150 },
+        { actor: "Uxyz", inputTokens: 1000, outputTokens: 50 },
+      ],
+      perModel: [{ model: "claude-sonnet-4-6", inputTokens: 12300, outputTokens: 700 }],
+    };
+    const out = stripAnsi(formatAuditReport(report));
+    assert.match(out, /Token usage/);
+    assert.match(out, /total in \/ out:\s+12\.3k \/ 0\.7k tokens/);
+    assert.match(out, /cache read:\s+9\.0k tokens/);
+    assert.match(out, /per-actor.*Uabc 8\.2k in.*Udef 3\.1k in/);
+    assert.match(out, /per-model:\s+claude-sonnet-4-6 \(12\.3k in \/ 0\.7k out\)/);
+  });
+
+  it("renders Token usage section with zero counts (always shown, no cache line)", () => {
+    const report = emptyReport();
+    const out = stripAnsi(formatAuditReport(report));
+    assert.match(out, /Token usage/);
+    assert.match(out, /total in \/ out:\s+0 \/ 0 tokens/);
+    assert.doesNotMatch(out, /cache read:/);
+    assert.match(out, /per-actor.*\(none\)/);
+  });
+
   it("renders flags section only when there are flags", () => {
     const report = emptyReport({
       flags: [

--- a/packages/cli/test/gateway-audit.test.ts
+++ b/packages/cli/test/gateway-audit.test.ts
@@ -508,4 +508,57 @@ describe("gateway audit aggregator (#24)", () => {
     assert.equal(buildAuditReport({ days: NaN }).windowDays, 7);
     assert.equal(buildAuditReport({ days: 14 }).windowDays, 14);
   });
+
+  it("tokenUsage aggregates token.usage events (T7 / v0.12.0)", async () => {
+    const { appendGatewayEvent } = await import("../src/gateway/events");
+    const { buildAuditReport } = await import("../src/gateway/audit");
+    const now = Date.now();
+    appendGatewayEvent({
+      type: "token.usage",
+      actor: "Uabc",
+      provider: "anthropic-api",
+      model: "claude-sonnet-4-6",
+      inputTokens: 1000,
+      outputTokens: 100,
+    });
+    appendGatewayEvent({
+      type: "token.usage",
+      actor: "Uabc",
+      provider: "anthropic-api",
+      model: "claude-sonnet-4-6",
+      inputTokens: 2000,
+      outputTokens: 200,
+      cacheReadTokens: 500,
+    });
+    appendGatewayEvent({
+      type: "token.usage",
+      actor: "Udef",
+      provider: "anthropic-api",
+      model: "claude-sonnet-4-6",
+      inputTokens: 3000,
+      outputTokens: 300,
+    });
+
+    const report = buildAuditReport({ days: 30, nowMs: now });
+    assert.equal(report.tokenUsage.total.inputTokens, 6000);
+    assert.equal(report.tokenUsage.total.outputTokens, 600);
+    assert.equal(report.tokenUsage.total.cacheReadTokens, 500);
+    assert.equal(report.tokenUsage.total.cacheCreationTokens, 0);
+
+    // Per-actor: both Uabc and Udef have inputTokens=3000 — order between
+    // them is implementation-defined for ties (stable sort + Map insertion
+    // order), so assert order-agnostically.
+    const top = report.tokenUsage.perActor;
+    assert.equal(top.length, 2);
+    const byActor = Object.fromEntries(top.map((t) => [t.actor, t]));
+    assert.equal(byActor.Uabc.inputTokens, 3000);
+    assert.equal(byActor.Uabc.outputTokens, 300);
+    assert.equal(byActor.Udef.inputTokens, 3000);
+    assert.equal(byActor.Udef.outputTokens, 300);
+
+    assert.equal(report.tokenUsage.perModel.length, 1);
+    assert.equal(report.tokenUsage.perModel[0].model, "claude-sonnet-4-6");
+    assert.equal(report.tokenUsage.perModel[0].inputTokens, 6000);
+    assert.equal(report.tokenUsage.perModel[0].outputTokens, 600);
+  });
 });

--- a/packages/cli/test/gateway-events.test.ts
+++ b/packages/cli/test/gateway-events.test.ts
@@ -397,6 +397,23 @@ describe("gateway events log (#24)", () => {
     assert.ok(types.includes("message.capped"));
   });
 
+  it("round-trips token.usage event (T2 / v0.12.0)", async () => {
+    const { appendGatewayEvent, readGatewayEvents } =
+      await import("../src/gateway/events");
+    appendGatewayEvent({
+      type: "token.usage",
+      actor: "Uabc",
+      provider: "anthropic-api",
+      model: "claude-sonnet-4-6",
+      inputTokens: 12345,
+      outputTokens: 678,
+      cacheReadTokens: 9000,
+      cacheCreationTokens: 0,
+    });
+    const types = readGatewayEvents({}).map((e) => e.type);
+    assert.ok(types.includes("token.usage"));
+  });
+
   it("legacy events.log with mixed valid + malformed lines: malformed are skipped, valid still parse", async () => {
     const { readGatewayEvents } = await import("../src/gateway/events");
     const gatewayDir = path.join(tmpHome, ".pmk", "gateway");

--- a/packages/cli/test/llm-anthropic-api.test.ts
+++ b/packages/cli/test/llm-anthropic-api.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const ORIG_HOME = process.env.HOME;
+
+describe("AnthropicApiKeyProvider token.usage emission (T5 / v0.12.0)", () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-anthropic-test-"));
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    else delete process.env.HOME;
+  });
+
+  it("emits token.usage event after stream completes (when actor is provided)", async () => {
+    const { AnthropicApiKeyProvider } = await import(
+      "../src/llm/anthropic-api"
+    );
+    const { readGatewayEvents } = await import("../src/gateway/events");
+
+    const provider = new AnthropicApiKeyProvider({
+      provider: "anthropic-api",
+      model: "claude-sonnet-4-6",
+      maxTokens: 4096,
+      apiKey: "sk-ant-test",
+    } as never);
+
+    const fakeStream = {
+      [Symbol.asyncIterator]: async function* () {
+        yield {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "hello" },
+        };
+      },
+      finalMessage: async () => ({
+        usage: {
+          input_tokens: 1234,
+          output_tokens: 56,
+          cache_read_input_tokens: 100,
+          cache_creation_input_tokens: 0,
+        },
+      }),
+    };
+    (provider as unknown as { client: unknown }).client = {
+      messages: { stream: async () => fakeStream },
+    };
+
+    const result = await provider.chat(
+      "sys",
+      [{ role: "user", content: "hi" }],
+      { actor: "Uabc" },
+    );
+    assert.equal(result, "hello");
+
+    const events = readGatewayEvents({});
+    const usage = events.find((e) => e.type === "token.usage");
+    assert.ok(usage, "expected token.usage event");
+    if (usage && usage.type === "token.usage") {
+      assert.equal(usage.actor, "Uabc");
+      assert.equal(usage.provider, "anthropic-api");
+      assert.equal(usage.model, "claude-sonnet-4-6");
+      assert.equal(usage.inputTokens, 1234);
+      assert.equal(usage.outputTokens, 56);
+      assert.equal(usage.cacheReadTokens, 100);
+      assert.equal(usage.cacheCreationTokens, 0);
+    }
+  });
+
+  it("does NOT emit token.usage when actor is undefined", async () => {
+    const { AnthropicApiKeyProvider } = await import(
+      "../src/llm/anthropic-api"
+    );
+    const { readGatewayEvents } = await import("../src/gateway/events");
+
+    const provider = new AnthropicApiKeyProvider({
+      provider: "anthropic-api",
+      model: "claude-sonnet-4-6",
+      maxTokens: 4096,
+      apiKey: "sk-ant-test",
+    } as never);
+
+    const fakeStream = {
+      [Symbol.asyncIterator]: async function* () {
+        yield {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "ok" },
+        };
+      },
+      finalMessage: async () => ({
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }),
+    };
+    (provider as unknown as { client: unknown }).client = {
+      messages: { stream: async () => fakeStream },
+    };
+
+    await provider.chat("sys", [{ role: "user", content: "hi" }]);
+
+    const events = readGatewayEvents({});
+    assert.equal(
+      events.filter((e) => e.type === "token.usage").length,
+      0,
+      "no token.usage event when actor missing",
+    );
+  });
+});

--- a/packages/cli/test/messaging.test.ts
+++ b/packages/cli/test/messaging.test.ts
@@ -32,15 +32,15 @@ describe("capMessageContent", () => {
   });
 });
 
-describe("messaging cap defaults", () => {
-  it("MAX_SESSION_TOKENS default is 25_000 (v0.11.1)", () => {
-    assert.equal(MAX_SESSION_TOKENS, 25_000);
+describe("messaging cap defaults (v0.12.0)", () => {
+  it("MAX_SESSION_TOKENS default is 60_000", () => {
+    assert.equal(MAX_SESSION_TOKENS, 60_000);
   });
-  it("SEED_CAP default is 12_000", () => {
-    assert.equal(SEED_CAP, 12_000);
+  it("SEED_CAP default is 30_000", () => {
+    assert.equal(SEED_CAP, 30_000);
   });
-  it("MRA_RESULT_CAP default is 16_000", () => {
-    assert.equal(MRA_RESULT_CAP, 16_000);
+  it("MRA_RESULT_CAP default is 40_000", () => {
+    assert.equal(MRA_RESULT_CAP, 40_000);
   });
 });
 

--- a/packages/cli/test/resolver.test.ts
+++ b/packages/cli/test/resolver.test.ts
@@ -77,3 +77,29 @@ describe("resolveProvider (explicit provider)", () => {
     );
   });
 });
+
+describe("resolveProvider autoResolve order (v0.12.0)", () => {
+  beforeEach(() => {
+    delete process.env.PMK_PROVIDER;
+    process.env.PMK_SKIP_CLAUDE_PROBE = "1"; // disable filesystem probe in tests
+  });
+  afterEach(() => {
+    if (ORIG_PROVIDER !== undefined) process.env.PMK_PROVIDER = ORIG_PROVIDER;
+    else delete process.env.PMK_PROVIDER;
+    delete process.env.PMK_SKIP_CLAUDE_PROBE;
+  });
+
+  it("apiKey present → anthropic-api (preferred over claude-agent)", () => {
+    const provider = resolveProvider(
+      baseConfig({ provider: "auto", apiKey: "sk-ant-xxx" }),
+    );
+    assert.equal(provider.name, "anthropic-api");
+  });
+
+  it("apiKey absent + no claude binary → throws NoProviderAvailableError", () => {
+    assert.throws(
+      () => resolveProvider(baseConfig({ provider: "auto", apiKey: undefined })),
+      /no usable LLM provider/,
+    );
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmk/core",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Core scripts — traceability matrix, Confluence sync, shared utilities",
   "license": "MIT",
   "main": "src/index.js",

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmk/rag",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "RAG engine for pmk — pure-JS TF-IDF retrieval over pm-workspace-kit docs (no native deps)",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmk/shared",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Shared types and utilities for pm-workspace-kit packages",
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Switches the gateway default LLM provider from `claude-agent-sdk` to the direct Anthropic SDK (`AnthropicApiKeyProvider`). Eliminates SDK-inherited host context (`~/.claude/` skills/hooks/MCP descriptions) as a budget unknown — closes the architectural follow-up from v0.11.1's forward-link.
- Soft flip: users with `ANTHROPIC_API_KEY` set auto-switch on upgrade; users without it stay on `claude-agent` with no behavioural change. `PMK_PROVIDER=claude-agent` still pins the legacy path explicitly.
- Restores cap headroom now that SDK overhead is gone: `PMK_MAX_SESSION_TOKENS` 25_000→60_000, `PMK_SEED_CAP` 12_000→30_000, `PMK_MRA_RESULT_CAP` 16_000→40_000.
- Adds per-call `token.usage` audit event (anthropic-api only, when an `actor` is provided) and a new `Token usage` section in `pmk gateway audit`.

Spec: `apps/docs/docs/plans/2026-05-08-gateway-anthropic-api-default.md`. Plan: `apps/docs/docs/plans/2026-05-08-gateway-anthropic-api-default-implementation.md` (12 TDD tasks).

## Changes

### Source

- `packages/cli/src/llm/provider.ts` — `ChatOptions` gains optional `actor?: string` for usage attribution. `NoProviderAvailableError` message reordered to lead with the API-key path.
- `packages/cli/src/llm/resolver.ts` — `autoResolve()` body swapped: apiKey-present → `AnthropicApiKeyProvider`; else fall through to `ClaudeAgentSdkProvider`. JSDoc updated to v0.12.0+ order.
- `packages/cli/src/llm/anthropic-api.ts` — emits `token.usage` event after `stream.finalMessage()` when `opts.actor` is set; failures swallowed (best-effort). Cache fields conditionally spread.
- `packages/cli/src/llm/claude-agent.ts` — JSDoc note that this provider is now the v0.12.0 fallback path; no behavioural change.
- `packages/cli/src/gateway/events.ts` — `TokenUsageEvent` interface added to the `GatewayEvent` union and `VALID_TYPES` set.
- `packages/cli/src/gateway/messaging.ts` — three cap defaults bumped with v0.12.0-rationale JSDoc rewrites.
- `packages/cli/src/gateway/config.ts` — optional `apiKey?: string` added to `GatewayConfig`.
- `packages/cli/src/commands/gateway.ts` — `initCmd` prompts for `ANTHROPIC_API_KEY` after Slack tokens; conditionally writes to `gateway.json` (mode 0600 preserved).
- `packages/cli/src/gateway/slack/index.ts` — at LLM-resolution site, merges `gateway.json` apiKey into the CLI config when env / cli-config doesn't supply one (env > cli-config > gateway.json).
- `packages/cli/src/gateway/slack/context-retry.ts` — forwards `actor` through to `llm.chat()` opts.
- `packages/cli/src/gateway/audit.ts` — `AuditReport.tokenUsage` aggregation (totals + per-actor + per-model).
- `packages/cli/src/gateway/audit-format.ts` — renders `Token usage` section after `Context safety`; new `formatTokens` helper for compact `X.Yk` rendering.

### Tests

`@pmk/cli` 304 → **312** (+8):

- `resolver.test.ts` — autoResolve order: apiKey-preferred + fail path.
- `llm-anthropic-api.test.ts` (new) — token-usage emission with mocked stream + finalMessage; no-emission when actor undefined.
- `gateway-events.test.ts` — `token.usage` round-trip.
- `messaging.test.ts` — cap-default assertions flipped to v0.12.0 values.
- `gateway-audit.test.ts` — `tokenUsage` aggregation across multiple actors / models.
- `gateway-audit-format.test.ts` — `Token usage` section rendering for non-zero + zero cases; `emptyReport` helper updated for the new required field.

### Docs

- `apps/docs/docs/changelog.md` — v0.12.0 entry.
- `apps/docs/docs/gateway/v0.12-migration.md` (new) — operator-facing summary mirroring v0.11 migration doc shape.
- `apps/docs/docs/plans/2026-05-08-gateway-anthropic-api-default.md` — design spec.
- `apps/docs/docs/plans/2026-05-08-gateway-anthropic-api-default-implementation.md` — TDD plan.

## Test plan

- [x] `npm --workspace packages/cli test` → 312/312 pass
- [x] `npm --workspace packages/cli run typecheck:test` → clean
- [x] `npm run cli:build` → clean (T12 prebuild)
- [ ] Live verify: set `ANTHROPIC_API_KEY` and restart gateway. Send a DM. Tail `~/.pmk/gateway/events-2026-05.log | grep token.usage` — expect ≥1 event per turn with non-zero `inputTokens`.
- [ ] Live verify audit: `pmk gateway audit --days 1` shows `Token usage` section populated.
- [ ] Live verify fallback: unset `ANTHROPIC_API_KEY`, restart, confirm gateway runs on `claude-agent` without errors and emits NO `token.usage` events from this branch.
- [ ] Tag `v0.12.0` after merge.

## Forward-looking

- v0.11.2 candidate (parallel track): SlackGateway integration harness so the seed-cap / mra-result-cap / prune-ordering / retry-prefix wiring sites get direct integration coverage.
- v0.13+ candidates: deprecate `claude-agent` based on `Token usage` audit data; \$-cost calculation gated on a stable price-table source.