### PR TITLE
feat(gateway): multi-user channel concurrency + append-only message log

### DIFF
--- a/packages/cli/src/gateway/channel-log.ts
+++ b/packages/cli/src/gateway/channel-log.ts
@@ -1,0 +1,207 @@
+/**
+ * Append-only channel message log (v0.13).
+ *
+ * Replaces the v0.7 `chat-session.json` read-modify-write model in
+ * the channel free-chat path. The old shared `ChannelChatSession`
+ * raced when multiple users @-mentioned the bot in parallel (which
+ * the v0.13 per-user-per-channel inFlight lock now allows) — two
+ * users would load the same in-memory snapshot, each push their own
+ * turn, and the second `saveChannelChatSession` overwrote the
+ * first's turn on disk.
+ *
+ * This module switches to a per-line JSONL log appended with
+ * `fs.appendFileSync` (one POSIX syscall ≡ atomic write). Multiple
+ * concurrent writers all land; ordering by timestamp + write-order.
+ * No read-modify-write means no last-write-wins data loss.
+ *
+ * Layout (mirrors the channel session-store layout):
+ *
+ *   ~/.pmk/gateway/slack/channels/<channelId>/messages.jsonl
+ *   ~/.pmk/gateway/slack/channels/<channelId>/threads/<ts>/messages.jsonl
+ *
+ * One line per turn-message. Reading is a streaming scan (skip
+ * malformed lines); writing is append-only with `mkdir -p` so each
+ * channel/thread provisions on first use.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import type { ChatMessage } from "@pmk/shared";
+
+const PLATFORM_SLACK = "slack";
+
+function gatewaySlackChannelsDir(): string {
+  return path.join(os.homedir(), ".pmk", "gateway", PLATFORM_SLACK, "channels");
+}
+
+function channelDir(channelId: string, threadTs?: string): string {
+  const base = path.join(gatewaySlackChannelsDir(), channelId);
+  return threadTs ? path.join(base, "threads", threadTs) : base;
+}
+
+function channelLogPath(channelId: string, threadTs?: string): string {
+  return path.join(channelDir(channelId, threadTs), "messages.jsonl");
+}
+
+/** Legacy `chat-session.json` location — same dir as `messages.jsonl`. */
+function legacyChatSessionPath(channelId: string, threadTs?: string): string {
+  return path.join(channelDir(channelId, threadTs), "chat-session.json");
+}
+
+/**
+ * One entry in the channel log. User entries carry `userId` so the
+ * bot can attribute turns in multi-user channels; assistant entries
+ * never need attribution (the bot is implicit).
+ *
+ * `content` is the user-visible text the legacy session stored —
+ * after `stripCaseUpdateBlock` / `stripMraAskBlock` / `stripEscalateBlock`
+ * for assistant entries. We deliberately do NOT persist the full
+ * directive-bearing LLM output (none of the legacy session.json
+ * persisted it either; follow-up turns work on the stripped text).
+ */
+export interface ChannelLogEntry {
+  /** ISO-8601 UTC timestamp. */
+  ts: string;
+  role: "user" | "assistant";
+  /** Present on user entries; absent on assistant + seed-context entries. */
+  userId?: string;
+  content: string;
+}
+
+/**
+ * Append one or more entries atomically. Each `appendFileSync` is a
+ * single POSIX syscall so two parallel callers can safely append at
+ * the same time without read-modify-write races.
+ */
+export function appendChannelTurns(
+  channelId: string,
+  threadTs: string | undefined,
+  entries: ChannelLogEntry[],
+): void {
+  if (entries.length === 0) return;
+  const dir = channelDir(channelId, threadTs);
+  fs.mkdirSync(dir, { recursive: true });
+  const lines = entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+  fs.appendFileSync(channelLogPath(channelId, threadTs), lines, {
+    encoding: "utf8",
+  });
+}
+
+export interface LoadChannelTurnsOptions {
+  /** Return at most this many most-recent entries (after migration). */
+  limit?: number;
+  /** Drop entries older than `Date.now() - sinceMs`. */
+  sinceMs?: number;
+}
+
+/**
+ * Read all entries for a channel (or channel-thread). Triggers a
+ * one-time migration from the legacy `chat-session.json` on first
+ * call: messages get converted to JSONL entries, the old file is
+ * removed, and the converted entries flow through normally on this
+ * read. Subsequent reads are migration-free.
+ *
+ * Malformed lines are skipped silently — a single bad write
+ * mustn't poison the audit / replay.
+ */
+export function loadChannelTurns(
+  channelId: string,
+  threadTs?: string,
+  opts: LoadChannelTurnsOptions = {},
+): ChannelLogEntry[] {
+  migrateLegacyChatSessionIfPresent(channelId, threadTs);
+  const file = channelLogPath(channelId, threadTs);
+  if (!fs.existsSync(file)) return [];
+  const raw = fs.readFileSync(file, "utf8");
+  const entries: ChannelLogEntry[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line) as ChannelLogEntry;
+      if (
+        parsed &&
+        (parsed.role === "user" || parsed.role === "assistant") &&
+        typeof parsed.content === "string" &&
+        typeof parsed.ts === "string"
+      ) {
+        entries.push(parsed);
+      }
+    } catch {
+      /* skip malformed lines */
+    }
+  }
+  let result = entries;
+  if (opts.sinceMs !== undefined) {
+    const cutoff = Date.now() - opts.sinceMs;
+    result = result.filter((e) => {
+      const t = Date.parse(e.ts);
+      return Number.isFinite(t) && t >= cutoff;
+    });
+  }
+  if (opts.limit !== undefined && opts.limit >= 0 && result.length > opts.limit) {
+    result = result.slice(result.length - opts.limit);
+  }
+  return result;
+}
+
+/**
+ * Convert log entries to the `ChatMessage[]` shape the LLM call
+ * expects. Drops the `userId` and `ts` metadata — the legacy session
+ * never had them, so behaviour is unchanged for the model.
+ *
+ * (A future iteration could prepend `[<userId>]` attribution to user
+ * entries so the LLM can distinguish speakers in multi-user channels;
+ * holding that change for a follow-up because it shifts prompt
+ * semantics.)
+ */
+export function entriesToMessages(entries: ChannelLogEntry[]): ChatMessage[] {
+  return entries.map((e) => ({ role: e.role, content: e.content }));
+}
+
+/**
+ * One-time conversion of an existing `chat-session.json` to JSONL.
+ * Idempotent: a no-op when the JSONL already exists or the legacy
+ * file is absent. Uses each message's index as an epoch-offset
+ * timestamp so chronological ordering is preserved relative to new
+ * entries that get appended afterwards.
+ */
+function migrateLegacyChatSessionIfPresent(
+  channelId: string,
+  threadTs?: string,
+): void {
+  const newFile = channelLogPath(channelId, threadTs);
+  if (fs.existsSync(newFile)) return;
+  const oldFile = legacyChatSessionPath(channelId, threadTs);
+  if (!fs.existsSync(oldFile)) return;
+  try {
+    const raw = fs.readFileSync(oldFile, "utf8");
+    const parsed = JSON.parse(raw) as {
+      messages?: Array<{ role: string; content: string }>;
+      lastActiveAt?: number;
+    };
+    if (!Array.isArray(parsed.messages)) return;
+    // Synthesise timestamps. Without per-message timestamps in the
+    // legacy file, we space them out by 1s each so chronological
+    // ordering relative to newly-appended entries stays sensible.
+    const baseMs = typeof parsed.lastActiveAt === "number"
+      ? parsed.lastActiveAt - parsed.messages.length * 1000
+      : 0;
+    const entries: ChannelLogEntry[] = parsed.messages
+      .filter(
+        (m): m is { role: "user" | "assistant"; content: string } =>
+          (m.role === "user" || m.role === "assistant") &&
+          typeof m.content === "string",
+      )
+      .map((m, i) => ({
+        ts: new Date(baseMs + i * 1000).toISOString(),
+        role: m.role,
+        content: m.content,
+      }));
+    if (entries.length > 0) {
+      appendChannelTurns(channelId, threadTs, entries);
+    }
+    fs.unlinkSync(oldFile);
+  } catch {
+    /* best-effort; leave the legacy file in place if conversion fails */
+  }
+}

