### PR TITLE
fix(audio): classify audio by filename extension (sparse Slack metadata)

### DIFF
--- a/packages/cli/src/gateway/attachments/registry.ts
+++ b/packages/cli/src/gateway/attachments/registry.ts
@@ -1,4 +1,4 @@
-import { IMAGE_MIMETYPES, AUDIO_MIMETYPES, AUDIO_FILETYPES } from "./types";
+import { IMAGE_MIMETYPES, AUDIO_MIMETYPES, AUDIO_FILETYPES, AUDIO_EXTENSIONS } from "./types";
 
 export type Category = "text" | "pdf" | "image" | "audio" | "unsupported";
 
@@ -8,8 +8,15 @@ const TEXT_FILETYPES = new Set([
   "html", "css", "sql", "xml", "tsx", "jsx",
 ]);
 
-/** Classify a Slack file into an extractor category by mimetype, then filetype. */
-export function categoryFor(file: { mimetype?: string; filetype?: string }): Category {
+/** Lowercase filename extension (no dot), or "" if none. */
+function extOf(name?: string): string {
+  if (!name) return "";
+  const i = name.lastIndexOf(".");
+  return i >= 0 ? name.slice(i + 1).toLowerCase() : "";
+}
+
+/** Classify a Slack file into an extractor category by mimetype, then filetype, then filename extension. */
+export function categoryFor(file: { mimetype?: string; filetype?: string; name?: string }): Category {
   const mt = (file.mimetype ?? "").toLowerCase();
   if (mt === "application/pdf") return "pdf";
   if (IMAGE_MIMETYPES.has(mt)) return "image";
@@ -17,5 +24,9 @@ export function categoryFor(file: { mimetype?: string; filetype?: string }): Cat
   if (mt.startsWith("text/") || mt === "application/json") return "text";
   if (file.filetype && AUDIO_FILETYPES.has(file.filetype.toLowerCase())) return "audio";
   if (file.filetype && TEXT_FILETYPES.has(file.filetype.toLowerCase())) return "text";
+  // Fallback: Slack sometimes omits/uses an unexpected mimetype+filetype
+  // (e.g. voice memos). Recognize audio by filename extension so a file like
+  // "新錄音.m4a" still routes to transcription.
+  if (AUDIO_EXTENSIONS.has(extOf(file.name))) return "audio";
   return "unsupported";
 }

--- a/packages/cli/src/gateway/attachments/types.ts
+++ b/packages/cli/src/gateway/attachments/types.ts
@@ -71,3 +71,11 @@ export const AUDIO_MIMETYPES = new Set([
 export const AUDIO_FILETYPES = new Set([
   "mp3", "m4a", "mp4", "wav", "webm", "ogg", "flac", "aac", "mpga", "mpeg",
 ]);
+/**
+ * Audio filename extensions (lowercase, no dot). Fallback when Slack omits or
+ * sends an unexpected mimetype/filetype — classify by the file name so e.g.
+ * "新錄音.m4a" is still recognized as audio.
+ */
+export const AUDIO_EXTENSIONS = new Set([
+  "mp3", "m4a", "mp4", "wav", "webm", "ogg", "oga", "flac", "aac", "mpga", "mpeg", "m4b", "aiff", "aif",
+]);

--- a/packages/cli/test/audio-registry.test.ts
+++ b/packages/cli/test/audio-registry.test.ts
@@ -18,4 +18,13 @@ describe("categoryFor audio", () => {
     assert.equal(categoryFor({ mimetype: "image/png" }), "image");
     assert.equal(categoryFor({ mimetype: "text/markdown" }), "text");
   });
+  it("falls back to filename extension when mimetype + filetype are missing/unexpected", () => {
+    // the live-test failure: a voice memo with sparse Slack metadata
+    assert.equal(categoryFor({ name: "新錄音.m4a" }), "audio");
+    assert.equal(categoryFor({ name: "meeting.mp3", mimetype: "", filetype: "" }), "audio");
+    assert.equal(categoryFor({ name: "x.wav", mimetype: "application/octet-stream" }), "audio");
+    // non-audio extensions must NOT become audio
+    assert.equal(categoryFor({ name: "notes.txt" }), "unsupported");
+    assert.equal(categoryFor({ name: "noext" }), "unsupported");
+  });
 });


### PR DESCRIPTION
## Problem (found in live testing)
A voice memo `新錄音.m4a` arrived with sparse/unexpected Slack metadata, so `categoryFor` (which only inspected `mimetype`/`filetype`) returned `unsupported`. The file never reached the audio short-circuit — it fell through to normal free-chat ("略過: …unsupported type"). No `audio.*` event fired.

## Fix
Add an `AUDIO_EXTENSIONS` fallback: when `mimetype` and `filetype` don't match, classify audio by the **filename extension** (`.m4a/.mp3/.wav/.webm/.ogg/.flac/.aac/.mp4/...`). Robust against Slack omitting or sending an unexpected mimetype.

## Verified
- New unit test (the exact `新錄音.m4a` case + negatives); full suite **840/840**, typecheck clean.
- **Live-verified**: after deploying, an 8s clip transcribed (gpt-4o-mini-transcribe, ~$0.003) → short-mode summary posted. `audio.transcribed` + `audio.summarized` events confirmed.

No behavior change when audio is disabled.