### PR TITLE
refactor(gateway): tranche 3 (free-chat extract) + FIFO inflight queue

### DIFF
--- a/packages/cli/src/gateway/index.ts
+++ b/packages/cli/src/gateway/index.ts
@@ -89,7 +89,12 @@ export async function runGateway(opts: GatewayRunOptions = {}): Promise<void> {
     // accurately.
     markGracefulShutdown();
     try {
-      await adapter.stop();
+      // 25s drain budget — K8s SIGTERM gives ~30s before SIGKILL.
+      // The drain awaits queued / in-flight free-chat turns so users
+      // who saw "已排入隊伍" actually get their replies; if a stuck
+      // LLM round blows the budget we log + proceed so SIGKILL isn't
+      // what reaps the process.
+      await adapter.stop({ drainTimeoutMs: 25_000 });
     } catch (err) {
       log(`adapter stop error: ${(err as Error).message}`);
     }

--- a/packages/cli/src/gateway/slack/free-chat-turn.ts
+++ b/packages/cli/src/gateway/slack/free-chat-turn.ts
@@ -1,0 +1,509 @@
+/**
+ * Free-chat turn runner (v0.13 tranche 3).
+ *
+ * The orchestration layer that ties together everything between
+ * "user said something" and "bot's reply lands in Slack":
+ *
+ *  1. **Seed** — on first turn, inject PKB context from
+ *     `config.defaultIngest` (capped per v0.11.1).
+ *  2. **Retrieval** — pull relevant knowledge atoms and inject as
+ *     ephemeral context (not persisted).
+ *  3. **Prune** — trim session before the LLM call so a bloated
+ *     history doesn't trigger `msg_too_long` (v0.11.1 pre-call
+ *     pattern).
+ *  4. **First-call** — `chatWithContextRetry` wraps the LLM call;
+ *     on `PmkContextTooLongError` it force-prunes and retries.
+ *  5. **mra-ask round** — if the model emits an `mra-ask` directive,
+ *     run the subprocess and call the LLM again to synthesise.
+ *  6. **escalate** — if the (possibly synthesised) response emits
+ *     an `escalate` directive, hand off to `EscalationCoordinator`.
+ *  7. **Reply** — strip directives, persist to session, update the
+ *     placeholder.
+ *
+ * Behaviour is byte-equivalent to the pre-extraction
+ * `SlackAdapter.runFreeChatTurn` + `handleMraAskRound` +
+ * `synthesiseAfterMra` private methods; the v0.13 harness's DM
+ * happy-path, mra-ask escalate-round, and msg_too_long hardening
+ * tests all transitively cover the new module without modification.
+ */
+import type { WebClient } from "@slack/web-api";
+import type { ChatMessage } from "@pmk/shared";
+import { pickGatewayPrompt } from "@pmk/shared";
+import type { GatewayConfig } from "../config";
+import { pickAudience } from "../config";
+import type { LlmProvider } from "../../llm";
+import { PmkContextTooLongError } from "../../llm/claude-agent";
+import type {
+  mraDoctor as mraDoctorImpl,
+  runMraAsk as runMraAskImpl,
+} from "../../adapters/mra";
+import { appendGatewayEvent } from "../events";
+import { createLastLineThrottle } from "../throttle";
+import { sanitizeProgressLine } from "./progress";
+import { parseMraAsk, stripMraAskBlock } from "../mra-ask";
+import { parseEscalate, stripEscalateBlock } from "../escalate";
+import { stripCaseUpdateBlock } from "../../case";
+import { chatWithContextRetry } from "./context-retry";
+import {
+  approxTokensFor,
+  buildIngestSeed,
+  buildMraFailureMessage,
+  buildMraSuccessMessage,
+  capMessageContent,
+  MRA_RESULT_CAP,
+  pruneSessionIfNeeded,
+  SEED_CAP,
+  truncate,
+} from "../messaging";
+import {
+  searchAtoms,
+  formatAtomsForInjection,
+} from "../knowledge";
+import {
+  markdownToMrkdwn,
+  truncateForSlack,
+} from "../formatters";
+import { EscalationCoordinator } from "./escalation";
+
+/**
+ * Structural shape of any session the free-chat runner can mutate —
+ * `UserSession` (DM) and the channel-log-derived in-memory session
+ * both satisfy this. Defined here (alongside its only consumer)
+ * rather than in `slack/index.ts` to avoid a circular import.
+ */
+export interface FreeChatSession {
+  messages: ChatMessage[];
+  turns: number;
+  approxTokens: number;
+}
+
+export interface FreeChatTurnRunnerOptions {
+  web: WebClient;
+  config: GatewayConfig;
+  onLog: (msg: string) => void;
+  llm: LlmProvider;
+  mraDoctor: typeof mraDoctorImpl;
+  runMraAsk: typeof runMraAskImpl;
+  escalation: EscalationCoordinator;
+}
+
+export class FreeChatTurnRunner {
+  constructor(private readonly opts: FreeChatTurnRunnerOptions) {}
+
+  /**
+   * Run a single free-chat turn end-to-end. Generic over the session
+   * shape so DM and channel-log callers can pass their own
+   * `saveSession` semantics without this layer caring.
+   */
+  async run<S extends FreeChatSession>(args: {
+    channelId: string;
+    threadTs: string;
+    text: string;
+    userId: string;
+    session: S;
+    saveSession: (s: S) => void;
+  }): Promise<void> {
+    const { channelId, threadTs, text, userId, session, saveSession } = args;
+    const { web, config, onLog, llm } = this.opts;
+
+    // First turn: seed the conversation with PKB context from
+    // config.defaultIngest (e.g. mra:--all). Without this the model
+    // truthfully says it has no idea about the user's codebase even
+    // though we configured the ingest spec at gateway init.
+    //
+    // v0.11.1: cap the seed at SEED_CAP chars so an `mra:--all` against a
+    // large multi-repo workspace can't single-handedly exhaust the
+    // model's input window. Emits a `message.capped` event when capping
+    // fires so operators can see how often the cap is biting.
+    if (session.messages.length === 0 && config.defaultIngest) {
+      const seedRaw = buildIngestSeed(
+        config.defaultIngest,
+        config.mraWorkspace,
+      );
+      if (seedRaw) {
+        const cap = capMessageContent(seedRaw, SEED_CAP);
+        if (cap.capped) {
+          appendGatewayEvent({
+            type: "message.capped",
+            actor: userId,
+            kind: "seed",
+            originalChars: cap.originalChars,
+            cappedChars: cap.content.length,
+          });
+        }
+        session.messages.push({ role: "user", content: cap.content });
+        session.messages.push({
+          role: "assistant",
+          content: "了解，已載入 workspace PKB context。請繼續。",
+        });
+      }
+    }
+
+    // Knowledge retrieval: pull any prior IT-supplied atoms that look
+    // relevant to this question and inject them as ephemeral context
+    // (not persisted to session.messages, so old retrieved answers
+    // don't keep stacking up turn after turn).
+    const retrieved = searchAtoms(text, { limit: 3 });
+    const retrievalPrefix: ChatMessage[] = retrieved.length
+      ? [
+          { role: "user", content: formatAtomsForInjection(retrieved) },
+          {
+            role: "assistant",
+            content: "收到，這些補充當作 ground truth。",
+          },
+        ]
+      : [];
+
+    // v0.11.1: prune BEFORE the LLM call so a bloated session can be
+    // trimmed on its way in, not after it has already triggered
+    // msg_too_long. Includes retrievalPrefix and the new user turn in
+    // the budget check so the prune reflects what we'll actually send.
+    const pruneReport = pruneSessionIfNeeded(session, {
+      extra: retrievalPrefix,
+      newUser: text,
+    });
+    if (pruneReport.pruned) {
+      onLog(
+        `pruned session: dropped ${pruneReport.droppedPairs} turn-pair(s); now ${pruneReport.tokensAfter} approx tokens`,
+      );
+    }
+
+    const placeholder = await web.chat.postMessage({
+      channel: channelId,
+      thread_ts: threadTs,
+      text: ":hourglass_flowing_sand: thinking…",
+    });
+
+    const audience = pickAudience(config, userId, channelId);
+    const systemPrompt = pickGatewayPrompt(audience);
+
+    // T11: wrap llm.chat in the context-too-long retry helper. The
+    // buildMessages closure includes the new user turn at the tail so
+    // the LLM sees it on both attempts; we deliberately do NOT push it
+    // onto session.messages until AFTER the retry succeeds, so a failed
+    // turn doesn't pollute persisted history (and so forcePruneToMinimum
+    // operates on a coherent paired-history shape).
+    const retryResult = await chatWithContextRetry({
+      llm,
+      systemPrompt,
+      buildMessages: () => [
+        ...retrievalPrefix,
+        ...session.messages,
+        { role: "user", content: text },
+      ],
+      session,
+      actor: userId,
+      retrievalAtoms: retrieved.length,
+      phase: "first-call",
+    });
+
+    if (!retryResult.ok) {
+      const errText =
+        retryResult.kind === "context"
+          ? ":x: 對話太長，請開新 thread 重新提問"
+          : `:warning: ${(retryResult.error as Error).message}`;
+      await web.chat.update({
+        channel: channelId,
+        ts: String(placeholder.ts),
+        text: errText,
+      });
+      return;
+    }
+
+    // Retry succeeded — NOW commit the new user turn to session history.
+    session.messages.push({ role: "user", content: text });
+    session.turns += 1;
+
+    let full = retryResult.full;
+    let scissorsPrefix = retryResult.scissorsPrefix;
+
+    // If the model asked us to delegate a deep code-search round to
+    // mra, run it and feed the result back for synthesis.
+    const askReq = parseMraAsk(full);
+    if (askReq) {
+      try {
+        const mraResult = await this.handleMraAskRound({
+          channelId,
+          placeholderTs: String(placeholder.ts),
+          session,
+          retrievalPrefix,
+          retrievalAtoms: retrieved.length,
+          firstResponse: full,
+          request: askReq,
+          systemPrompt,
+          actor: userId,
+        });
+        full = mraResult.full;
+        // T12: if the synthesise round ALSO needed force-prune, the
+        // post-prune scissors notice more accurately reflects the final
+        // session state than the first-call notice. Two notices stacked
+        // would just confuse the user, so the latter wins.
+        if (mraResult.scissorsPrefix) {
+          scissorsPrefix = mraResult.scissorsPrefix;
+        }
+      } catch (err) {
+        if (err instanceof PmkContextTooLongError) {
+          await web.chat.update({
+            channel: channelId,
+            ts: String(placeholder.ts),
+            text: ":x: 對話太長，請開新 thread 重新提問",
+          });
+          return;
+        }
+        throw err;
+      }
+    }
+
+    // If the model asked to escalate to a human IT/domain expert, fan
+    // out the @-mention before showing the placeholder reply, and
+    // remember the thread so the next IT reply gets absorbed. The
+    // asker is recorded so the post-absorb synthesis can reply to
+    // them once IT answers.
+    const escReq = parseEscalate(full);
+    if (escReq) {
+      await this.opts.escalation.escalate({
+        channelId,
+        threadTs,
+        askerUserId: userId,
+        request: escReq,
+      });
+    }
+
+    const visible = stripEscalateBlock(
+      stripMraAskBlock(stripCaseUpdateBlock(full)),
+    );
+    session.messages.push({ role: "assistant", content: visible });
+    session.approxTokens = approxTokensFor(session.messages);
+
+    saveSession(session);
+
+    appendGatewayEvent({
+      type: "turn.processed",
+      actor: userId,
+      audience,
+      hadMraAsk: askReq !== undefined,
+      atomsInjected: retrieved.length,
+    });
+
+    await web.chat.update({
+      channel: channelId,
+      ts: String(placeholder.ts),
+      text: scissorsPrefix + truncateForSlack(markdownToMrkdwn(visible)),
+    });
+  }
+
+  /**
+   * Run one round of `mra ask` on behalf of the model, then re-call
+   * the LLM with the result so it can produce a synthesised final
+   * answer. Returns the synthesised response (with any directive
+   * blocks left intact — caller strips them).
+   *
+   * Failure modes (mra missing, timeout, non-zero exit) flow back to
+   * the LLM as an explicit "mra-result-failed" message so the model
+   * can apologise rather than the user seeing a crash.
+   */
+  private async handleMraAskRound(args: {
+    channelId: string;
+    placeholderTs: string;
+    session: FreeChatSession;
+    retrievalPrefix: ChatMessage[];
+    retrievalAtoms: number;
+    firstResponse: string;
+    request: { repo: string; question: string };
+    systemPrompt: string;
+    actor: string;
+  }): Promise<{ full: string; scissorsPrefix: string }> {
+    const {
+      channelId,
+      placeholderTs,
+      session,
+      retrievalPrefix,
+      retrievalAtoms,
+      firstResponse,
+      request,
+      systemPrompt,
+      actor,
+    } = args;
+    const { web, config, onLog, mraDoctor, runMraAsk } = this.opts;
+    const doctor = mraDoctor({ workspace: config.mraWorkspace });
+    if (!doctor.ok || !doctor.workspace) {
+      onLog(`mra-ask short-circuited: ${doctor.reason ?? "(no reason)"}`);
+      return await this.synthesiseAfterMra({
+        session,
+        retrievalPrefix,
+        retrievalAtoms,
+        firstResponse,
+        request,
+        systemPrompt,
+        actor,
+        result: {
+          ok: false,
+          stdout: "",
+          stderr: "",
+          reason:
+            doctor.reason ?? "mra workspace unavailable on the host machine",
+        },
+      });
+    }
+
+    const baseProgress = `:mag: 正在用 mra 查 \`${request.repo}\` 的 code…（最多 5 分鐘）`;
+    await web.chat
+      .update({
+        channel: channelId,
+        ts: placeholderTs,
+        text: baseProgress,
+      })
+      .catch(() => {});
+
+    // v0.10 (#22): drip-feed mra's stdout into the placeholder so the
+    // user sees movement during the 30–90s round. 3s coalescing
+    // window keeps us well under Slack's chat.update rate limit
+    // (Tier 3, ~50 rpm) even when mra is chatty.
+    const progressThrottle = createLastLineThrottle({
+      windowMs: 3000,
+      onFire: (line) => {
+        const safe = sanitizeProgressLine(line);
+        void web.chat
+          .update({
+            channel: channelId,
+            ts: placeholderTs,
+            text: `${baseProgress}\n> ${safe}`,
+          })
+          .catch(() => {
+            /* progress updates are best-effort; the final synthesis
+               update will overwrite anyway */
+          });
+      },
+    });
+
+    onLog(`mra ask repo=${request.repo} q=${truncate(request.question, 120)}`);
+    const mraStartMs = Date.now();
+    const result = await runMraAsk(
+      {
+        repo: request.repo,
+        question: request.question,
+        cwd: doctor.workspace,
+      },
+      {
+        onRetry: (attempt) => {
+          onLog(
+            `mra ask attempt ${attempt} failed without stderr; retrying once`,
+          );
+        },
+        onProgress: (line) => progressThrottle.push(line),
+      },
+    );
+    progressThrottle.cancel();
+    appendGatewayEvent({
+      type: "mra-ask.end",
+      actor,
+      repo: request.repo,
+      ok: result.ok,
+      retried: result.attempts > 1,
+      durationMs: Date.now() - mraStartMs,
+    });
+    if (result.ok && result.attempts > 1) {
+      onLog(`mra ask succeeded on attempt ${result.attempts}`);
+    }
+    if (!result.ok) {
+      // Diagnostic-friendly: surface stderr / partial stdout so the
+      // host operator can see WHY mra exited non-zero. Without this,
+      // failures collapse to Node's default "Command failed: <argv>"
+      // which is useless when triaging mra integration issues.
+      onLog(`mra ask failed: ${result.reason ?? "(no reason)"}`);
+      if (result.stderr.trim()) {
+        onLog(`mra ask stderr: ${truncate(result.stderr.trim(), 600)}`);
+      }
+      if (result.stdout.trim()) {
+        onLog(
+          `mra ask partial stdout: ${truncate(result.stdout.trim(), 200)}`,
+        );
+      }
+    }
+
+    return await this.synthesiseAfterMra({
+      session,
+      retrievalPrefix,
+      retrievalAtoms,
+      firstResponse,
+      request,
+      result,
+      systemPrompt,
+      actor,
+    });
+  }
+
+  /**
+   * Push the model's first (preamble) response and an `mra-result`
+   * user message into the session, then re-call the LLM. The mra
+   * result message is later kept in session history so follow-up
+   * turns can reference it.
+   *
+   * T12: wrapped in `chatWithContextRetry` (phase="synthesise") so a
+   * post-mra-ask blow-up triggers the same force-prune-and-scissors
+   * recovery path as the first-call site. Throws `PmkContextTooLongError`
+   * when even the post-prune retry can't fit, letting the caller decide
+   * how to surface the failure to Slack (see `run`).
+   */
+  private async synthesiseAfterMra(args: {
+    session: FreeChatSession;
+    retrievalPrefix: ChatMessage[];
+    retrievalAtoms: number;
+    firstResponse: string;
+    request: { repo: string; question: string };
+    result: { ok: boolean; stdout: string; stderr: string; reason?: string };
+    systemPrompt: string;
+    actor: string;
+  }): Promise<{ full: string; scissorsPrefix: string }> {
+    const {
+      session,
+      retrievalPrefix,
+      retrievalAtoms,
+      firstResponse,
+      request,
+      result,
+      systemPrompt,
+      actor,
+    } = args;
+    const { llm } = this.opts;
+    session.messages.push({ role: "assistant", content: firstResponse });
+
+    let mraMessage: string;
+    if (result.ok) {
+      const cap = capMessageContent(result.stdout, MRA_RESULT_CAP);
+      if (cap.capped) {
+        appendGatewayEvent({
+          type: "message.capped",
+          actor,
+          kind: "mra-result",
+          originalChars: cap.originalChars,
+          cappedChars: cap.content.length,
+        });
+      }
+      mraMessage = buildMraSuccessMessage(request.repo, cap.content);
+    } else {
+      mraMessage = buildMraFailureMessage(request.repo, result);
+    }
+    session.messages.push({ role: "user", content: mraMessage });
+
+    const retryResult = await chatWithContextRetry({
+      llm,
+      systemPrompt,
+      buildMessages: () => [...retrievalPrefix, ...session.messages],
+      session,
+      actor,
+      retrievalAtoms,
+      phase: "synthesise",
+      chatOptions: { onToken: () => {} },
+    });
+
+    if (!retryResult.ok) {
+      if (retryResult.kind === "context") {
+        throw new PmkContextTooLongError(retryResult.secondError);
+      }
+      throw retryResult.error;
+    }
+
+    return { full: retryResult.full, scissorsPrefix: retryResult.scissorsPrefix };
+  }
+}

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -28,6 +28,10 @@ import {
   FreeChatTurnRunner,
   type FreeChatSession,
 } from "./free-chat-turn";
+import {
+  InFlightQueue,
+  QueueFullError,
+} from "./inflight-queue";
 import { PresenceBroadcaster } from "./presence";
 
 // v0.13: re-exported so existing test imports (`gateway.test.ts`) keep
@@ -158,7 +162,14 @@ export class SlackAdapter {
   private llm: LlmProvider;
   private readonly mraDoctor: typeof mraDoctorImpl;
   private readonly runMraAsk: typeof runMraAskImpl;
-  private inFlight = new Set<string>();
+  /**
+   * v0.13: per-user (DM) / per-user-per-channel (mention) FIFO queue
+   * for rapid follow-up messages. Pre-v0.13 dropped messages with a
+   * `:hourglass: 還在處理` notice that misled users into thinking they
+   * were queued; the queue actually does that now and matches the
+   * notice semantics.
+   */
+  private readonly queue: InFlightQueue;
   /** Envelope IDs we've already accepted; protects against Slack retries. */
   private readonly dedup: EnvelopeDedup;
   /** Online/offline broadcast fan-out (#44). */
@@ -232,6 +243,7 @@ export class SlackAdapter {
       runMraAsk: this.runMraAsk,
       escalation: this.escalation,
     });
+    this.queue = new InFlightQueue({ onLog: this.onLog });
   }
 
   async start(): Promise<SlackBotInfo> {
@@ -277,6 +289,13 @@ export class SlackAdapter {
     // offlineDurationMs / gracefulShutdown.
     await this.presence.backOnline();
     return this.botInfo;
+  }
+
+  /** v0.13: wait for all pending background work to drain. Used by
+   *  the harness in tests so assertions see post-work state. Production
+   *  callers can use this on graceful shutdown. */
+  async waitForPending(): Promise<void> {
+    await this.queue.waitForAll();
   }
 
   async stop(): Promise<void> {
@@ -330,55 +349,72 @@ export class SlackAdapter {
     }
     this.dedup.remember(payload.envelope_id);
 
-    if (this.inFlight.has(userId)) {
-      await this.web.chat.postMessage({
-        channel: event.channel!,
-        text: ":hourglass: 上一則訊息還在處理，請稍候。",
-      });
-      return;
-    }
+    // replyThreadTs: where Slack should anchor the bot's response.
+    // sessionThreadTs: which conversation history to load — undefined
+    // means "main" (top-level DM, no Slack thread); a thread_ts means
+    // an in-thread reply, which gets its own isolated session so
+    // contexts don't bleed across threads.
+    const replyThreadTs = event.thread_ts ?? event.ts;
+    if (!replyThreadTs) return;
 
-    this.inFlight.add(userId);
+    const channel = event.channel!;
+    const work = async () => {
+      try {
+        // If this DM is in a thread that pmk previously escalated AND
+        // the sender is one of the IT contacts pmk tagged, absorb the
+        // answer into the knowledge store and stop — don't run the
+        // normal LLM turn (otherwise we'd answer the IT's reply as if
+        // it were a user question).
+        const absorbed = await this.escalation.maybeAbsorbReply({
+          channelId: channel,
+          threadTs: replyThreadTs,
+          contributorUserId: userId,
+          answerText: text,
+        });
+        if (absorbed) return;
+        await this.handleDmMessage({
+          channelId: channel,
+          userId,
+          text,
+          threadTs: replyThreadTs,
+          sessionThreadTs: event.thread_ts,
+        });
+      } catch (err) {
+        this.onLog(
+          `error handling DM from ${userId}: ${(err as Error).message}`,
+        );
+        await this.web.chat
+          .postMessage({
+            channel,
+            thread_ts: event.thread_ts,
+            text: `:warning: pmk 內部錯誤：${(err as Error).message}`,
+          })
+          .catch(() => {});
+      }
+    };
+
+    let result: "ran" | "queued";
     try {
-      // replyThreadTs: where Slack should anchor the bot's response.
-      // sessionThreadTs: which conversation history to load — undefined
-      // means "main" (top-level DM, no Slack thread); a thread_ts means
-      // an in-thread reply, which gets its own isolated session so
-      // contexts don't bleed across threads.
-      const replyThreadTs = event.thread_ts ?? event.ts;
-      if (!replyThreadTs) return;
-
-      // If this DM is in a thread that pmk previously escalated AND the
-      // sender is one of the IT contacts pmk tagged, absorb the answer
-      // into the knowledge store and stop — don't run the normal LLM
-      // turn (otherwise we'd answer the IT's reply as if it were a
-      // user question).
-      const absorbed = await this.escalation.maybeAbsorbReply({
-        channelId: event.channel!,
-        threadTs: replyThreadTs,
-        contributorUserId: userId,
-        answerText: text,
-      });
-      if (absorbed) return;
-
-      await this.handleDmMessage({
-        channelId: event.channel!,
-        userId,
-        text,
-        threadTs: replyThreadTs,
-        sessionThreadTs: event.thread_ts,
-      });
+      result = this.queue.enqueue(userId, work);
     } catch (err) {
-      this.onLog(`error handling DM from ${userId}: ${(err as Error).message}`);
+      if (err instanceof QueueFullError) {
+        await this.web.chat
+          .postMessage({
+            channel,
+            text: ":no_entry: 你已有多則訊息排隊中（上限 3 則），請等回覆後再發。",
+          })
+          .catch(() => {});
+        return;
+      }
+      throw err;
+    }
+    if (result === "queued") {
       await this.web.chat
         .postMessage({
-          channel: event.channel!,
-          thread_ts: event.thread_ts,
-          text: `:warning: pmk 內部錯誤：${(err as Error).message}`,
+          channel,
+          text: ":hourglass: 你上一則還在處理，這則已排入隊伍（會依序處理）。",
         })
         .catch(() => {});
-    } finally {
-      this.inFlight.delete(userId);
     }
   }
 
@@ -413,63 +449,75 @@ export class SlackAdapter {
 
     if (this.config.blocklist.includes(userId)) return;
 
-    // v0.13: lock per-user-per-channel instead of per-channel. The old
-    // per-channel key serialised every @-mention in the channel,
-    // blocking multi-user Q&A in open channels (different users had
-    // to wait for each other's LLM round to finish). Per-user-per-
-    // channel still serialises a single user's rapid double-taps (the
-    // original intent of the lock) but lets distinct users proceed
-    // in parallel.
+    // v0.13: queue key is per-user-per-channel. Different users in the
+    // same channel run in parallel; a single user's rapid follow-ups
+    // queue up FIFO behind their own in-flight round (up to 3 deep)
+    // instead of being silently dropped as in pre-v0.13.
     //
     // Trade-off: when the channel has an active case file
-    // (`/pmk open <name>`), parallel @-mentions can race on
+    // (`/pmk open <name>`), parallel @-mentions can still race on
     // `saveCase` (last write wins). In practice case-channels are
     // low-traffic single-thread workflows, so the race is rare;
     // the v0.13 backlog tracks a load-modify-write retry on case
     // files if it bites.
-    const inFlightKey = `${channelId}:${userId}`;
-    if (this.inFlight.has(inFlightKey)) {
-      await this.web.chat.postMessage({
-        channel: channelId,
-        thread_ts: replyThreadTs,
-        text: ":hourglass: 你上一則訊息還在處理，請稍候。",
-      });
-      return;
-    }
+    const queueKey = `${channelId}:${userId}`;
+    const work = async () => {
+      try {
+        // Absorb-first: if this thread is pending escalation and the
+        // mentioner is one of the tagged IT contacts, treat the message
+        // as the expert answer instead of routing to the LLM.
+        const absorbed = await this.escalation.maybeAbsorbReply({
+          channelId,
+          threadTs: replyThreadTs,
+          contributorUserId: userId,
+          answerText: text,
+        });
+        if (absorbed) return;
+        await this.handleChannelMention({
+          channelId,
+          userId,
+          text,
+          threadTs: replyThreadTs,
+          sessionThreadTs,
+        });
+      } catch (err) {
+        this.onLog(
+          `error handling mention in ${channelId}: ${(err as Error).message}`,
+        );
+        await this.web.chat
+          .postMessage({
+            channel: channelId,
+            thread_ts: replyThreadTs,
+            text: `:warning: pmk 內部錯誤：${(err as Error).message}`,
+          })
+          .catch(() => {});
+      }
+    };
 
-    this.inFlight.add(inFlightKey);
+    let result: "ran" | "queued";
     try {
-      // Absorb-first: if this thread is pending escalation and the
-      // mentioner is one of the tagged IT contacts, treat the message
-      // as the expert answer instead of routing to the LLM.
-      const absorbed = await this.escalation.maybeAbsorbReply({
-        channelId,
-        threadTs: replyThreadTs,
-        contributorUserId: userId,
-        answerText: text,
-      });
-      if (absorbed) return;
-
-      await this.handleChannelMention({
-        channelId,
-        userId,
-        text,
-        threadTs: replyThreadTs,
-        sessionThreadTs,
-      });
+      result = this.queue.enqueue(queueKey, work);
     } catch (err) {
-      this.onLog(
-        `error handling mention in ${channelId}: ${(err as Error).message}`,
-      );
+      if (err instanceof QueueFullError) {
+        await this.web.chat
+          .postMessage({
+            channel: channelId,
+            thread_ts: replyThreadTs,
+            text: ":no_entry: 你已有多則訊息排隊中（上限 3 則），請等回覆後再發。",
+          })
+          .catch(() => {});
+        return;
+      }
+      throw err;
+    }
+    if (result === "queued") {
       await this.web.chat
         .postMessage({
           channel: channelId,
           thread_ts: replyThreadTs,
-          text: `:warning: pmk 內部錯誤：${(err as Error).message}`,
+          text: ":hourglass: 你上一則還在處理，這則已排入隊伍（會依序處理）。",
         })
         .catch(() => {});
-    } finally {
-      this.inFlight.delete(inFlightKey);
     }
   }
 

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -1,12 +1,8 @@
 import { SocketModeClient } from "@slack/socket-mode";
 import { WebClient } from "@slack/web-api";
 import type { GatewayConfig } from "../config";
-import {
-  isAdmin,
-  pickAudience,
-} from "../config";
+import { isAdmin } from "../config";
 import { handleAdminSlash } from "./admin";
-import { chatWithContextRetry } from "./context-retry";
 import {
   formatTrackingSummary,
   markdownToMrkdwn,
@@ -28,15 +24,16 @@ import {
 } from "../channel-log";
 import { EnvelopeDedup } from "./envelope-dedup";
 import { EscalationCoordinator } from "./escalation";
+import {
+  FreeChatTurnRunner,
+  type FreeChatSession,
+} from "./free-chat-turn";
 import { PresenceBroadcaster } from "./presence";
 
 // v0.13: re-exported so existing test imports (`gateway.test.ts`) keep
 // working after the extraction to `./concurrency`.
 export { runWithConcurrency } from "./concurrency";
-import type { ChatMessage } from "@pmk/shared";
-import { pickGatewayPrompt } from "@pmk/shared";
 import { resolveProvider, type LlmProvider } from "../../llm";
-import { PmkContextTooLongError } from "../../llm/claude-agent";
 import { loadConfig as loadCliConfig } from "../../config";
 import { PROMPT_CASE } from "../../prompts";
 import {
@@ -54,40 +51,19 @@ import {
   runMraAsk as runMraAskImpl,
 } from "../../adapters/mra";
 import { appendGatewayEvent } from "../events";
-import { createLastLineThrottle } from "../throttle";
-import { sanitizeProgressLine } from "./progress";
-import { parseMraAsk, stripMraAskBlock } from "../mra-ask";
-import {
-  approxTokensFor,
-  buildIngestSeed,
-  buildMraFailureMessage,
-  buildMraSuccessMessage,
-  capMessageContent,
-  MRA_RESULT_CAP,
-  pruneSessionIfNeeded,
-  SEED_CAP,
-  truncate,
-} from "../messaging";
-import { parseEscalate, stripEscalateBlock } from "../escalate";
+import { approxTokensFor } from "../messaging";
 import {
   approveAtom,
   findAtomByApprovalMessage,
-  formatAtomsForInjection,
   rejectAtom,
-  searchAtoms,
 } from "../knowledge";
 import * as path from "node:path";
 import * as fs from "node:fs";
 
-/**
- * Structural shape of any session the free-chat helpers can mutate —
- * UserSession (DM) and ChannelChatSession (channel) both satisfy this.
- */
-interface FreeChatSession {
-  messages: ChatMessage[];
-  turns: number;
-  approxTokens: number;
-}
+// `FreeChatSession` type moved alongside its owner in
+// `./free-chat-turn.ts` (v0.13 tranche 3 extraction). It is re-exported
+// from there for the channel-log saveSession closure to construct an
+// in-memory session that satisfies the runner's generic.
 
 export type SlashCommandScope =
   | { kind: "user"; userId: string }
@@ -189,6 +165,8 @@ export class SlackAdapter {
   private readonly presence: PresenceBroadcaster;
   /** Outbound escalate + inbound absorb + asker-synthesis follow-up. */
   private readonly escalation: EscalationCoordinator;
+  /** End-to-end free-chat turn: seed + retrieval + LLM + mra-ask + escalate + reply. */
+  private readonly freeChatTurn: FreeChatTurnRunner;
 
   constructor(opts: SlackAdapterOptions) {
     // v0.13: token guard only fires on the prod construction path.
@@ -244,6 +222,15 @@ export class SlackAdapter {
       config: this.config,
       onLog: this.onLog,
       llm: this.llm,
+    });
+    this.freeChatTurn = new FreeChatTurnRunner({
+      web: this.web,
+      config: this.config,
+      onLog: this.onLog,
+      llm: this.llm,
+      mraDoctor: this.mraDoctor,
+      runMraAsk: this.runMraAsk,
+      escalation: this.escalation,
     });
   }
 
@@ -510,7 +497,7 @@ export class SlackAdapter {
     }
 
     const session = loadUserSession(userId, sessionThreadTs);
-    await this.runFreeChatTurn({
+    await this.freeChatTurn.run({
       channelId,
       threadTs,
       text,
@@ -520,212 +507,6 @@ export class SlackAdapter {
     });
   }
 
-  /**
-   * Free-chat turn shared between DM and channel-without-active-case.
-   * On first turn, seeds with PKB from `config.defaultIngest`; runs
-   * the LLM under PROMPT_GATEWAY_DM; if the model emits an `mra-ask`
-   * directive, runs `mra ask` and synthesises a final answer; finally
-   * updates the Slack placeholder with the visible response.
-   *
-   * The session is generic over UserSession / ChannelChatSession —
-   * both have the same {messages, turns, approxTokens} shape we
-   * touch here.
-   */
-  private async runFreeChatTurn<S extends FreeChatSession>(args: {
-    channelId: string;
-    threadTs: string;
-    text: string;
-    userId: string;
-    session: S;
-    saveSession: (s: S) => void;
-  }): Promise<void> {
-    const { channelId, threadTs, text, userId, session, saveSession } = args;
-
-    // First turn: seed the conversation with PKB context from
-    // config.defaultIngest (e.g. mra:--all). Without this the model
-    // truthfully says it has no idea about the user's codebase even
-    // though we configured the ingest spec at gateway init.
-    //
-    // v0.11.1: cap the seed at SEED_CAP chars so an `mra:--all` against a
-    // large multi-repo workspace can't single-handedly exhaust the
-    // model's input window. Emits a `message.capped` event when capping
-    // fires so operators can see how often the cap is biting.
-    if (session.messages.length === 0 && this.config.defaultIngest) {
-      const seedRaw = buildIngestSeed(
-        this.config.defaultIngest,
-        this.config.mraWorkspace,
-      );
-      if (seedRaw) {
-        const cap = capMessageContent(seedRaw, SEED_CAP);
-        if (cap.capped) {
-          appendGatewayEvent({
-            type: "message.capped",
-            actor: userId,
-            kind: "seed",
-            originalChars: cap.originalChars,
-            cappedChars: cap.content.length,
-          });
-        }
-        session.messages.push({ role: "user", content: cap.content });
-        session.messages.push({
-          role: "assistant",
-          content: "了解，已載入 workspace PKB context。請繼續。",
-        });
-      }
-    }
-
-    // Knowledge retrieval: pull any prior IT-supplied atoms that look
-    // relevant to this question and inject them as ephemeral context
-    // (not persisted to session.messages, so old retrieved answers
-    // don't keep stacking up turn after turn).
-    const retrieved = searchAtoms(text, { limit: 3 });
-    const retrievalPrefix: ChatMessage[] = retrieved.length
-      ? [
-          { role: "user", content: formatAtomsForInjection(retrieved) },
-          {
-            role: "assistant",
-            content: "收到，這些補充當作 ground truth。",
-          },
-        ]
-      : [];
-
-    // v0.11.1: prune BEFORE the LLM call so a bloated session can be
-    // trimmed on its way in, not after it has already triggered
-    // msg_too_long. Includes retrievalPrefix and the new user turn in
-    // the budget check so the prune reflects what we'll actually send.
-    const pruneReport = pruneSessionIfNeeded(session, {
-      extra: retrievalPrefix,
-      newUser: text,
-    });
-    if (pruneReport.pruned) {
-      this.onLog(
-        `pruned session: dropped ${pruneReport.droppedPairs} turn-pair(s); now ${pruneReport.tokensAfter} approx tokens`,
-      );
-    }
-
-    const placeholder = await this.web.chat.postMessage({
-      channel: channelId,
-      thread_ts: threadTs,
-      text: ":hourglass_flowing_sand: thinking…",
-    });
-
-    const audience = pickAudience(this.config, userId, channelId);
-    const systemPrompt = pickGatewayPrompt(audience);
-
-    // T11: wrap llm.chat in the context-too-long retry helper. The
-    // buildMessages closure includes the new user turn at the tail so
-    // the LLM sees it on both attempts; we deliberately do NOT push it
-    // onto session.messages until AFTER the retry succeeds, so a failed
-    // turn doesn't pollute persisted history (and so forcePruneToMinimum
-    // operates on a coherent paired-history shape).
-    const retryResult = await chatWithContextRetry({
-      llm: this.llm,
-      systemPrompt,
-      buildMessages: () => [
-        ...retrievalPrefix,
-        ...session.messages,
-        { role: "user", content: text },
-      ],
-      session,
-      actor: userId,
-      retrievalAtoms: retrieved.length,
-      phase: "first-call",
-    });
-
-    if (!retryResult.ok) {
-      const errText =
-        retryResult.kind === "context"
-          ? ":x: 對話太長，請開新 thread 重新提問"
-          : `:warning: ${(retryResult.error as Error).message}`;
-      await this.web.chat.update({
-        channel: channelId,
-        ts: String(placeholder.ts),
-        text: errText,
-      });
-      return;
-    }
-
-    // Retry succeeded — NOW commit the new user turn to session history.
-    session.messages.push({ role: "user", content: text });
-    session.turns += 1;
-
-    let full = retryResult.full;
-    let scissorsPrefix = retryResult.scissorsPrefix;
-
-    // If the model asked us to delegate a deep code-search round to
-    // mra, run it and feed the result back for synthesis.
-    const askReq = parseMraAsk(full);
-    if (askReq) {
-      try {
-        const mraResult = await this.handleMraAskRound({
-          channelId,
-          placeholderTs: String(placeholder.ts),
-          session,
-          retrievalPrefix,
-          retrievalAtoms: retrieved.length,
-          firstResponse: full,
-          request: askReq,
-          systemPrompt,
-          actor: userId,
-        });
-        full = mraResult.full;
-        // T12: if the synthesise round ALSO needed force-prune, the
-        // post-prune scissors notice more accurately reflects the final
-        // session state than the first-call notice. Two notices stacked
-        // would just confuse the user, so the latter wins.
-        if (mraResult.scissorsPrefix) {
-          scissorsPrefix = mraResult.scissorsPrefix;
-        }
-      } catch (err) {
-        if (err instanceof PmkContextTooLongError) {
-          await this.web.chat.update({
-            channel: channelId,
-            ts: String(placeholder.ts),
-            text: ":x: 對話太長，請開新 thread 重新提問",
-          });
-          return;
-        }
-        throw err;
-      }
-    }
-
-    // If the model asked to escalate to a human IT/domain expert, fan
-    // out the @-mention before showing the placeholder reply, and
-    // remember the thread so the next IT reply gets absorbed. The
-    // asker is recorded so the post-absorb synthesis can reply to
-    // them once IT answers.
-    const escReq = parseEscalate(full);
-    if (escReq) {
-      await this.escalation.escalate({
-        channelId,
-        threadTs,
-        askerUserId: userId,
-        request: escReq,
-      });
-    }
-
-    const visible = stripEscalateBlock(
-      stripMraAskBlock(stripCaseUpdateBlock(full)),
-    );
-    session.messages.push({ role: "assistant", content: visible });
-    session.approxTokens = approxTokensFor(session.messages);
-
-    saveSession(session);
-
-    appendGatewayEvent({
-      type: "turn.processed",
-      actor: userId,
-      audience,
-      hadMraAsk: askReq !== undefined,
-      atomsInjected: retrieved.length,
-    });
-
-    await this.web.chat.update({
-      channel: channelId,
-      ts: String(placeholder.ts),
-      text: scissorsPrefix + truncateForSlack(markdownToMrkdwn(visible)),
-    });
-  }
 
 
   /**
@@ -803,237 +584,7 @@ export class SlackAdapter {
     }
   }
 
-  /**
-   * Run one round of `mra ask` on behalf of the model, then re-call
-   * the LLM with the result so it can produce a synthesised final
-   * answer. Returns the synthesised response (with any directive
-   * blocks left intact — caller strips them).
-   *
-   * Failure modes (mra missing, timeout, non-zero exit) flow back to
-   * the LLM as an explicit "mra-result-failed" message so the model
-   * can apologise rather than the user seeing a crash.
-   */
-  private async handleMraAskRound(args: {
-    channelId: string;
-    placeholderTs: string;
-    session: FreeChatSession;
-    /** Retrieval atoms injected into the first LLM call; passed
-     * through so the synthesis round still sees them. */
-    retrievalPrefix: ChatMessage[];
-    /** Atom count corresponding to retrievalPrefix; threaded through
-     * to synthesiseAfterMra → chatWithContextRetry so the
-     * `context.exceeded` audit event records it accurately. */
-    retrievalAtoms: number;
-    firstResponse: string;
-    request: { repo: string; question: string };
-    systemPrompt: string;
-    /** Slack user ID that triggered this round — recorded in the
-     * audit event so per-user mra-ask cost is attributable. */
-    actor: string;
-  }): Promise<{ full: string; scissorsPrefix: string }> {
-    const {
-      channelId,
-      placeholderTs,
-      session,
-      retrievalPrefix,
-      retrievalAtoms,
-      firstResponse,
-      request,
-      systemPrompt,
-      actor,
-    } = args;
-    const doctor = this.mraDoctor({ workspace: this.config.mraWorkspace });
-    if (!doctor.ok || !doctor.workspace) {
-      // Host-side log so the gateway operator can see WHY mra-ask
-      // bailed (config-fixable vs binary-missing vs workspace-stale).
-      this.onLog(`mra-ask short-circuited: ${doctor.reason ?? "(no reason)"}`);
-      // Surface as a synthetic mra failure so the model can degrade gracefully.
-      return await this.synthesiseAfterMra({
-        session,
-        retrievalPrefix,
-        retrievalAtoms,
-        firstResponse,
-        request,
-        systemPrompt,
-        actor,
-        result: {
-          ok: false,
-          stdout: "",
-          stderr: "",
-          reason:
-            doctor.reason ?? "mra workspace unavailable on the host machine",
-        },
-      });
-    }
 
-    const baseProgress = `:mag: 正在用 mra 查 \`${request.repo}\` 的 code…（最多 5 分鐘）`;
-    await this.web.chat
-      .update({
-        channel: channelId,
-        ts: placeholderTs,
-        text: baseProgress,
-      })
-      .catch(() => {});
-
-    // v0.10 (#22): drip-feed mra's stdout into the placeholder so the
-    // user sees movement during the 30–90s round. 3s coalescing
-    // window keeps us well under Slack's chat.update rate limit
-    // (Tier 3, ~50 rpm) even when mra is chatty.
-    const progressThrottle = createLastLineThrottle({
-      windowMs: 3000,
-      onFire: (line) => {
-        // ANSI strip + mrkdwn-meta strip + length cap. See
-        // sanitizeProgressLine for rationale.
-        const safe = sanitizeProgressLine(line);
-        void this.web.chat
-          .update({
-            channel: channelId,
-            ts: placeholderTs,
-            text: `${baseProgress}\n> ${safe}`,
-          })
-          .catch(() => {
-            /* progress updates are best-effort; the final synthesis
-               update will overwrite anyway */
-          });
-      },
-    });
-
-    this.onLog(
-      `mra ask repo=${request.repo} q=${truncate(request.question, 120)}`,
-    );
-    const mraStartMs = Date.now();
-    const result = await this.runMraAsk(
-      {
-        repo: request.repo,
-        question: request.question,
-        cwd: doctor.workspace,
-      },
-      {
-        onRetry: (attempt) => {
-          this.onLog(
-            `mra ask attempt ${attempt} failed without stderr; retrying once`,
-          );
-        },
-        onProgress: (line) => progressThrottle.push(line),
-      },
-    );
-    progressThrottle.cancel();
-    appendGatewayEvent({
-      type: "mra-ask.end",
-      actor,
-      repo: request.repo,
-      ok: result.ok,
-      retried: result.attempts > 1,
-      durationMs: Date.now() - mraStartMs,
-    });
-    if (result.ok && result.attempts > 1) {
-      this.onLog(`mra ask succeeded on attempt ${result.attempts}`);
-    }
-    if (!result.ok) {
-      // Diagnostic-friendly: surface stderr / partial stdout so the
-      // host operator can see WHY mra exited non-zero. Without this,
-      // failures collapse to Node's default "Command failed: <argv>"
-      // which is useless when triaging mra integration issues.
-      this.onLog(`mra ask failed: ${result.reason ?? "(no reason)"}`);
-      if (result.stderr.trim()) {
-        this.onLog(`mra ask stderr: ${truncate(result.stderr.trim(), 600)}`);
-      }
-      if (result.stdout.trim()) {
-        this.onLog(
-          `mra ask partial stdout: ${truncate(result.stdout.trim(), 200)}`,
-        );
-      }
-    }
-
-    return await this.synthesiseAfterMra({
-      session,
-      retrievalPrefix,
-      retrievalAtoms,
-      firstResponse,
-      request,
-      result,
-      systemPrompt,
-      actor,
-    });
-  }
-
-  /**
-   * Push the model's first (preamble) response and an `mra-result`
-   * user message into the session, then re-call the LLM. The mra
-   * result message is later kept in session history so follow-up
-   * turns can reference it.
-   *
-   * T12: wrapped in `chatWithContextRetry` (phase="synthesise") so a
-   * post-mra-ask blow-up triggers the same force-prune-and-scissors
-   * recovery path as the first-call site. Throws `PmkContextTooLongError`
-   * when even the post-prune retry can't fit, letting the caller decide
-   * how to surface the failure to Slack (see runFreeChatTurn).
-   */
-  private async synthesiseAfterMra(args: {
-    session: FreeChatSession;
-    retrievalPrefix: ChatMessage[];
-    retrievalAtoms: number;
-    firstResponse: string;
-    request: { repo: string; question: string };
-    result: { ok: boolean; stdout: string; stderr: string; reason?: string };
-    systemPrompt: string;
-    actor: string;
-  }): Promise<{ full: string; scissorsPrefix: string }> {
-    const {
-      session,
-      retrievalPrefix,
-      retrievalAtoms,
-      firstResponse,
-      request,
-      result,
-      systemPrompt,
-      actor,
-    } = args;
-    session.messages.push({ role: "assistant", content: firstResponse });
-
-    let mraMessage: string;
-    if (result.ok) {
-      const cap = capMessageContent(result.stdout, MRA_RESULT_CAP);
-      if (cap.capped) {
-        appendGatewayEvent({
-          type: "message.capped",
-          actor,
-          kind: "mra-result",
-          originalChars: cap.originalChars,
-          cappedChars: cap.content.length,
-        });
-      }
-      mraMessage = buildMraSuccessMessage(request.repo, cap.content);
-    } else {
-      mraMessage = buildMraFailureMessage(request.repo, result);
-    }
-    session.messages.push({ role: "user", content: mraMessage });
-
-    // Retrieval atoms come back here too — synthesis benefits from
-    // both the retrieved knowledge AND the fresh mra-result.
-    const retryResult = await chatWithContextRetry({
-      llm: this.llm,
-      systemPrompt,
-      buildMessages: () => [...retrievalPrefix, ...session.messages],
-      session,
-      actor,
-      retrievalAtoms,
-      phase: "synthesise",
-      chatOptions: { onToken: () => {} },
-    });
-
-    if (!retryResult.ok) {
-      // Bubble up so the caller (runFreeChatTurn) can post the friendly
-      // ":x: 對話太長…" message. Other (non-context) errors are
-      // re-thrown as-is and caught by the outer Slack handler.
-      if (retryResult.kind === "context") {
-        throw new PmkContextTooLongError(retryResult.secondError);
-      }
-      throw retryResult.error;
-    }
-
-    return { full: retryResult.full, scissorsPrefix: retryResult.scissorsPrefix };
-  }
 
   // ────────────────────────── channel logic ──────────────────────────
 
@@ -1086,7 +637,7 @@ export class SlackAdapter {
         ).length,
         approxTokens: approxTokensFor(initialMessages),
       };
-      await this.runFreeChatTurn({
+      await this.freeChatTurn.run({
         channelId,
         threadTs,
         text,

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -298,13 +298,46 @@ export class SlackAdapter {
     await this.queue.waitForAll();
   }
 
-  async stop(): Promise<void> {
-    await this.presence.offline();
+  /**
+   * Graceful shutdown.
+   *
+   * Order matters: (1) cut the socket so no new envelopes arrive and
+   * the queue stops growing; (2) drain in-flight + queued turns so
+   * users actually get their replies (with a bounded timeout so a
+   * stuck LLM round can't block SIGTERM forever); (3) broadcast
+   * offline last, so presence reflects the true "done" moment.
+   *
+   * Pre-v0.13 had no queue and stop() finished in <1s; v0.13's
+   * fire-and-forget handlers turned shutdown into a real drain
+   * problem (PR #55 review: queued turns get abandoned without
+   * posting/saving reply if we don't await here).
+   */
+  async stop(opts: { drainTimeoutMs?: number } = {}): Promise<void> {
     try {
       await this.socket.disconnect();
     } catch {
       /* socket may already be closed */
     }
+
+    const timeoutMs = opts.drainTimeoutMs;
+    if (timeoutMs !== undefined && timeoutMs > 0) {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeout = new Promise<"timeout">((resolve) => {
+        timer = setTimeout(() => resolve("timeout"), timeoutMs);
+      });
+      const drained = this.queue.waitForAll().then(() => "drained" as const);
+      const winner = await Promise.race([drained, timeout]);
+      if (timer) clearTimeout(timer);
+      if (winner === "timeout") {
+        this.onLog(
+          `stop: drain timed out after ${timeoutMs}ms; abandoning remaining in-flight work`,
+        );
+      }
+    } else {
+      await this.queue.waitForAll();
+    }
+
+    await this.presence.offline();
   }
 
   // ─────────────────────────── event handlers ───────────────────────────

--- a/packages/cli/src/gateway/slack/inflight-queue.ts
+++ b/packages/cli/src/gateway/slack/inflight-queue.ts
@@ -86,19 +86,32 @@ export class InFlightQueue {
   }
 
   private async drain(key: string): Promise<void> {
-    const queue = this.queues.get(key);
-    while (queue && queue.length > 0) {
-      const work = queue.shift()!;
-      try {
-        await work();
-      } catch (err) {
-        this.onLog(
-          `inflight-queue work failed for ${key}: ${(err as Error).message}`,
-        );
+    try {
+      const queue = this.queues.get(key);
+      while (queue && queue.length > 0) {
+        const work = queue.shift()!;
+        try {
+          await work();
+        } catch (err) {
+          // `onLog` is caller-supplied — wrap in its own try/catch so a
+          // broken logger can't reject the worker promise (which would
+          // poison `waitForAll` and force-fail graceful shutdown).
+          try {
+            this.onLog(
+              `inflight-queue work failed for ${key}: ${(err as Error).message}`,
+            );
+          } catch {
+            /* logger threw; nothing useful to do here */
+          }
+        }
       }
+    } finally {
+      // Cleanup must run even if something above unexpectedly throws —
+      // otherwise the worker dies but `workers`/`queues` still claim
+      // the key as active, locking that user out forever.
+      this.queues.delete(key);
+      this.workers.delete(key);
     }
-    this.queues.delete(key);
-    this.workers.delete(key);
   }
 
   /** Number of items currently QUEUED (not counting the running one). */

--- a/packages/cli/src/gateway/slack/inflight-queue.ts
+++ b/packages/cli/src/gateway/slack/inflight-queue.ts
@@ -1,0 +1,128 @@
+/**
+ * Per-key FIFO work queue (v0.13 follow-up to #53).
+ *
+ * Replaces the pre-v0.13 "drop second message + busy notice" model
+ * (which was misleading — the notice said `:hourglass: 你上一則訊息還在處理，請稍候。`
+ * implying queue semantics, but the handler returned early and the
+ * message was lost). With this queue, rapid follow-up messages from
+ * the same user behind their own in-flight LLM round get queued FIFO
+ * up to `maxDepth`, then drained automatically when the running work
+ * completes.
+ *
+ * Key choice is the caller's: `userId` for DM, `${channelId}:${userId}`
+ * for channel @-mention. The queue itself doesn't care.
+ *
+ * Bounded: when the queue for a key hits `maxDepth`, `enqueue` throws
+ * `QueueFullError` so the caller can post an explicit "queue full"
+ * rejection notice (better UX than silently dropping the Nth message).
+ */
+
+/** Default queue depth. 3 follow-ups feels like a reasonable ceiling for
+ *  rapid-fire clarifications without letting one user monopolise the bot. */
+export const DEFAULT_MAX_DEPTH = 3;
+
+export class QueueFullError extends Error {
+  readonly key: string;
+  readonly depth: number;
+  constructor(key: string, depth: number) {
+    super(`InFlightQueue full for key "${key}" (depth ${depth})`);
+    this.name = "QueueFullError";
+    this.key = key;
+    this.depth = depth;
+  }
+}
+
+export type EnqueueResult = "ran" | "queued";
+
+export interface InFlightQueueOptions {
+  /** Max queued items per key (excluding the one currently running). Default 3. */
+  maxDepth?: number;
+  /** Diagnostic log for swallowed work errors. Default: no-op. */
+  onLog?: (msg: string) => void;
+}
+
+export class InFlightQueue {
+  private readonly queues = new Map<string, Array<() => Promise<void>>>();
+  private readonly workers = new Map<string, Promise<void>>();
+  private readonly maxDepth: number;
+  private readonly onLog: (msg: string) => void;
+
+  constructor(opts: InFlightQueueOptions = {}) {
+    this.maxDepth = opts.maxDepth ?? DEFAULT_MAX_DEPTH;
+    this.onLog = opts.onLog ?? (() => {});
+  }
+
+  /**
+   * Submit `work` for sequential execution under `key`.
+   *
+   * - If nothing is running for `key`: spawns a worker that runs
+   *   `work` immediately, returns `"ran"`.
+   * - If a worker is already running: appends `work` to the queue,
+   *   returns `"queued"`. Caller can post a "queued, will process" notice.
+   * - If the queue is at `maxDepth`: throws `QueueFullError`. Caller
+   *   should post an explicit "rejected" notice.
+   *
+   * `enqueue` is synchronous (no promise). The submitted work runs
+   * in the background via the worker; errors thrown by `work` are
+   * caught and logged via `onLog` so one failed turn doesn't poison
+   * the rest of the queue.
+   */
+  enqueue(key: string, work: () => Promise<void>): EnqueueResult {
+    if (this.workers.has(key)) {
+      const queue = this.queues.get(key) ?? [];
+      if (queue.length >= this.maxDepth) {
+        throw new QueueFullError(key, queue.length);
+      }
+      queue.push(work);
+      this.queues.set(key, queue);
+      return "queued";
+    }
+    const queue = this.queues.get(key) ?? [];
+    queue.push(work);
+    this.queues.set(key, queue);
+    const worker = this.drain(key);
+    this.workers.set(key, worker);
+    return "ran";
+  }
+
+  private async drain(key: string): Promise<void> {
+    const queue = this.queues.get(key);
+    while (queue && queue.length > 0) {
+      const work = queue.shift()!;
+      try {
+        await work();
+      } catch (err) {
+        this.onLog(
+          `inflight-queue work failed for ${key}: ${(err as Error).message}`,
+        );
+      }
+    }
+    this.queues.delete(key);
+    this.workers.delete(key);
+  }
+
+  /** Number of items currently QUEUED (not counting the running one). */
+  depth(key: string): number {
+    return this.queues.get(key)?.length ?? 0;
+  }
+
+  /** Is there a worker actively running for this key? */
+  busy(key: string): boolean {
+    return this.workers.has(key);
+  }
+
+  /** Wait until the worker for `key` drains. Useful for graceful shutdown
+   *  and for tests that need to observe post-drain state. */
+  async waitIdle(key: string): Promise<void> {
+    const worker = this.workers.get(key);
+    if (worker) await worker;
+  }
+
+  /** Wait for all currently-active workers across every key. Tests call
+   *  this between an `emit` and the assert; production callers can use
+   *  it on graceful shutdown to let in-flight LLM rounds complete. */
+  async waitForAll(): Promise<void> {
+    const workers = Array.from(this.workers.values());
+    await Promise.all(workers);
+  }
+}

--- a/packages/cli/test/harness/slack-fakes.ts
+++ b/packages/cli/test/harness/slack-fakes.ts
@@ -281,6 +281,14 @@ export interface Harness {
   home: string;
   /** Restores `$HOME` and removes the tmp dir. Idempotent. */
   cleanup: () => void;
+  /**
+   * v0.13: wait until every background InFlightQueue worker drains.
+   * The handlers enqueue work and return immediately (production-shape
+   * fire-and-forget so Slack envelope ack stays under 3s); tests need
+   * to await this after `socket.emit(...)` before asserting on side-
+   * effects like `web.posted` or LLM call counts.
+   */
+  flush: () => Promise<void>;
 }
 
 export interface BuildHarnessOptions {
@@ -336,6 +344,7 @@ export function buildHarness(opts: BuildHarnessOptions = {}): Harness {
     llm,
     mra,
     home,
+    flush: () => adapter.waitForPending(),
     cleanup: () => {
       if (restored) return;
       restored = true;

--- a/packages/cli/test/inflight-queue.test.ts
+++ b/packages/cli/test/inflight-queue.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit coverage for the v0.13 InFlightQueue. Adapter-level
+ * integration tests live in `slack-adapter.test.ts`; this file
+ * pins the queue's contract in isolation.
+ */
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import {
+  DEFAULT_MAX_DEPTH,
+  InFlightQueue,
+  QueueFullError,
+} from "../src/gateway/slack/inflight-queue";
+
+/** Build a controllable async work fn: returns the fn + resolver. */
+function gateWork(): {
+  fn: () => Promise<void>;
+  release: () => void;
+  ran: { count: number };
+} {
+  let resolveGate: () => void = () => {};
+  const gate = new Promise<void>((res) => {
+    resolveGate = res;
+  });
+  const ran = { count: 0 };
+  return {
+    fn: async () => {
+      ran.count++;
+      await gate;
+    },
+    release: () => resolveGate(),
+    ran,
+  };
+}
+
+describe("InFlightQueue: enqueue contract", () => {
+  it("enqueue on empty key runs immediately", () => {
+    const q = new InFlightQueue();
+    const w = gateWork();
+    const result = q.enqueue("k", w.fn);
+    assert.equal(result, "ran");
+    w.release();
+  });
+
+  it("enqueue while worker active returns 'queued'", async () => {
+    const q = new InFlightQueue();
+    const w1 = gateWork();
+    const w2 = gateWork();
+    assert.equal(q.enqueue("k", w1.fn), "ran");
+    // Let w1 enter its first await so the worker is observably active.
+    await new Promise((res) => setImmediate(res));
+    assert.equal(q.enqueue("k", w2.fn), "queued");
+    w1.release();
+    w2.release();
+    await q.waitIdle("k");
+  });
+
+  it("queue at maxDepth throws QueueFullError", async () => {
+    const q = new InFlightQueue({ maxDepth: 2 });
+    const w = gateWork();
+    q.enqueue("k", w.fn); // ran
+    await new Promise((res) => setImmediate(res));
+    q.enqueue("k", async () => {}); // queued depth=1
+    q.enqueue("k", async () => {}); // queued depth=2
+    assert.throws(
+      () => q.enqueue("k", async () => {}),
+      (err: unknown) => {
+        if (!(err instanceof QueueFullError)) return false;
+        assert.equal(err.key, "k");
+        assert.equal(err.depth, 2);
+        return true;
+      },
+    );
+    w.release();
+    await q.waitIdle("k");
+  });
+
+  it("default maxDepth is 3", async () => {
+    const q = new InFlightQueue();
+    const w = gateWork();
+    q.enqueue("k", w.fn);
+    await new Promise((res) => setImmediate(res));
+    // Queue 3 — at cap.
+    q.enqueue("k", async () => {});
+    q.enqueue("k", async () => {});
+    q.enqueue("k", async () => {});
+    assert.equal(q.depth("k"), 3);
+    // 4th overflows.
+    assert.throws(() => q.enqueue("k", async () => {}), QueueFullError);
+    assert.equal(DEFAULT_MAX_DEPTH, 3);
+    w.release();
+    await q.waitIdle("k");
+  });
+});
+
+describe("InFlightQueue: FIFO order", () => {
+  it("queued work runs in submission order after drain", async () => {
+    const q = new InFlightQueue();
+    const order: number[] = [];
+    let releaseFirst: () => void = () => {};
+    const gate = new Promise<void>((res) => {
+      releaseFirst = res;
+    });
+
+    q.enqueue("k", async () => {
+      await gate;
+      order.push(1);
+    });
+    await new Promise((res) => setImmediate(res));
+    q.enqueue("k", async () => {
+      order.push(2);
+    });
+    q.enqueue("k", async () => {
+      order.push(3);
+    });
+
+    releaseFirst();
+    await q.waitIdle("k");
+
+    assert.deepEqual(order, [1, 2, 3]);
+  });
+});
+
+describe("InFlightQueue: different keys are independent", () => {
+  it("two keys' workers run in parallel; one key's queue full doesn't affect the other", async () => {
+    const q = new InFlightQueue({ maxDepth: 1 });
+    const wa = gateWork();
+    const wb = gateWork();
+    assert.equal(q.enqueue("a", wa.fn), "ran");
+    assert.equal(q.enqueue("b", wb.fn), "ran");
+    await new Promise((res) => setImmediate(res));
+    // Key "a" can take 1 more; key "b" can take 1 more — independently.
+    assert.equal(q.enqueue("a", async () => {}), "queued");
+    assert.equal(q.enqueue("b", async () => {}), "queued");
+    // Now both keys at cap — adding to either throws.
+    assert.throws(() => q.enqueue("a", async () => {}), QueueFullError);
+    assert.throws(() => q.enqueue("b", async () => {}), QueueFullError);
+    wa.release();
+    wb.release();
+    await q.waitForAll();
+    assert.equal(q.busy("a"), false);
+    assert.equal(q.busy("b"), false);
+  });
+});
+
+describe("InFlightQueue: error handling", () => {
+  it("a throwing work item doesn't poison the rest of the queue", async () => {
+    const logs: string[] = [];
+    const q = new InFlightQueue({ onLog: (m) => logs.push(m) });
+    const order: number[] = [];
+
+    q.enqueue("k", async () => {
+      throw new Error("boom");
+    });
+    q.enqueue("k", async () => {
+      order.push(2);
+    });
+    q.enqueue("k", async () => {
+      order.push(3);
+    });
+
+    await q.waitIdle("k");
+
+    assert.deepEqual(order, [2, 3]);
+    assert.equal(logs.length, 1);
+    assert.match(logs[0], /boom/);
+  });
+});
+
+describe("InFlightQueue: waitForAll", () => {
+  it("resolves when every active key drains", async () => {
+    const q = new InFlightQueue();
+    const wa = gateWork();
+    const wb = gateWork();
+    q.enqueue("a", wa.fn);
+    q.enqueue("b", wb.fn);
+    await new Promise((res) => setImmediate(res));
+    assert.equal(q.busy("a"), true);
+    assert.equal(q.busy("b"), true);
+    wa.release();
+    wb.release();
+    await q.waitForAll();
+    assert.equal(q.busy("a"), false);
+    assert.equal(q.busy("b"), false);
+  });
+
+  it("resolves immediately when nothing is running", async () => {
+    const q = new InFlightQueue();
+    await q.waitForAll();
+    assert.equal(q.busy("anything"), false);
+  });
+});

--- a/packages/cli/test/inflight-queue.test.ts
+++ b/packages/cli/test/inflight-queue.test.ts
@@ -164,6 +164,31 @@ describe("InFlightQueue: error handling", () => {
     assert.equal(logs.length, 1);
     assert.match(logs[0], /boom/);
   });
+
+  it("a throwing onLog doesn't leak worker/queue state for the key", async () => {
+    // Defends the drain() finally-block invariant — if cleanup ran in
+    // the happy path only, an onLog explosion would leave the key
+    // permanently "busy" and lock the user out forever.
+    const q = new InFlightQueue({
+      onLog: () => {
+        throw new Error("logger blew up");
+      },
+    });
+    q.enqueue("k", async () => {
+      throw new Error("work blew up — triggers onLog");
+    });
+    await q.waitIdle("k");
+    assert.equal(q.busy("k"), false, "worker map cleared even if onLog threw");
+    assert.equal(q.depth("k"), 0, "queue map cleared even if onLog threw");
+    // Subsequent enqueue under the same key must run, not be blocked
+    // by stale `workers.has(key) === true`.
+    let secondRan = false;
+    q.enqueue("k", async () => {
+      secondRan = true;
+    });
+    await q.waitIdle("k");
+    assert.equal(secondRan, true, "post-recovery enqueue runs cleanly");
+  });
 });
 
 describe("InFlightQueue: waitForAll", () => {

--- a/packages/cli/test/slack-adapter.test.ts
+++ b/packages/cli/test/slack-adapter.test.ts
@@ -66,6 +66,7 @@ describe("SlackAdapter integration: DM happy-path", () => {
         text: "What is this PRD about?",
       }),
     );
+    await h.flush();
 
     assert.equal(h.llm.calls.length, 1, "LLM should be called once");
 
@@ -104,6 +105,7 @@ describe("SlackAdapter integration: DM happy-path", () => {
         text: "hello bot",
       }),
     );
+    await h.flush();
 
     assert.equal(h.llm.calls.length, 0, "channel-scope message must skip LLM");
     assert.equal(h.web.updated.length, 0, "no update should fire");
@@ -126,6 +128,7 @@ describe("SlackAdapter integration: DM happy-path", () => {
         text: "let me in",
       }),
     );
+    await h.flush();
 
     assert.equal(h.llm.calls.length, 0);
     const posts = h.web.postsTo("D-BAD-DM");
@@ -174,6 +177,7 @@ describe("SlackAdapter integration: mra-ask escalate round", () => {
         text: "where is sales_performances defined?",
       }),
     );
+    await h.flush();
 
     assert.equal(h.llm.calls.length, 2, "first-call + synthesise = 2 LLM calls");
     assert.equal(h.mra.askCalls.length, 1, "mra ask invoked exactly once");
@@ -209,6 +213,7 @@ describe("SlackAdapter integration: mra-ask escalate round", () => {
         text: "where is X?",
       }),
     );
+    await h.flush();
 
     assert.equal(h.mra.askCalls.length, 0, "doctor short-circuits before runAsk");
     assert.equal(
@@ -242,6 +247,7 @@ describe("SlackAdapter integration: mra-ask escalate round", () => {
         text: "where is X?",
       }),
     );
+    await h.flush();
 
     assert.equal(h.mra.askCalls.length, 1);
     assert.equal(h.llm.calls.length, 2, "synthesise still runs after mra failure");
@@ -273,6 +279,7 @@ describe("SlackAdapter integration: channel @-mention", () => {
         text: "<@UBOTID> what does this module do?",
       }),
     );
+    await h.flush();
 
     assert.equal(h.llm.calls.length, 1);
     // Bot-mention prefix is stripped before reaching the LLM.
@@ -329,6 +336,7 @@ describe("SlackAdapter integration: channel @-mention", () => {
         text: "<@UBOTID> any theories on root cause?",
       }),
     );
+    await h.flush();
 
     assert.equal(h.llm.calls.length, 1, "case path uses one LLM call");
 
@@ -395,6 +403,7 @@ describe("SlackAdapter integration: /pmk admin slash command", () => {
         text: "admin audience set <@UOTHER> exec",
       }),
     );
+    await h.flush();
 
     // Config now persists the per-user override.
     const after = loadGatewayConfig();
@@ -426,6 +435,7 @@ describe("SlackAdapter integration: /pmk admin slash command", () => {
         text: "admin audience set <@UVICTIM> biz",
       }),
     );
+    await h.flush();
 
     const after = loadGatewayConfig();
     assert.equal(
@@ -454,6 +464,7 @@ describe("SlackAdapter integration: /pmk admin slash command", () => {
         text: "admin audience set <@UOTHER> biz",
       }),
     );
+    await h.flush();
 
     const after = loadGatewayConfig();
     assert.equal(after.audience.users["UOTHER"], undefined);
@@ -520,6 +531,7 @@ describe("SlackAdapter integration: reaction-based atom approval", () => {
         itemTs: messageTs,
       }),
     );
+    await h.flush();
 
     // Atom flipped to approved on disk.
     const after = loadAtoms({ promote: false });
@@ -552,6 +564,7 @@ describe("SlackAdapter integration: reaction-based atom approval", () => {
         itemTs: messageTs,
       }),
     );
+    await h.flush();
 
     // Atom file removed from disk.
     const after = loadAtoms({ promote: false });
@@ -582,6 +595,7 @@ describe("SlackAdapter integration: reaction-based atom approval", () => {
         itemTs: messageTs,
       }),
     );
+    await h.flush();
 
     const after = loadAtoms({ promote: false });
     assert.equal(after.length, 1);
@@ -609,6 +623,7 @@ describe("SlackAdapter integration: reaction-based atom approval", () => {
         itemTs: "1700000999.999999",
       }),
     );
+    await h.flush();
 
     // No findAtomByApprovalMessage match → return early; no posts, no
     // atom mutation.
@@ -780,6 +795,7 @@ describe("SlackAdapter integration: msg_too_long hardening (v0.11.1)", () => {
         text: "and what about the reports table?",
       }),
     );