--- a/packages/cli/src/gateway/session-store.ts
+++ b/packages/cli/src/gateway/session-store.ts
@@ -66,22 +66,13 @@ export interface ChannelMeta {
   lastActiveAt: number;
 }
 
-/**
- * Channel-shared free-chat session. Used when `@pmk` is mentioned in a
- * channel that has no active case — the bot drops into the same
- * PKB-grounded chat mode as DMs, but the message history is shared
- * across everyone in the channel (mirrors how channel cases are
- * shared, not per-user).
- *
- * File: ~/.pmk/gateway/slack/channels/<channelId>/chat-session.json
- */
-export interface ChannelChatSession {
-  channelId: string;
-  messages: ChatMessage[];
-  lastActiveAt: number;
-  approxTokens: number;
-  turns: number;
-}
+/* v0.13: the `ChannelChatSession` type + `loadChannelChatSession` /
+ * `saveChannelChatSession` helpers that previously lived here are
+ * gone. They modelled the channel free-chat history as a single
+ * read-modify-write blob (`chat-session.json`) which raced when
+ * parallel @-mentions in the same channel both loaded → mutated →
+ * saved. Free-chat now uses the append-only `gateway/channel-log.ts`
+ * module; on-disk files migrate automatically on first load. */
 
 export function loadUserSession(
   slackUserId: string,
@@ -106,40 +97,6 @@ export function saveUserSession(s: UserSession, threadTs?: string): void {
   s.lastActiveAt = Date.now();
   fs.writeFileSync(
     path.join(dir, "session.json"),
-    JSON.stringify(s, null, 2),
-    "utf8",
-  );
-}
-
-export function loadChannelChatSession(
-  slackChannelId: string,
-  threadTs?: string,
-): ChannelChatSession {
-  const file = path.join(
-    channelDir(slackChannelId, threadTs),
-    "chat-session.json",
-  );
-  if (!fs.existsSync(file)) {
-    return {
-      channelId: slackChannelId,
-      messages: [],
-      lastActiveAt: 0,
-      approxTokens: 0,
-      turns: 0,
-    };
-  }
-  return JSON.parse(fs.readFileSync(file, "utf8")) as ChannelChatSession;
-}
-
-export function saveChannelChatSession(
-  s: ChannelChatSession,
-  threadTs?: string,
-): void {
-  const dir = channelDir(s.channelId, threadTs);
-  fs.mkdirSync(dir, { recursive: true });
-  s.lastActiveAt = Date.now();
-  fs.writeFileSync(
-    path.join(dir, "chat-session.json"),
     JSON.stringify(s, null, 2),
     "utf8",
   );

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -423,16 +423,31 @@ export class SlackAdapter {
 
     if (this.config.blocklist.includes(userId)) return;
 
-    if (this.inFlight.has(channelId)) {
+    // v0.13: lock per-user-per-channel instead of per-channel. The old
+    // per-channel key serialised every @-mention in the channel,
+    // blocking multi-user Q&A in open channels (different users had
+    // to wait for each other's LLM round to finish). Per-user-per-
+    // channel still serialises a single user's rapid double-taps (the
+    // original intent of the lock) but lets distinct users proceed
+    // in parallel.
+    //
+    // Trade-off: when the channel has an active case file
+    // (`/pmk open <name>`), parallel @-mentions can race on
+    // `saveCase` (last write wins). In practice case-channels are
+    // low-traffic single-thread workflows, so the race is rare;
+    // the v0.13 backlog tracks a load-modify-write retry on case
+    // files if it bites.
+    const inFlightKey = `${channelId}:${userId}`;
+    if (this.inFlight.has(inFlightKey)) {
       await this.web.chat.postMessage({
         channel: channelId,
         thread_ts: replyThreadTs,
-        text: ":hourglass: 已有訊息在處理中，請稍候。",
+        text: ":hourglass: 你上一則訊息還在處理，請稍候。",
       });
       return;
     }
 
-    this.inFlight.add(channelId);
+    this.inFlight.add(inFlightKey);
     try {
       // Absorb-first: if this thread is pending escalation and the
       // mentioner is one of the tagged IT contacts, treat the message
@@ -464,7 +479,7 @@ export class SlackAdapter {
         })
         .catch(() => {});
     } finally {
-      this.inFlight.delete(channelId);
+      this.inFlight.delete(inFlightKey);
     }
   }
 

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -17,16 +17,20 @@ import {
 import {
   channelCasesDir,
   clearThreadEscalation,
-  loadChannelChatSession,
   loadChannelMeta,
   loadThreadEscalation,
   loadUserSession,
-  saveChannelChatSession,
   saveChannelMeta,
   saveThreadEscalation,
   saveUserSession,
   userCasesDir,
 } from "../session-store";
+import {
+  appendChannelTurns,
+  entriesToMessages,
+  loadChannelTurns,
+  type ChannelLogEntry,
+} from "../channel-log";
 import { EnvelopeDedup } from "./envelope-dedup";
 import { PresenceBroadcaster } from "./presence";
 
@@ -1304,14 +1308,53 @@ export class SlackAdapter {
       // per-thread session (top-level mentions share one "main" session,
       // each Slack thread gets an isolated session). Users who want
       // bug-tracking semantics explicitly run `/pmk open <name>`.
-      const session = loadChannelChatSession(channelId, sessionThreadTs);
+      //
+      // v0.13: switched from `ChannelChatSession` (read-modify-write
+      // `chat-session.json`) to append-only `channel-log.ts`. The legacy
+      // model raced when parallel @-mentions in the same channel both
+      // load → push → save (last write wins). The append-only log uses
+      // atomic `fs.appendFileSync` so two writers both land; the
+      // saveSession closure here only appends entries new since this
+      // turn's load, filtered by `(role, content)` so prune-trimmed
+      // history (local to this request's LLM context) is NOT
+      // re-appended.
+      const loadedEntries = loadChannelTurns(channelId, sessionThreadTs);
+      const initialMessages = entriesToMessages(loadedEntries);
+      const initialKeys = new Set(
+        initialMessages.map((m) => `${m.role} ${m.content}`),
+      );
+      const session: FreeChatSession = {
+        messages: [...initialMessages],
+        turns: loadedEntries.filter(
+          (e) => e.role === "user" && e.userId !== undefined,
+        ).length,
+        approxTokens: approxTokensFor(initialMessages),
+      };
       await this.runFreeChatTurn({
         channelId,
         threadTs,
         text,
         userId,
         session,
-        saveSession: (s) => saveChannelChatSession(s, sessionThreadTs),
+        saveSession: (s) => {
+          const newMessages = s.messages.filter(
+            (m) => !initialKeys.has(`${m.role} ${m.content}`),
+          );
+          if (newMessages.length === 0) return;
+          const now = new Date().toISOString();
+          const entries: ChannelLogEntry[] = newMessages.map((m) => ({
+            ts: now,
+            role: m.role,
+            content: m.content,
+            // Only the message whose content matches the turn's prompt
+            // is attributed to the calling user; seed and mra-result
+            // user-role messages stay unattributed.
+            ...(m.role === "user" && m.content === text
+              ? { userId }
+              : {}),
+          }));
+          appendChannelTurns(channelId, sessionThreadTs, entries);
+        },
       });
       // Touch channel meta so listRecentChannels picks it up for the
       // offline / online broadcast list.

--- a/packages/cli/test/channel-log.test.ts
+++ b/packages/cli/test/channel-log.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Unit coverage for the v0.13 append-only channel message log.
+ * Three groups: (1) basic round-trip + filter options,
+ * (2) race-freedom under simulated concurrent appends,
+ * (3) one-time migration from the legacy `chat-session.json`.
+ */
+import { describe, it, beforeEach, afterEach } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  appendChannelTurns,
+  entriesToMessages,
+  loadChannelTurns,
+  type ChannelLogEntry,
+} from "../src/gateway/channel-log";
+
+const ORIG_HOME = process.env.HOME;
+
+function isoOffset(seconds: number): string {
+  return new Date(Date.UTC(2026, 4, 19, 10, 0, seconds)).toISOString();
+}
+
+describe("channel-log: round-trip + filters", () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-chlog-rt-"));
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    else delete process.env.HOME;
+  });
+
+  it("append → load returns entries in write order", () => {
+    appendChannelTurns("C-A", undefined, [
+      { ts: isoOffset(0), role: "user", userId: "U-1", content: "hello" },
+      { ts: isoOffset(1), role: "assistant", content: "hi" },
+    ]);
+    appendChannelTurns("C-A", undefined, [
+      { ts: isoOffset(2), role: "user", userId: "U-2", content: "again" },
+      { ts: isoOffset(3), role: "assistant", content: "ack" },
+    ]);
+
+    const all = loadChannelTurns("C-A");
+    assert.equal(all.length, 4);
+    assert.deepEqual(
+      all.map((e) => e.content),
+      ["hello", "hi", "again", "ack"],
+    );
+    assert.equal(all[0].userId, "U-1");
+    assert.equal(all[2].userId, "U-2");
+    assert.equal(all[1].userId, undefined);
+  });
+
+  it("threadTs scopes the log to a sub-directory", () => {
+    appendChannelTurns("C-A", "1700.0001", [
+      { ts: isoOffset(0), role: "user", userId: "U-1", content: "thread Q" },
+    ]);
+    appendChannelTurns("C-A", undefined, [
+      { ts: isoOffset(0), role: "user", userId: "U-1", content: "top-level Q" },
+    ]);
+
+    const top = loadChannelTurns("C-A");
+    const inThread = loadChannelTurns("C-A", "1700.0001");
+    assert.equal(top.length, 1);
+    assert.equal(top[0].content, "top-level Q");
+    assert.equal(inThread.length, 1);
+    assert.equal(inThread[0].content, "thread Q");
+  });
+
+  it("limit returns the most-recent N entries", () => {
+    const entries: ChannelLogEntry[] = Array.from({ length: 10 }, (_, i) => ({
+      ts: isoOffset(i),
+      role: i % 2 === 0 ? "user" : "assistant",
+      content: `m${i}`,
+      ...(i % 2 === 0 ? { userId: `U-${i}` } : {}),
+    }));
+    appendChannelTurns("C-A", undefined, entries);
+    const last3 = loadChannelTurns("C-A", undefined, { limit: 3 });
+    assert.deepEqual(
+      last3.map((e) => e.content),
+      ["m7", "m8", "m9"],
+    );
+  });
+
+  it("malformed lines are silently skipped (single bad write must not poison the audit)", () => {
+    appendChannelTurns("C-A", undefined, [
+      { ts: isoOffset(0), role: "user", content: "good" },
+    ]);
+    const file = path.join(
+      tmpHome,
+      ".pmk",
+      "gateway",
+      "slack",
+      "channels",
+      "C-A",
+      "messages.jsonl",
+    );
+    fs.appendFileSync(file, "not-json-at-all\n", "utf8");
+    fs.appendFileSync(
+      file,
+      JSON.stringify({ ts: isoOffset(2), role: "user", content: "also good" }) +
+        "\n",
+      "utf8",
+    );
+
+    const all = loadChannelTurns("C-A");
+    assert.equal(all.length, 2, "two valid entries; the malformed line dropped");
+    assert.equal(all[0].content, "good");
+    assert.equal(all[1].content, "also good");
+  });
+
+  it("entriesToMessages drops metadata, keeps role + content", () => {
+    const entries: ChannelLogEntry[] = [
+      { ts: isoOffset(0), role: "user", userId: "U-1", content: "q1" },
+      { ts: isoOffset(1), role: "assistant", content: "a1" },
+    ];
+    const msgs = entriesToMessages(entries);
+    assert.deepEqual(msgs, [
+      { role: "user", content: "q1" },
+      { role: "assistant", content: "a1" },
+    ]);
+  });
+});
+
+describe("channel-log: race-free under concurrent appends", () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-chlog-race-"));
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    else delete process.env.HOME;
+  });
+
+  it("20 parallel appends from 4 simulated users all persist (no last-write-wins drop)", async () => {
+    // The pre-v0.13 ChannelChatSession model would have lost
+    // entries here: each "user" loaded the same snapshot, pushed,
+    // and saved → last write wins. With appendFileSync each call
+    // is atomic so all 20 entries must land in the JSONL.
+    const users = ["U-A", "U-B", "U-C", "U-D"];
+    const tasks = users.flatMap((u, ui) =>
+      Array.from({ length: 5 }, (_, i) => async () => {
+        appendChannelTurns("C-RACE", undefined, [
+          {
+            ts: isoOffset(ui * 5 + i),
+            role: "user",
+            userId: u,
+            content: `${u} msg ${i}`,
+          },
+          {
+            ts: isoOffset(ui * 5 + i),
+            role: "assistant",
+            content: `${u} reply ${i}`,
+          },
+        ]);
+      }),
+    );
+    await Promise.all(tasks.map((t) => t()));
+
+    const all = loadChannelTurns("C-RACE");
+    assert.equal(
+      all.length,
+      40,
+      "every parallel write must land (20 turns × 2 entries each)",
+    );
+    // Each user has exactly 5 user-role entries on disk.
+    for (const u of users) {
+      const userEntries = all.filter(
+        (e) => e.role === "user" && e.userId === u,
+      );
+      assert.equal(userEntries.length, 5, `${u} kept all 5 entries`);
+    }
+  });
+});
+
+describe("channel-log: migration from legacy chat-session.json", () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-chlog-mig-"));
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    else delete process.env.HOME;
+  });
+
+  function writeLegacy(
+    channelId: string,
+    threadTs: string | undefined,
+    messages: Array<{ role: string; content: string }>,
+    lastActiveAt: number,
+  ): string {
+    const base = path.join(
+      tmpHome,
+      ".pmk",
+      "gateway",
+      "slack",
+      "channels",
+      channelId,
+    );
+    const dir = threadTs ? path.join(base, "threads", threadTs) : base;
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, "chat-session.json");
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        channelId,
+        messages,
+        lastActiveAt,
+        approxTokens: 0,
+        turns: messages.length / 2,
+      }),
+      "utf8",
+    );
+    return file;
+  }
+
+  it("first load converts legacy chat-session.json to JSONL, then deletes the old file", () => {
+    const oldFile = writeLegacy(
+      "C-MIG",
+      undefined,
+      [
+        { role: "user", content: "legacy q1" },
+        { role: "assistant", content: "legacy a1" },
+        { role: "user", content: "legacy q2" },
+        { role: "assistant", content: "legacy a2" },
+      ],
+      Date.parse("2026-05-10T12:00:00Z"),
+    );
+
+    const entries = loadChannelTurns("C-MIG");
+    assert.equal(entries.length, 4, "all legacy messages migrated");
+    assert.equal(entries[0].content, "legacy q1");
+    assert.equal(entries[3].content, "legacy a2");
+
+    assert.equal(
+      fs.existsSync(oldFile),
+      false,
+      "legacy chat-session.json removed after migration",
+    );
+
+    // Second load should be migration-free (no chat-session.json exists)
+    // and still return the same entries.
+    const second = loadChannelTurns("C-MIG");
+    assert.deepEqual(
+      second.map((e) => e.content),
+      entries.map((e) => e.content),
+    );
+  });
+
+  it("migration is idempotent — running load when only JSONL exists is a no-op", () => {
+    appendChannelTurns("C-NM", undefined, [
+      { ts: isoOffset(0), role: "user", content: "native" },
+    ]);
+
+    // No legacy file present; load should not blow up or duplicate.
+    const entries = loadChannelTurns("C-NM");
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].content, "native");
+  });
+
+  it("legacy file with malformed messages array → migration leaves entries empty, deletes nothing", () => {
+    const base = path.join(
+      tmpHome,
+      ".pmk",
+      "gateway",
+      "slack",
+      "channels",
+      "C-BAD",
+    );
+    fs.mkdirSync(base, { recursive: true });
+    fs.writeFileSync(
+      path.join(base, "chat-session.json"),
+      "{this-is-not-json",
+      "utf8",
+    );
+
+    const entries = loadChannelTurns("C-BAD");
+    assert.equal(entries.length, 0);
+    // Legacy file remained because conversion failed — operator
+    // can investigate. The JSONL was never created.
+    assert.equal(
+      fs.existsSync(path.join(base, "chat-session.json")),
+      true,
+      "malformed legacy file is preserved for manual inspection",
+    );
+    assert.equal(
+      fs.existsSync(path.join(base, "messages.jsonl")),
+      false,
+      "no JSONL was written from a failed migration",
+    );
+  });
+});

