### PR TITLE
chore(audio): non-blocking follow-ups (robustness, UX, coverage)

### DIFF
--- a/packages/cli/src/gateway/attachments/types.ts
+++ b/packages/cli/src/gateway/attachments/types.ts
@@ -63,6 +63,7 @@ export const AUDIO_CHUNK_TARGET_BYTES = 20 * 1024 * 1024; // 切片目標（留 
 export const TRANSCRIPT_CAP = 500_000;
 export const MAX_AUDIO_FILES_PER_MESSAGE = 2;
 
+/** Supported audio mimetypes accepted by the transcription pipeline. */
 export const AUDIO_MIMETYPES = new Set([
   "audio/mpeg", "audio/mp3", "audio/mp4", "audio/m4a", "audio/x-m4a",
   "audio/wav", "audio/x-wav", "audio/webm", "audio/ogg", "audio/flac", "audio/aac",

--- a/packages/cli/src/gateway/audio/coordinator.ts
+++ b/packages/cli/src/gateway/audio/coordinator.ts
@@ -354,7 +354,7 @@ export class AudioCoordinator {
           language: ac.language,
           maxDurationSec: ac.maxDurationSec,
         },
-        { outDir: tempDir, signal: controller.signal },
+        { outDir: tempDir, signal: controller.signal, knownDurationSec: probedDuration },
       );
 
       if (!result.ok) {

--- a/packages/cli/src/gateway/audio/quota.ts
+++ b/packages/cli/src/gateway/audio/quota.ts
@@ -14,7 +14,19 @@ function dayFile(now: number): string {
 
 function load(file: string): DayUsage {
   try {
-    return JSON.parse(fs.readFileSync(file, "utf8")) as DayUsage;
+    const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as DayUsage;
+    // Validate shape: guard against valid-JSON-but-wrong-type files that
+    // would make global/perUser arithmetic produce NaN and bypass caps.
+    if (!Number.isFinite(parsed.global) || typeof parsed.perUser !== "object" || parsed.perUser === null) {
+      return { global: 0, perUser: {} };
+    }
+    // Coerce each per-user value; drop non-finite entries.
+    const perUser: Record<string, number> = {};
+    for (const [k, v] of Object.entries(parsed.perUser)) {
+      const n = Number(v);
+      if (Number.isFinite(n)) perUser[k] = n;
+    }
+    return { global: Number(parsed.global), perUser };
   } catch {
     return { global: 0, perUser: {} };
   }

--- a/packages/cli/src/gateway/audio/spawn.ts
+++ b/packages/cli/src/gateway/audio/spawn.ts
@@ -23,6 +23,7 @@ export async function runMedia(
     const child = spawn(bin, args, { stdio: ["ignore", "pipe", "pipe"], env, signal: opts.signal });
     let stdout = "", stderr = "";
     const timer = setTimeout(() => { try { child.kill("SIGTERM"); } catch { /* noop */ } }, timeoutMs);
+    timer.unref(); // don't keep the event loop alive if the child exits early
     child.stdout?.on("data", (d) => { stdout += d.toString(); });
     child.stderr?.on("data", (d) => { stderr += d.toString(); });
     child.on("error", (e) => { clearTimeout(timer); reject(new MediaError(`${bin} spawn failed: ${e.message}`)); });

--- a/packages/cli/src/gateway/audio/summarize.ts
+++ b/packages/cli/src/gateway/audio/summarize.ts
@@ -9,15 +9,25 @@ const LONG_PROMPT =
 const SHORT_PROMPT =
   "你是 PM 助理。這是一段簡短語音。用繁體中文台灣用語給 1-2 句重點摘要,再問一句使用者想拿它做什麼。不要套用冗長模板。";
 
+/** Per-tier tone clause appended to the base system prompt. */
+const TIER_TONE: Record<string, string> = {
+  tech: "語氣簡潔技術性,省略背景說明,直接列重點與結論。",
+  pm: "聚焦決策、行動項目與需求,結構清晰。",
+  biz: "強調成果與影響,避免技術術語,適合業務利害關係人閱讀。",
+  exec: "強調成果與影響,避免技術術語,適合業務利害關係人閱讀。",
+};
+
 export async function summarizeMeeting(args: {
   transcript: string; durationSec: number; userInstruction?: string; tier: string; llm: LlmProvider; actor?: string;
 }): Promise<{ text: string; mode: "short" | "long" | "instructed" }> {
   const mode: "short" | "long" | "instructed" =
     args.userInstruction ? "instructed" : args.durationSec < 120 ? "short" : "long";
-  const system =
+  const baseSystem =
     mode === "instructed"
       ? `你是 PM 助理,依使用者指令處理逐字稿,用繁體中文台灣用語回答。使用者指令:${args.userInstruction}`
       : mode === "short" ? SHORT_PROMPT : LONG_PROMPT;
+  const tierTone = TIER_TONE[args.tier] ?? "";
+  const system = tierTone ? `${baseSystem} ${tierTone}` : baseSystem;
   const user = `${TRANSCRIPT_FRAME_HEADER}\n\n${args.transcript}`;
   const messages: ChatMessage[] = [{ role: "user", content: user }];
   const text = await args.llm.chat(system, messages, { actor: args.actor });

--- a/packages/cli/src/gateway/audio/transcribe-client.ts
+++ b/packages/cli/src/gateway/audio/transcribe-client.ts
@@ -12,7 +12,7 @@ const ENDPOINT = "https://api.openai.com/v1/audio/transcriptions";
 export async function transcribeFile(
   filePath: string,
   opts: { apiKey: string; model: string; language?: string },
-  deps: { fetchImpl?: typeof fetch; readStream?: (p: string) => unknown } = {},
+  deps: { fetchImpl?: typeof fetch; readStream?: (p: string) => unknown; signal?: AbortSignal } = {},
 ): Promise<string> {
   const fetchImpl = deps.fetchImpl ?? fetch;
   const bytes = deps.readStream ? deps.readStream(filePath) : fs.readFileSync(filePath);
@@ -23,7 +23,7 @@ export async function transcribeFile(
 
   let resp: Response;
   try {
-    resp = await fetchImpl(ENDPOINT, { method: "POST", headers: { Authorization: `Bearer ${opts.apiKey}` }, body: form as never });
+    resp = await fetchImpl(ENDPOINT, { method: "POST", headers: { Authorization: `Bearer ${opts.apiKey}` }, body: form as never, signal: deps.signal });
   } catch (err) {
     throw new TranscribeError(`network error: ${(err as Error).message}`);
   }

--- a/packages/cli/src/gateway/audio/transcribe-client.ts
+++ b/packages/cli/src/gateway/audio/transcribe-client.ts
@@ -25,6 +25,7 @@ export async function transcribeFile(
   try {
     resp = await fetchImpl(ENDPOINT, { method: "POST", headers: { Authorization: `Bearer ${opts.apiKey}` }, body: form as never, signal: deps.signal });
   } catch (err) {
+    if ((err as { name?: string }).name === "AbortError") throw err; // propagate abort immediately
     throw new TranscribeError(`network error: ${(err as Error).message}`);
   }
   if (!resp.ok) {

--- a/packages/cli/src/gateway/audio/transcribe.ts
+++ b/packages/cli/src/gateway/audio/transcribe.ts
@@ -31,6 +31,7 @@ async function withRetry(
     try {
       return await fn();
     } catch (err) {
+      if (!(err instanceof TranscribeError)) throw err;
       lastErr = err;
       const status = err instanceof TranscribeError ? err.status : undefined;
       // Terminal: 4xx errors OTHER than 429 (e.g. 400 Bad Request, 401 Unauthorized)
@@ -73,7 +74,8 @@ export async function transcribeAudio(
         sleep,
       );
       segs.push(text);
-    } catch {
+    } catch (err) {
+      if (!(err instanceof TranscribeError)) throw err;
       const partial =
         (segs.length > 0 ? segs.join("\n") + "\n" : "") +
         `[第 ${i + 1} 段轉錄失敗，回 retry 重跑此段]`;

--- a/packages/cli/src/gateway/audio/transcribe.ts
+++ b/packages/cli/src/gateway/audio/transcribe.ts
@@ -15,6 +15,8 @@ export interface TranscribeDeps {
   sleep?: (ms: number) => Promise<void>;
   outDir?: string;
   signal?: AbortSignal;
+  /** Skip the internal probe() call and use this duration directly. */
+  knownDurationSec?: number;
 }
 
 const truncate = (s: string): string =>
@@ -34,8 +36,8 @@ async function withRetry(
       // Terminal: 4xx errors OTHER than 429 (e.g. 400 Bad Request, 401 Unauthorized)
       // Retryable: 429 (rate-limit), any 5xx (transient server error), network errors (no status)
       if (status !== undefined && status >= 400 && status < 500 && status !== 429) throw err;
-      // Exponential backoff before next attempt
-      await sleep(500 * Math.pow(2, attempt));
+      // Exponential backoff before next attempt — only when another attempt will follow.
+      if (attempt < 2) await sleep(500 * Math.pow(2, attempt));
     }
   }
   throw lastErr;
@@ -52,7 +54,10 @@ export async function transcribeAudio(
   const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
   const outDir = deps.outDir ?? os.tmpdir();
 
-  const { durationSec } = await probe(inputPath, {});
+  const { durationSec } =
+    deps.knownDurationSec !== undefined
+      ? { durationSec: deps.knownDurationSec }
+      : await probe(inputPath, {});
   const maxAllowed = Math.min(cfg.maxDurationSec, MAX_AUDIO_DURATION_SEC);
   if (durationSec > maxAllowed) {
     return { ok: false, reason: "too-long", durationSec };
@@ -64,7 +69,7 @@ export async function transcribeAudio(
   for (let i = 0; i < chunks.length; i++) {
     try {
       const text = await withRetry(
-        () => tf(chunks[i], { apiKey: cfg.apiKey, model: cfg.model, language: cfg.language }),
+        () => tf(chunks[i], { apiKey: cfg.apiKey, model: cfg.model, language: cfg.language }, { signal: deps.signal }),
         sleep,
       );
       segs.push(text);

--- a/packages/cli/src/gateway/slack/channel-mention.ts
+++ b/packages/cli/src/gateway/slack/channel-mention.ts
@@ -137,7 +137,7 @@ export class ChannelMentionHandler {
         const tier = this.config
           ? pickAudience(this.config, userId, channelId)
           : "tech";
-        if (needsConsentNotice(channelId)) {
+        if (needsConsentNotice(`${channelId}:${userId}`)) {
           await this.web.chat
             .postMessage({
               channel: channelId,

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -716,6 +716,12 @@ export class SlackAdapter {
           .catch((err) =>
             this.onLog(`review: mention retry failed: ${(err as Error).message}`),
           );
+      } else {
+        // Neither audio nor review owns this thread: inform the user instead
+        // of silently dropping the bare retry.
+        await this.web.chat
+          .postMessage({ channel: channelId, thread_ts: replyThreadTs, text: "這個 thread 沒有可重試的音訊或 PR review。" })
+          .catch(() => {});
       }
       return;
     }
@@ -858,6 +864,12 @@ export class SlackAdapter {
           .catch((err) =>
             this.onLog(`review: DM retry failed: ${(err as Error).message}`),
           );
+      } else {
+        // Neither audio nor review owns this thread: inform the user instead
+        // of silently dropping the bare retry.
+        await this.web.chat
+          .postMessage({ channel: channelId, thread_ts: threadTs, text: "這個 thread 沒有可重試的音訊或 PR review。" })
+          .catch(() => {});
       }
       return;
     }
@@ -868,7 +880,7 @@ export class SlackAdapter {
     if (this.audio.isEnabled() && isAudioMessage(files ?? [])) {
       const botToken = this.config.slack.botToken ?? "";
       const tier = pickAudience(this.config, userId);
-      if (needsConsentNotice(channelId)) {
+      if (needsConsentNotice(`${channelId}:${userId}`)) {
         await this.web.chat
           .postMessage({
             channel: channelId,

--- a/packages/cli/test/audio-download-stream.test.ts
+++ b/packages/cli/test/audio-download-stream.test.ts
@@ -31,4 +31,17 @@ describe("streamSlackFileToTemp", () => {
     await assert.rejects(() => streamSlackFileToTemp(f({ size: 1 }), "t", dest, { fetchImpl: (async () => resp("X".repeat(100))) as never, maxBytes: 10 }));
     assert.equal(fs.existsSync(dest), false);
   });
+  it("rejects before fetching when file.size exceeds maxBytes (metadata pre-check)", async () => {
+    let fetched = false;
+    await assert.rejects(
+      () => streamSlackFileToTemp(
+        f({ size: 500 }),
+        "t",
+        path.join(tmp, "precheck"),
+        { fetchImpl: (async () => { fetched = true; return resp(""); }) as never, maxBytes: 100 },
+      ),
+      /exceeds size limit/,
+    );
+    assert.equal(fetched, false, "fetch must not be called when file.size already exceeds maxBytes");
+  });
 });

--- a/packages/cli/test/audio-events.test.ts
+++ b/packages/cli/test/audio-events.test.ts
@@ -13,6 +13,9 @@ describe("audio.* events round-trip", () => {
   afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); if (ORIG) process.env.HOME = ORIG; });
 
   it("writes and reads audio.transcribed/summarized/failed", () => {
+    // `as never` casts below are TDD-RED-phase artifacts: audio event types are
+    // not yet registered in the shared GatewayEvent union, so we cast to bypass
+    // TS until the union is extended in a follow-up.
     appendGatewayEvent({ type: "audio.transcribed", actor: "U1", durationSec: 600, chunks: 1, ms: 1234, estimatedUsd: 0.06 } as never);
     appendGatewayEvent({ type: "audio.summarized", actor: "U1", mode: "long" } as never);
     appendGatewayEvent({ type: "audio.failed", actor: "U1", reason: "transcribe-failed" } as never);

--- a/packages/cli/test/audio-probe.test.ts
+++ b/packages/cli/test/audio-probe.test.ts
@@ -14,4 +14,18 @@ describe("probeAudio", () => {
   it("throws on unparseable output", async () => {
     await assert.rejects(() => probeAudio("/tmp/x.ogg", { run: fakeRun("not json") as never }));
   });
+  it("rejects when duration is zero (ffprobe reports no audio)", async () => {
+    const json = JSON.stringify({ format: { duration: "0", size: "1048576" } });
+    await assert.rejects(
+      () => probeAudio("/tmp/x.ogg", { run: fakeRun(json) as never }),
+      /no duration/,
+    );
+  });
+  it("rejects when duration field is missing from ffprobe output", async () => {
+    const json = JSON.stringify({ format: { size: "1048576" } });
+    await assert.rejects(
+      () => probeAudio("/tmp/x.ogg", { run: fakeRun(json) as never }),
+      /no duration/,
+    );
+  });
 });

--- a/packages/cli/test/audio-routing.test.ts
+++ b/packages/cli/test/audio-routing.test.ts
@@ -27,4 +27,21 @@ describe("audio routing helpers", () => {
       else delete process.env.HOME;
     }
   });
+
+  it("needsConsentNotice is per-user (different users in same channel each get the notice)", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-cn-"));
+    process.env.HOME = tmp;
+    try {
+      // User A in channel C1: first call → true (needs notice)
+      assert.equal(needsConsentNotice("C1:UA"), true);
+      // User A in channel C1: second call → false (already seen)
+      assert.equal(needsConsentNotice("C1:UA"), false);
+      // User B in channel C1: first call → true (different user, hasn't seen notice yet)
+      assert.equal(needsConsentNotice("C1:UB"), true);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+      if (ORIG_HOME) process.env.HOME = ORIG_HOME;
+      else delete process.env.HOME;
+    }
+  });
 });

--- a/packages/cli/test/audio-summarize.test.ts
+++ b/packages/cli/test/audio-summarize.test.ts
@@ -24,4 +24,25 @@ describe("summarizeMeeting", () => {
     const r = await summarizeMeeting({ transcript: "x", durationSec: 3600, userInstruction: "幫我抓待辦", tier: "pm", llm: fakeLlm({}) });
     assert.equal(r.mode, "instructed");
   });
+
+  it("tech tier appends concise/technical tone to system prompt", async () => {
+    const cap: { system?: string } = {};
+    await summarizeMeeting({ transcript: "hi", durationSec: 3600, tier: "tech", llm: fakeLlm(cap) });
+    assert.ok((cap.system ?? "").includes("簡潔技術性"), `expected tech tone in system prompt, got: ${cap.system}`);
+  });
+
+  it("biz tier appends outcome/impact tone to system prompt", async () => {
+    const cap: { system?: string } = {};
+    await summarizeMeeting({ transcript: "hi", durationSec: 3600, tier: "biz", llm: fakeLlm(cap) });
+    assert.ok((cap.system ?? "").includes("成果與影響"), `expected biz tone in system prompt, got: ${cap.system}`);
+  });
+
+  it("unknown tier does not append any tone clause", async () => {
+    const cap: { system?: string } = {};
+    await summarizeMeeting({ transcript: "hi", durationSec: 3600, tier: "unknown_tier", llm: fakeLlm(cap) });
+    // None of the known tier-specific tone keywords should appear.
+    assert.ok(!(cap.system ?? "").includes("技術性"), "unexpected tech tone for unknown tier");
+    assert.ok(!(cap.system ?? "").includes("成果與影響"), "unexpected biz tone for unknown tier");
+    assert.ok(!(cap.system ?? "").includes("聚焦決策"), "unexpected pm tone for unknown tier");
+  });
 });

--- a/packages/cli/test/audio-temp-claim.test.ts
+++ b/packages/cli/test/audio-temp-claim.test.ts
@@ -62,4 +62,24 @@ describe("audio temp + claim", () => {
     assert.equal(claimAudio("FRESH_CLAIM"), false, "fresh claim should still be active");
     releaseAudio("FRESH_CLAIM");
   });
+
+  it("rethrows a non-EEXIST error from claimAudio (EACCES when dir is read-only)", () => {
+    // Make the claims directory non-writable so writeFileSync fails with EACCES
+    // (not EEXIST), which must be rethrown rather than silently returning false.
+    const claimsDir = path.join(tmp, ".pmk", "gateway", "audio-claims");
+    fs.mkdirSync(claimsDir, { recursive: true });
+    fs.chmodSync(claimsDir, 0o555);
+    try {
+      assert.throws(
+        () => claimAudio("NOPERM"),
+        (err: unknown) => {
+          const code = (err as NodeJS.ErrnoException).code;
+          assert.notEqual(code, "EEXIST", "non-EEXIST errors must be rethrown, not swallowed");
+          return true;
+        },
+      );
+    } finally {
+      fs.chmodSync(claimsDir, 0o700); // restore so afterEach can clean up
+    }
+  });
 });

--- a/packages/cli/test/audio-transcribe.test.ts
+++ b/packages/cli/test/audio-transcribe.test.ts
@@ -53,10 +53,12 @@ describe("transcribeAudio", () => {
     if (!r.ok) assert.equal(r.reason, "transcribe-failed");
   });
 
-  it("retries a plain network Error (no status) and succeeds on second attempt", async () => {
+  it("retries a wrapped network TranscribeError (no status) and succeeds on second attempt", async () => {
     let calls = 0;
+    // In real code transcribeFile wraps ECONNRESET → TranscribeError (no status).
+    // withRetry must retry those; raw non-TranscribeError are propagated immediately (see AbortError test).
     const tf = async () => {
-      if (calls++ === 0) throw new Error("ECONNRESET");
+      if (calls++ === 0) throw new TranscribeError("network error: ECONNRESET");
       return "net-seg";
     };
     const r = await transcribeAudio("/tmp/in.m4a", cfg, base({
@@ -65,6 +67,23 @@ describe("transcribeAudio", () => {
     }));
     assert.equal(r.ok, true);
     if (r.ok) assert.match(r.transcript, /net-seg/);
+  });
+
+  it("does not retry an AbortError — propagates immediately with a single transcribeFile call", async () => {
+    let calls = 0;
+    const tf = async () => {
+      calls++;
+      throw Object.assign(new Error("aborted"), { name: "AbortError" });
+    };
+    await assert.rejects(
+      () =>
+        transcribeAudio("/tmp/in.m4a", cfg, base({
+          prepare: (async () => ["/tmp/job/chunk-000.ogg"]) as never,
+          transcribeFile: tf as never,
+        })),
+      (err: unknown) => (err as Error).name === "AbortError",
+    );
+    assert.equal(calls, 1, "transcribeFile must be called exactly once — no retries on abort");
   });
 
   it("truncates a successful transcript longer than TRANSCRIPT_CAP", async () => {

--- a/packages/cli/test/audio-transcribe.test.ts
+++ b/packages/cli/test/audio-transcribe.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "node:test";
 import * as assert from "node:assert/strict";
 import { transcribeAudio } from "../src/gateway/audio/transcribe";
 import { TranscribeError } from "../src/gateway/audio/transcribe-client";
+import { TRANSCRIPT_CAP } from "../src/gateway/attachments/types";
 
 const cfg = { apiKey: "sk-x", model: "m", language: "zh", maxDurationSec: 7200 };
 const base = (over: Record<string, unknown> = {}) => ({
@@ -50,5 +51,33 @@ describe("transcribeAudio", () => {
     }));
     assert.equal(r.ok, false);
     if (!r.ok) assert.equal(r.reason, "transcribe-failed");
+  });
+
+  it("retries a plain network Error (no status) and succeeds on second attempt", async () => {
+    let calls = 0;
+    const tf = async () => {
+      if (calls++ === 0) throw new Error("ECONNRESET");
+      return "net-seg";
+    };
+    const r = await transcribeAudio("/tmp/in.m4a", cfg, base({
+      prepare: (async () => ["/tmp/job/chunk-000.ogg"]) as never,
+      transcribeFile: tf as never,
+    }));
+    assert.equal(r.ok, true);
+    if (r.ok) assert.match(r.transcript, /net-seg/);
+  });
+
+  it("truncates a successful transcript longer than TRANSCRIPT_CAP", async () => {
+    const longText = "a".repeat(TRANSCRIPT_CAP + 100);
+    const tf = async () => longText;
+    const r = await transcribeAudio("/tmp/in.m4a", cfg, base({
+      prepare: (async () => ["/tmp/job/chunk-000.ogg"]) as never,
+      transcribeFile: tf as never,
+    }));
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.ok(r.transcript.length <= TRANSCRIPT_CAP + 20, "transcript should be near-capped");
+      assert.ok(r.transcript.includes("…(truncated)"), "truncation marker must be present");
+    }
   });
 });


### PR DESCRIPTION
## Summary

Post-merge follow-ups to the audio feature from the /review #64 + SDD ledger:

- Retry-sleep trim, quota shape validation, spawn timer unref
- AbortSignal threaded into the transcription HTTP call (+ immediate-propagate: AbortError is no longer wrapped as a network `TranscribeError` and is no longer retried)
- Double-probe removed via `knownDurationSec`
- Retry nudge on unowned threads, per-user consent scope, tier-aware summary tone
- Added test coverage: network-retry, transcript cap, probe<=0, download pre-check, claim non-EEXIST rethrow, AbortError no-retry

Full suite green (839/839). No behavior change when audio is disabled.