+    await h.flush();
 
     assert.equal(
       h.llm.calls.length,
@@ -820,6 +836,7 @@ describe("SlackAdapter integration: msg_too_long hardening (v0.11.1)", () => {
         text: "another huge follow-up",
       }),
     );
+    await h.flush();
 
     assert.equal(h.llm.calls.length, 2);
     const finalText = h.web.updated[h.web.updated.length - 1].text ?? "";
@@ -844,6 +861,7 @@ describe("SlackAdapter integration: msg_too_long hardening (v0.11.1)", () => {
         text: "hello",
       }),
     );
+    await h.flush();
 
     assert.equal(
       h.llm.calls.length,
@@ -887,7 +905,9 @@ describe("SlackAdapter integration: envelope dedup", () => {
       envelope_id: "env-dupe-12345",
     });
     await h.socket.emit("message", payload);
+    await h.flush();
     await h.socket.emit("message", payload);
+    await h.flush();
 
     assert.equal(
       h.llm.calls.length,
@@ -911,6 +931,7 @@ describe("SlackAdapter integration: envelope dedup", () => {
         retry_num: 1,
       }),
     );
+    await h.flush();
 
     assert.equal(h.llm.calls.length, 0, "retry_num>0 envelopes are dropped");
     assert.equal(h.web.posted.length, 0, "no placeholder, no anything");
@@ -927,7 +948,9 @@ describe("SlackAdapter integration: envelope dedup", () => {
       envelope_id: "env-mention-dupe",
     });
     await h.socket.emit("app_mention", payload);
+    await h.flush();
     await h.socket.emit("app_mention", payload);
+    await h.flush();
 
     assert.equal(h.llm.calls.length, 1);
     assert.equal(h.web.updated.length, 1);
@@ -948,7 +971,9 @@ describe("SlackAdapter integration: envelope dedup", () => {
       envelope_id: "env-slash-dupe",
     });
     await h.socket.emit("slash_commands", payload);
+    await h.flush();
     await h.socket.emit("slash_commands", payload);
+    await h.flush();
 
     // The admin-log row is the cleanest "did the handler actually run"
     // signal — and there should be exactly one even after two deliveries.
@@ -958,7 +983,7 @@ describe("SlackAdapter integration: envelope dedup", () => {
   });
 });
 