--- a/packages/cli/test/gateway.test.ts
+++ b/packages/cli/test/gateway.test.ts
@@ -20,11 +20,9 @@ import {
   clearThreadEscalation,
   listRecentChannels,
   listRecentUsers,
-  loadChannelChatSession,
   loadChannelMeta,
   loadThreadEscalation,
   loadUserSession,
-  saveChannelChatSession,
   saveChannelMeta,
   saveThreadEscalation,
   saveUserSession,
@@ -418,21 +416,8 @@ describe("session-store", () => {
     assert.deepEqual(recent.sort(), ["U-fresh"]);
   });
 
-  it("channel chat session round-trips and starts empty", () => {
-    const fresh = loadChannelChatSession("C-x");
-    assert.equal(fresh.channelId, "C-x");
-    assert.equal(fresh.messages.length, 0);
-    assert.equal(fresh.turns, 0);
-    fresh.messages.push({ role: "user", content: "hello channel" });
-    fresh.turns = 1;
-    fresh.approxTokens = 7;
-    saveChannelChatSession(fresh);
-    const reload = loadChannelChatSession("C-x");
-    assert.equal(reload.turns, 1);
-    assert.equal(reload.approxTokens, 7);
-    assert.equal(reload.messages[0].content, "hello channel");
-    assert.ok(reload.lastActiveAt > 0);
-  });
+  // Channel-chat-session round-trip + thread isolation moved to
+  // `channel-log.test.ts` (v0.13 append-only model).
 
   it("channel meta save → load + listRecentChannels", () => {
     const m = loadChannelMeta("C-debug");
@@ -872,21 +857,8 @@ describe("thread-aware sessions", () => {
     assert.equal(thread.messages.length, 0);
   });
 
-  it("channel chat thread/main isolation", () => {
-    const main = loadChannelChatSession("C-z");
-    main.messages.push({ role: "user", content: "channel main" });
-    saveChannelChatSession(main);
-
-    const thread = loadChannelChatSession("C-z", "ts-1");
-    assert.equal(thread.messages.length, 0);
-    thread.messages.push({ role: "user", content: "channel thread" });
-    saveChannelChatSession(thread, "ts-1");
-
-    const mainReload = loadChannelChatSession("C-z");
-    assert.equal(mainReload.messages[0].content, "channel main");
-    const threadReload = loadChannelChatSession("C-z", "ts-1");
-    assert.equal(threadReload.messages[0].content, "channel thread");
-  });
+  // Channel-chat-session round-trip + thread isolation moved to
+  // `channel-log.test.ts` (v0.13 append-only model).
 });
 
 describe("audience picker", () => {

--- a/packages/cli/test/slack-adapter.test.ts
+++ b/packages/cli/test/slack-adapter.test.ts
@@ -38,6 +38,7 @@ import {
 } from "../src/gateway/knowledge";
 import { readGatewayEvents } from "../src/gateway/events";
 import { saveUserSession } from "../src/gateway/session-store";
+import { loadChannelTurns } from "../src/gateway/channel-log";
 import { PmkContextTooLongError } from "../src/llm/claude-agent";
 
 describe("SlackAdapter integration: DM happy-path", () => {
@@ -1087,5 +1088,72 @@ describe("SlackAdapter integration: channel inFlight lock (v0.13)", () => {
 
     releaseFirst();
     await p1;
+  });
+
+  it("two users' concurrent turns both land in the channel-log (race-free persistence)", async () => {
+    // End-to-end proof that the v0.13 concurrency change + append-only
+    // log together prevent the data-loss race the legacy
+    // ChannelChatSession had: with the OLD model, Bob's loadChannel-
+    // ChatSession would have snapshotted before Alice's save, then
+    // Bob's saveChannelChatSession would have overwritten Alice's turn
+    // on disk (Slack-side messages still posted, but channel context
+    // would lose Alice's turn for future LLM calls).
+    let releaseFirst: () => void = () => {};
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    h.llm.script(
+      async () => {
+        await firstGate;
+        return "alice answer";
+      },
+      "bob answer",
+    );
+
+    await h.adapter.start();
+
+    const p1 = h.socket.emit(
+      "app_mention",
+      appMentionPayload({
+        user: "U-ALICE",
+        channel: "C-LOG",
+        text: "<@UBOTID> alice prompt",
+        envelope_id: "env-a",
+      }),
+    );
+
+    await new Promise((res) => setImmediate(res));
+
+    await h.socket.emit(
+      "app_mention",
+      appMentionPayload({
+        user: "U-BOB",
+        channel: "C-LOG",
+        text: "<@UBOTID> bob prompt",
+        envelope_id: "env-b",
+      }),
+    );
+
+    releaseFirst();
+    await p1;
+
+    const entries = loadChannelTurns("C-LOG");
+    const userTurns = entries.filter((e) => e.role === "user" && e.userId);
+    const userIds = userTurns.map((e) => e.userId);
+    assert.ok(
+      userIds.includes("U-ALICE"),
+      "Alice's turn persisted in the log",
+    );
+    assert.ok(
+      userIds.includes("U-BOB"),
+      "Bob's turn persisted in the log",
+    );
+    assert.equal(userTurns.length, 2, "exactly two user-attributed turns");
+
+    const assistantContents = entries
+      .filter((e) => e.role === "assistant")
+      .map((e) => e.content);
+    assert.ok(assistantContents.some((c) => c.includes("alice answer")));
+    assert.ok(assistantContents.some((c) => c.includes("bob answer")));
   });
 });

--- a/packages/cli/test/slack-adapter.test.ts
+++ b/packages/cli/test/slack-adapter.test.ts
@@ -956,3 +956,136 @@ describe("SlackAdapter integration: envelope dedup", () => {
     assert.equal(log[0].action, "status");
   });
 });
+
+describe("SlackAdapter integration: channel inFlight lock (v0.13)", () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    h = buildHarness();
+  });
+
+  afterEach(() => {
+    h.cleanup();
+  });
+
+  it("different users in same channel run concurrently (per-user-per-channel key)", async () => {
+    // First scripted reply waits on a gate so we can fire a second
+    // @-mention while the first is still in flight.
+    let releaseFirst: () => void = () => {};
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    h.llm.script(
+      async () => {
+        await firstGate;
+        return "answer for alice";
+      },
+      "answer for bob",
+    );
+
+    await h.adapter.start();
+
+    const p1 = h.socket.emit(
+      "app_mention",
+      appMentionPayload({
+        user: "U-ALICE",
+        channel: "C-QA",
+        text: "<@UBOTID> what does this scope do?",
+        envelope_id: "env-alice",
+      }),
+    );
+
+    // Let p1 reach its llm.chat() await and acquire its
+    // `${channel}:${user}` inFlight key.
+    await new Promise((res) => setImmediate(res));
+
+    // Different user, same channel — should NOT be blocked by the
+    // pre-v0.13 channel-wide lock.
+    await h.socket.emit(
+      "app_mention",
+      appMentionPayload({
+        user: "U-BOB",
+        channel: "C-QA",
+        text: "<@UBOTID> separate question",
+        envelope_id: "env-bob",
+      }),
+    );
+
+    // Bob's path completed (synthesised reply landed); Alice still
+    // awaiting the gate. Both LLM calls happened.
+    assert.equal(h.llm.calls.length, 2);
+
+    // No busy notice was posted (the previous behaviour would have
+    // dropped Bob's request with `:hourglass: 已有訊息在處理中`).
+    const busy = h.web.posted.find((p) =>
+      p.text?.includes("還在處理"),
+    );
+    assert.equal(busy, undefined, "no busy notice for different users");
+
+    // Release Alice so the test can finish cleanly.
+    releaseFirst();
+    await p1;
+
+    // Both placeholders → both final updates.
+    assert.equal(h.web.updated.length, 2);
+  });
+
+  it("same user double-tap in same channel → second blocked with busy notice", async () => {
+    let releaseFirst: () => void = () => {};
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    h.llm.script(async () => {
+      await firstGate;
+      return "first answer";
+    });
+
+    await h.adapter.start();
+
+    const p1 = h.socket.emit(
+      "app_mention",
+      appMentionPayload({
+        user: "U-ALICE",
+        channel: "C-QA",
+        text: "<@UBOTID> q1",
+        envelope_id: "env-alice-1",
+      }),
+    );
+
+    // Let p1 acquire its inFlight key before the second emit checks.
+    await new Promise((res) => setImmediate(res));
+
+    // Same user + same channel + different envelope_id (so dedup
+    // doesn't catch it first) → must be blocked by the per-user lock.
+    await h.socket.emit(
+      "app_mention",
+      appMentionPayload({
+        user: "U-ALICE",
+        channel: "C-QA",
+        text: "<@UBOTID> q2 from same user",
+        envelope_id: "env-alice-2",
+      }),
+    );
+
+    assert.equal(
+      h.llm.calls.length,
+      1,
+      "second tap from the same user must not start a parallel LLM round",
+    );
+
+    const busy = h.web.posted.find((p) =>
+      p.text?.includes("還在處理"),
+    );
+    assert.ok(busy, "busy notice should fire on same-user double-tap");
+    assert.match(
+      busy!.text ?? "",
+      /你上一則訊息還在處理/,
+      "notice should call out THIS user's prior message, not the channel",
+    );
+
+    releaseFirst();
+    await p1;
+  });
+});


### PR DESCRIPTION
## Summary

Two coupled v0.13 changes that together enable race-free multi-user @-mention concurrency in channels:

1. **Per-user-per-channel inFlight lock** — the v0.7 baseline keyed `inFlight` by `channelId` alone, serialising every @-mention in the channel. A single user's 60-90s mra-ask round blocked the whole team. Now keyed by `\`${channelId}:${userId}\`` — different users proceed in parallel, same user's rapid double-tap still gets blocked.

2. **Append-only channel message log** — fixing only the lock would have introduced a data-loss race: the shared `ChannelChatSession` (`chat-session.json`) used read-modify-write, so two parallel writers' load-then-save sequences would clobber each other. Replaced by an append-only JSONL log per channel/thread, written via `fs.appendFileSync` (POSIX-atomic single syscall). All concurrent writers land; no last-write-wins drop.

Found via live-Slack verify on PR #52 (a second user hit `:hourglass: 已有訊息在處理中` during an unrelated round) and follow-up analysis surfacing the latent persistence race.

## What changed

### `packages/cli/src/gateway/channel-log.ts` (new, 179 lines)

Append-only message log module. Layout mirrors the existing channel session storage:

```
~/.pmk/gateway/slack/channels/<channelId>/messages.jsonl
~/.pmk/gateway/slack/channels/<channelId>/threads/<ts>/messages.jsonl
```