-describe("SlackAdapter integration: channel inFlight lock (v0.13)", () => {
+describe("SlackAdapter integration: inflight queue (v0.13)", () => {
   let h: Harness;
 
   beforeEach(() => {
@@ -970,8 +995,6 @@ describe("SlackAdapter integration: channel inFlight lock (v0.13)", () => {
   });
 
   it("different users in same channel run concurrently (per-user-per-channel key)", async () => {
-    // First scripted reply waits on a gate so we can fire a second
-    // @-mention while the first is still in flight.
     let releaseFirst: () => void = () => {};
     const firstGate = new Promise<void>((resolve) => {
       releaseFirst = resolve;
@@ -987,65 +1010,67 @@ describe("SlackAdapter integration: channel inFlight lock (v0.13)", () => {
 
     await h.adapter.start();
 
-    const p1 = h.socket.emit(
+    // Both emits are fire-and-forget (handlers enqueue + return fast).
+    void h.socket.emit(
       "app_mention",
       appMentionPayload({
         user: "U-ALICE",
         channel: "C-QA",
-        text: "<@UBOTID> what does this scope do?",
+        text: "<@UBOTID> alice prompt",
         envelope_id: "env-alice",
       }),
     );
-
-    // Let p1 reach its llm.chat() await and acquire its
-    // `${channel}:${user}` inFlight key.
+    // Yield so alice's worker reaches the gated llm.chat() before we
+    // queue bob.
     await new Promise((res) => setImmediate(res));
-
-    // Different user, same channel — should NOT be blocked by the
-    // pre-v0.13 channel-wide lock.
-    await h.socket.emit(
+    void h.socket.emit(
       "app_mention",
       appMentionPayload({
         user: "U-BOB",
         channel: "C-QA",
-        text: "<@UBOTID> separate question",
+        text: "<@UBOTID> bob prompt",
         envelope_id: "env-bob",
       }),
     );
+    // Let bob's worker start and reach its own llm.chat() (different
+    // queue key from alice, so it runs in parallel).
+    await new Promise((res) => setImmediate(res));
 
-    // Bob's path completed (synthesised reply landed); Alice still
-    // awaiting the gate. Both LLM calls happened.
-    assert.equal(h.llm.calls.length, 2);
-
-    // No busy notice was posted (the previous behaviour would have
-    // dropped Bob's request with `:hourglass: 已有訊息在處理中`).
-    const busy = h.web.posted.find((p) =>
-      p.text?.includes("還在處理"),
+    assert.equal(
+      h.llm.calls.length,
+      2,
+      "both workers should be in flight (different queue keys)",
     );
-    assert.equal(busy, undefined, "no busy notice for different users");
 
-    // Release Alice so the test can finish cleanly.
+    // No busy / queued notice was posted (different users → different
+    // queues → no contention).
+    const contention = h.web.posted.find((p) =>
+      /還在處理|排隊中/.test(p.text ?? ""),
+    );
+    assert.equal(contention, undefined, "no queue notice for different users");
+
     releaseFirst();
-    await p1;
+    await h.flush();
 
-    // Both placeholders → both final updates.
-    assert.equal(h.web.updated.length, 2);
+    assert.equal(h.web.updated.length, 2, "both final updates fire");
   });
 
-  it("same user double-tap in same channel → second blocked with busy notice", async () => {
+  it("same user double-tap in same channel → second QUEUED, both processed in order", async () => {
     let releaseFirst: () => void = () => {};
     const firstGate = new Promise<void>((resolve) => {
       releaseFirst = resolve;
     });
-
-    h.llm.script(async () => {
-      await firstGate;
-      return "first answer";
-    });
+    h.llm.script(
+      async () => {
+        await firstGate;
+        return "first answer";
+      },
+      "second answer",
+    );
 
     await h.adapter.start();
 
-    const p1 = h.socket.emit(
+    void h.socket.emit(
       "app_mention",
       appMentionPayload({
         user: "U-ALICE",
@@ -1054,13 +1079,9 @@ describe("SlackAdapter integration: channel inFlight lock (v0.13)", () => {
         envelope_id: "env-alice-1",
       }),
     );
-
-    // Let p1 acquire its inFlight key before the second emit checks.
     await new Promise((res) => setImmediate(res));
-
-    // Same user + same channel + different envelope_id (so dedup
-    // doesn't catch it first) → must be blocked by the per-user lock.
-    await h.socket.emit(
+    // Same user + same channel + different envelope → queued behind q1.
+    void h.socket.emit(
       "app_mention",
       appMentionPayload({
         user: "U-ALICE",
@@ -1069,25 +1090,113 @@ describe("SlackAdapter integration: channel inFlight lock (v0.13)", () => {
         envelope_id: "env-alice-2",
       }),
     );
+    await new Promise((res) => setImmediate(res));
 
     assert.equal(
       h.llm.calls.length,
       1,
-      "second tap from the same user must not start a parallel LLM round",
+      "second tap is queued; only q1's LLM call has started",
     );
-
-    const busy = h.web.posted.find((p) =>
-      p.text?.includes("還在處理"),
+    const queued = h.web.posted.find((p) =>
+      /排入隊伍/.test(p.text ?? ""),
     );
-    assert.ok(busy, "busy notice should fire on same-user double-tap");
-    assert.match(
-      busy!.text ?? "",
-      /你上一則訊息還在處理/,
-      "notice should call out THIS user's prior message, not the channel",
-    );
+    assert.ok(queued, "queued notice should fire when work is queued");
+    assert.match(queued!.text ?? "", /你上一則還在處理/);
 
     releaseFirst();
-    await p1;
+    await h.flush();
+
+    // Both turns processed in order.
+    assert.equal(
+      h.llm.calls.length,
+      2,
+      "after q1 drains, q2's LLM call fires",
+    );
+    assert.equal(h.web.updated.length, 2, "both final updates posted");
+  });
+
+  it("queue cap exceeded → rejection notice, work not enqueued", async () => {
+    let releaseFirst: () => void = () => {};
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    // Script enough replies for the running + 3 queued (cap default).
+    h.llm.script(
+      async () => {
+        await firstGate;
+        return "answer 1";
+      },
+      "answer 2",
+      "answer 3",
+      "answer 4",
+    );
+
+    await h.adapter.start();
+
+    // 1st fires immediately (runs).
+    void h.socket.emit(
+      "app_mention",
+      appMentionPayload({
+        user: "U-ALICE",
+        channel: "C-QA",
+        text: "<@UBOTID> q1",
+        envelope_id: "env-a1",
+      }),
+    );
+    await new Promise((res) => setImmediate(res));
+    // 2nd, 3rd, 4th queue behind (depth=1, 2, 3 — cap is 3 queued).
+    void h.socket.emit(
+      "app_mention",
+      appMentionPayload({
+        user: "U-ALICE",
+        channel: "C-QA",
+        text: "<@UBOTID> q2",
+        envelope_id: "env-a2",
+      }),
+    );
+    await new Promise((res) => setImmediate(res));
+    void h.socket.emit(
+      "app_mention",
+      appMentionPayload({
+        user: "U-ALICE",
+        channel: "C-QA",
+        text: "<@UBOTID> q3",
+        envelope_id: "env-a3",
+      }),
+    );
+    await new Promise((res) => setImmediate(res));
+    void h.socket.emit(
+      "app_mention",
+      appMentionPayload({
+        user: "U-ALICE",
+        channel: "C-QA",
+        text: "<@UBOTID> q4",
+        envelope_id: "env-a4",
+      }),
+    );
+    await new Promise((res) => setImmediate(res));
+    // 5th rejected — queue full.
+    void h.socket.emit(
+      "app_mention",
+      appMentionPayload({
+        user: "U-ALICE",
+        channel: "C-QA",
+        text: "<@UBOTID> q5 over cap",
+        envelope_id: "env-a5",
+      }),
+    );
+    await new Promise((res) => setImmediate(res));
+
+    const rejected = h.web.posted.find((p) =>
+      /上限.*3.*則/.test(p.text ?? ""),
+    );
+    assert.ok(rejected, "queue-full rejection notice should fire");
+
+    releaseFirst();
+    await h.flush();
+
+    // 4 LLM calls (q1 ran + q2/q3/q4 from queue) — q5 was rejected.
+    assert.equal(h.llm.calls.length, 4);
   });
 
   it("two users' concurrent turns both land in the channel-log (race-free persistence)", async () => {
@@ -1112,7 +1221,7 @@ describe("SlackAdapter integration: channel inFlight lock (v0.13)", () => {
 
     await h.adapter.start();
 
-    const p1 = h.socket.emit(
+    void h.socket.emit(
       "app_mention",
       appMentionPayload({
         user: "U-ALICE",
@@ -1121,10 +1230,8 @@ describe("SlackAdapter integration: channel inFlight lock (v0.13)", () => {
         envelope_id: "env-a",
       }),
     );
-
     await new Promise((res) => setImmediate(res));
-
-    await h.socket.emit(
+    void h.socket.emit(
       "app_mention",
       appMentionPayload({
         user: "U-BOB",
@@ -1133,9 +1240,10 @@ describe("SlackAdapter integration: channel inFlight lock (v0.13)", () => {
         envelope_id: "env-b",
       }),
     );
+    await new Promise((res) => setImmediate(res));
 
     releaseFirst();
-    await p1;
+    await h.flush();
 
     const entries = loadChannelTurns("C-LOG");
     const userTurns = entries.filter((e) => e.role === "user" && e.userId);

--- a/packages/cli/test/slack-adapter.test.ts
+++ b/packages/cli/test/slack-adapter.test.ts
@@ -1265,3 +1265,109 @@ describe("SlackAdapter integration: inflight queue (v0.13)", () => {
     assert.ok(assistantContents.some((c) => c.includes("bob answer")));
   });
 });
+
+describe("SlackAdapter integration: graceful shutdown drain (v0.13 #55)", () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    h = buildHarness();
+  });
+
+  afterEach(() => {
+    h.cleanup();
+  });
+
+  it("stop() awaits in-flight queue work before broadcasting offline", async () => {
+    let releaseLlm: () => void = () => {};
+    const llmGate = new Promise<void>((resolve) => {
+      releaseLlm = resolve;
+    });
+    h.llm.script(async () => {
+      await llmGate;
+      return "delayed answer";
+    });
+
+    await h.adapter.start();
+
+    void h.socket.emit(
+      "message",
+      dmMessagePayload({
+        user: "U-SHUTDOWN",
+        channel: "D-SHUTDOWN",
+        text: "ask before shutdown",
+      }),
+    );
+    // Yield so the queue worker actually starts and reaches its LLM await.
+    await new Promise((res) => setImmediate(res));
+
+    // stop() must NOT race ahead of the queued turn; resolve the LLM
+    // gate only after a short delay and prove stop() didn't return
+    // before the final placeholder update landed.
+    const stopStartedAt = Date.now();
+    let stopResolved = false;
+    const stopPromise = h.adapter.stop({ drainTimeoutMs: 5000 }).then(() => {
+      stopResolved = true;
+    });
+    // Tick to let stop() reach its drain-await; it must still be pending.
+    await new Promise((res) => setImmediate(res));
+    assert.equal(
+      stopResolved,
+      false,
+      "stop() must wait for in-flight queue work, not return immediately",
+    );
+    assert.equal(
+      h.web.updated.length,
+      0,
+      "placeholder is still the thinking spinner — LLM hasn't returned",
+    );
+
+    releaseLlm();
+    await stopPromise;
+    const elapsed = Date.now() - stopStartedAt;
+    assert.ok(elapsed < 5000, `stop() should resolve well before the timeout (took ${elapsed}ms)`);
+
+    assert.equal(
+      h.web.updated.length,
+      1,
+      "final placeholder update fired before stop() returned",
+    );
+    assert.match(h.web.updated[0].text ?? "", /delayed answer/);
+  });
+
+  it("stop() honours drainTimeoutMs and logs when in-flight work blows the budget", async () => {
+    const logs: string[] = [];
+    h.cleanup();
+    h = buildHarness({ onLog: (m) => logs.push(m) });
+    // Never released — simulates a stuck LLM round that would otherwise
+    // wedge SIGTERM until SIGKILL.
+    h.llm.script(async () => {
+      await new Promise<void>(() => {});
+      return "never";
+    });
+
+    await h.adapter.start();
+
+    void h.socket.emit(
+      "message",
+      dmMessagePayload({
+        user: "U-STUCK",
+        channel: "D-STUCK",
+        text: "stuck turn",
+      }),
+    );
+    await new Promise((res) => setImmediate(res));
+
+    const startedAt = Date.now();
+    await h.adapter.stop({ drainTimeoutMs: 80 });
+    const elapsed = Date.now() - startedAt;
+
+    assert.ok(
+      elapsed >= 70 && elapsed < 1500,
+      `stop() should resolve near the timeout (~80ms), got ${elapsed}ms`,
+    );
+    assert.ok(
+      logs.some((l) => /drain timed out after 80ms/.test(l)),
+      "shutdown should log the timeout so operators can see abandoned work",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Two coupled v0.13 deliverables on one branch:

1. **Tranche 3 free-chat extraction** — full turn orchestration (seed + retrieval + prune + LLM + mra-ask + escalate + reply) moves into 509-line \`FreeChatTurnRunner\`. Adapter **1411 → 962 → 1010 lines** (after tranche 3 + the queue refactor).
2. **FIFO inflight queue** — found during this PR's live-Slack verify: pre-v0.13 dropped rapid follow-up messages but posted a misleading "上一則訊息還在處理，請稍候" notice that implied queue semantics. Now actually queues FIFO (up to 3 deep).

## v0.13 split progression

| Stage | adapter | new modules | tests |
|---|---|---|---|
| pre-v0.13 | 1708 | (monolith) | 312 |
| tranche 1 (#52) | 1597 | presence + dedup + concurrency | 339 |
| tranche 2 (#54) | 1411 | escalation | 349 |
| **tranche 3 (this)** | **1010** | **free-chat-turn + inflight-queue** | **359** |

**Net: -698 lines (-41%) from baseline.** Tranche 4 (dispatcher cleanup) targets the remaining ~1010 → under the 800-line coding-style max.

## What changed

### \`free-chat-turn.ts\` (new, 509 lines)

\`FreeChatTurnRunner\` owns the full turn orchestration. Constructor takes \`{ web, config, onLog, llm, mraDoctor, runMraAsk, escalation }\`. Public \`run(args)\`; private \`handleMraAskRound\` + \`synthesiseAfterMra\`. \`FreeChatSession\` type moves alongside its only consumer.

### \`inflight-queue.ts\` (new, 134 lines)

\`InFlightQueue\` class. Per-key FIFO with bounded depth:

- \`enqueue(key, work)\` → \`"ran" | "queued"\` or throws \`QueueFullError\`.
- Per-key worker drains FIFO; throwing work doesn't poison the queue.
- \`waitForAll()\` / \`waitIdle(key)\` — test + graceful-shutdown drain.

### SlackAdapter changes

- Drops 3 free-chat methods (~420 lines) → into \`FreeChatTurnRunner\`.
- Drops 15+ imports now exclusive to free-chat-turn.
- Replaces \`private inFlight = new Set<string>()\` with \`private readonly queue: InFlightQueue\`. \`handleMessage\` + \`handleAppMention\` refactored: absorb-or-handle work captured in closure and passed to \`queue.enqueue\`. Handler returns fast (Slack ack stays well under 3s).
- New \`waitForPending()\` for graceful shutdown / test drain.

### Slack-side UX (queueing)

| Pre-v0.13 | Post-PR |
|---|---|
| \`:hourglass: 上一則訊息還在處理，請稍候。\` (dropped silently) | \`:hourglass: 你上一則還在處理，這則已排入隊伍（會依序處理）。\` (actually queued) |
| (no rejection notice) | \`:no_entry: 你已有多則訊息排隊中（上限 3 則），請等回覆後再發。\` (at queue cap) |

## Module map after this PR

| File | Lines | Purpose |
|---|---|---|
| \`slack/index.ts\` | **1010** | adapter, event handlers, DM/channel dispatcher, case-file path |
| \`slack/admin.ts\` | 539 | \`/pmk admin\` (since v0.9) |
| **\`slack/free-chat-turn.ts\`** | **509** | **NEW: turn orchestration** |
| \`slack/escalation.ts\` | 308 | tranche 2 |
| \`slack/presence.ts\` | 146 | tranche 1 |
| \`slack/context-retry.ts\` | 132 | v0.11.1 |
| **\`slack/inflight-queue.ts\`** | **134** | **NEW: FIFO queue** |
| \`slack/envelope-dedup.ts\` | 45 | tranche 1 |
| \`slack/concurrency.ts\` | 36 | tranche 1 |
| \`slack/progress.ts\` | 23 | v0.10 |

## Tests (359 pass / 0 fail; +10 net)

- **\`inflight-queue.test.ts\`** (new, 9 unit tests): enqueue contract (ran/queued/QueueFullError), default maxDepth=3, FIFO order under release, key independence, error isolation, waitForAll correctness.
- **\`slack-adapter.test.ts\`** channel inflight-queue suite rewritten for queue semantics: different users still parallel (no queue notice); same user double-tap now **queued** and both processed in order (was: blocked); NEW queue-cap-exceeded test.
- Harness gains \`flush()\` helper exposing \`adapter.waitForPending()\` — auto-injected into existing tests where emit was followed by sync assertion (work is now fire-and-forget; assertions need to wait for drain).

## Test plan

- [x] \`npm test\` from \`packages/cli\`: 359 pass / 0 fail.
- [x] \`npx tsc -p tsconfig.test.json\`: clean.
- [ ] Live-Slack verify: rapid-fire 3 messages from one user in a channel → all three get processed in order, you see the "排入隊伍" notice for messages 2 and 3. Send a 4th → "上限 3 則" rejection. Verify in another DM that different users in the same channel still run in parallel without queue notice.