Entry shape: `{ts, role, userId?, content}` — `userId` present only on user-turn entries (the actual prompt), so seed and mra-result user-role messages stay unattributed.

API:
- `appendChannelTurns(channelId, threadTs, entries)` — single atomic `fs.appendFileSync`.
- `loadChannelTurns(channelId, threadTs, opts?)` — streaming JSONL scan with `limit` / `sinceMs` filters; triggers one-time migration from legacy `chat-session.json` on first call (convert → write JSONL → delete old).
- `entriesToMessages(entries)` — drops metadata, returns `ChatMessage[]` for LLM input.

### `packages/cli/src/gateway/slack/index.ts`

- `handleAppMention` inFlight key: `channelId` → `\`${channelId}:${userId}\``
- Busy-notice text: `:hourglass: 已有訊息在處理中` → `:hourglass: 你上一則訊息還在處理` (per-user wording)
- `handleChannelMention` free-chat path: `loadChannelChatSession` + `saveChannelChatSession` → `loadChannelTurns` + saveSession closure that diffs new entries by `(role, content)` and appends only the delta (robust to `pruneSessionIfNeeded`'s local trimming).

### `packages/cli/src/gateway/session-store.ts`

- `ChannelChatSession` interface + `loadChannelChatSession` + `saveChannelChatSession` removed (no in-tree consumers after the refactor).

### Trade-off documented inline

The channel **case-file path** (`/pmk open <name>` workflow) still uses `loadCase` + `saveCase` and could in theory race under per-user-per-channel concurrency. Case channels are typically low-traffic single-thread workflows so the race is rare; tracked for tranche 2 (per-case mutex) — not in this PR's scope.

## Tests

**`channel-log.test.ts` (new, 9 tests)**
- Round-trip + filters (5): append→load order; threadTs scopes to sub-dir; `limit` returns N most-recent; malformed lines skipped; `entriesToMessages` strips metadata.
- **Race-free under concurrent appends (1)**: 20 parallel appends from 4 users → all 40 entries land, each user keeps all 5 turns. The pre-v0.13 `ChannelChatSession` would have lost most of these.
- Migration (3): legacy `chat-session.json` converted on first load + old file deleted; idempotent when JSONL exists; malformed legacy file preserved.

**`slack-adapter.test.ts` (3 added on top of existing)**
- Different users in same channel concurrent → both processed (no busy notice).
- Same user double-tap → second blocked with per-user busy notice.
- End-to-end race-free: Alice + Bob parallel @-mentions both persist in the channel log with their own `userId`-tagged entries.

**`gateway.test.ts`**: 2 obsolete tests removed (channel chat session round-trip + thread isolation) — equivalent coverage now in `channel-log.test.ts`.

**Total: 339 → 349 pass** (net +10 after the 2 obsolete tests).

## Test plan

- [x] `npm test` from `packages/cli`: 349 pass / 0 fail
- [x] `npx tsc -p tsconfig.test.json`: clean
- [ ] Live-Slack verify: two users @-mention the bot in the same channel within ~10s; both processed without busy notice; channel log persists both users' turns (`cat ~/.pmk/gateway/slack/channels/<channelId>/messages.jsonl`).
- [ ] Migration: existing channels with `chat-session.json` should auto-migrate on first @-mention after upgrade.