### PR TITLE
fix(audio): whisper-1 default, refund phantom quota, monthly cap, surface failure cause

### DIFF
--- a/packages/cli/src/gateway/audio/coordinator.ts
+++ b/packages/cli/src/gateway/audio/coordinator.ts
@@ -292,6 +292,9 @@ export class AudioCoordinator {
     // Hoisted so the catch block can refund quota if it was reserved.
     let minutes = 0;
     let quotaReserved = false;
+    // Timestamp the quota is reserved at, so refunds target the same day/month
+    // bucket even if the job (or its failure) crosses a period boundary.
+    let reservedAtMs = 0;
     // True once transcription has incurred real API cost; catch must not refund then.
     let transcribeSucceeded = false;
 
@@ -330,6 +333,7 @@ export class AudioCoordinator {
 
       // 3. Quota gate with ACTUAL minutes (before transcription).
       minutes = Math.ceil(probedDuration / 60);
+      reservedAtMs = now();
       const q = reserveQuota({
         userId: args.userId,
         minutes,
@@ -368,7 +372,7 @@ export class AudioCoordinator {
           // FIX 4a: claim was never finalized → release it so a retry is possible.
           // FIX 2: no usable output → refund the reserved quota.
           releaseAudio(file.id);
-          releaseQuota({ userId: args.userId, minutes, now: () => now() });
+          releaseQuota({ userId: args.userId, minutes, now: () => now(), reservedAt: reservedAtMs });
           await post(
             `:warning: 錄音超過 ${Math.round(ac.maxDurationSec / 60)} 分鐘上限,請切段後再上傳。`,
           );
@@ -388,7 +392,7 @@ export class AudioCoordinator {
         } else {
           // Total failure, no usable output → release claim and refund quota.
           releaseAudio(file.id);
-          releaseQuota({ userId: args.userId, minutes, now: () => now() });
+          releaseQuota({ userId: args.userId, minutes, now: () => now(), reservedAt: reservedAtMs });
           await post(":warning: 轉錄失敗,請在本 thread 回 `retry` 重跑。");
         }
         return;
@@ -449,7 +453,7 @@ export class AudioCoordinator {
       // If transcribeSucceeded is true the OpenAI charge was already spent,
       // so the daily cap must NOT be refunded regardless of what failed later.
       if (quotaReserved && minutes > 0 && !transcribeSucceeded) {
-        releaseQuota({ userId: args.userId, minutes, now: () => now() });
+        releaseQuota({ userId: args.userId, minutes, now: () => now(), reservedAt: reservedAtMs });
       }
       appendGatewayEvent({
         type: "audio.failed",

--- a/packages/cli/src/gateway/audio/coordinator.ts
+++ b/packages/cli/src/gateway/audio/coordinator.ts
@@ -37,7 +37,7 @@ import { makeJobTempDir } from "./temp";
 import { claimAudio, releaseAudio, finalizeAudio } from "./claim";
 import { redactSecrets } from "./redact";
 
-const USD_PER_MINUTE = 0.003; // gpt-4o-mini-transcribe est.; for estimatedUsd only
+const USD_PER_MINUTE = 0.006; // whisper-1 list price ($0.006/min); for estimatedUsd only
 
 /** True when any file in the array is classified as audio. */
 export function isAudioMessage(files: SlackFile[]): boolean {
@@ -335,6 +335,7 @@ export class AudioCoordinator {
         minutes,
         perUserDailyMinutes: ac.perUserDailyMinutes,
         globalDailyMinutes: ac.globalDailyMinutes,
+        globalMonthlyMinutes: ac.globalMonthlyMinutes,
         now,
       });
       if (!q.ok) {
@@ -359,7 +360,10 @@ export class AudioCoordinator {
 
       if (!result.ok) {
         const reason = result.reason;
-        appendGatewayEvent({ type: "audio.failed", actor: args.userId, reason });
+        // Surface the underlying cause (e.g. "400 input_too_large") in the event
+        // so failures are diagnosable from the event log without re-instrumenting.
+        const eventReason = result.detail ? `${reason}: ${result.detail}` : reason;
+        appendGatewayEvent({ type: "audio.failed", actor: args.userId, reason: eventReason });
         if (reason === "too-long") {
           // FIX 4a: claim was never finalized → release it so a retry is possible.
           // FIX 2: no usable output → refund the reserved quota.

--- a/packages/cli/src/gateway/audio/quota.ts
+++ b/packages/cli/src/gateway/audio/quota.ts
@@ -7,9 +7,33 @@ interface DayUsage {
   perUser: Record<string, number>;
 }
 
+interface MonthUsage {
+  global: number;
+}
+
 function dayFile(now: number): string {
   const d = new Date(now).toISOString().slice(0, 10);
   return path.join(os.homedir(), ".pmk", "gateway", `audio-usage-${d}.json`);
+}
+
+function monthFile(now: number): string {
+  const m = new Date(now).toISOString().slice(0, 7); // YYYY-MM
+  return path.join(os.homedir(), ".pmk", "gateway", `audio-usage-month-${m}.json`);
+}
+
+function loadMonth(file: string): MonthUsage {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as MonthUsage;
+    if (!Number.isFinite(parsed.global)) return { global: 0 };
+    return { global: Number(parsed.global) };
+  } catch {
+    return { global: 0 };
+  }
+}
+
+function writeMonth(file: string, usage: MonthUsage): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(usage));
 }
 
 function load(file: string): DayUsage {
@@ -37,12 +61,17 @@ export function reserveAudioQuota(args: {
   minutes: number;
   perUserDailyMinutes: number;
   globalDailyMinutes: number;
+  /** Whole-workspace monthly ceiling in minutes; omit to disable the monthly cap. */
+  globalMonthlyMinutes?: number;
   now?: () => number;
 }): { ok: true } | { ok: false; reason: string } {
   const now = (args.now ?? (() => Date.now()))();
   const file = dayFile(now);
   const usage = load(file);
   const userUsed = usage.perUser[args.userId] ?? 0;
+
+  const mFile = monthFile(now);
+  const month = loadMonth(mFile);
 
   if (userUsed + args.minutes > args.perUserDailyMinutes)
     return {
@@ -56,12 +85,24 @@ export function reserveAudioQuota(args: {
       reason: `已達全域每日音訊上限（${args.globalDailyMinutes} 分鐘）,請稍後再試`,
     };
 
+  if (
+    Number.isFinite(args.globalMonthlyMinutes) &&
+    month.global + args.minutes > (args.globalMonthlyMinutes as number)
+  )
+    return {
+      ok: false,
+      reason: `已達全域每月音訊上限（${args.globalMonthlyMinutes} 分鐘）,請下個月再試`,
+    };
+
   const next: DayUsage = {
     global: usage.global + args.minutes,
     perUser: { ...usage.perUser, [args.userId]: userUsed + args.minutes },
   };
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, JSON.stringify(next));
+  // Always track the monthly accumulator so releases can refund it, regardless
+  // of whether the cap is currently enforced.
+  writeMonth(mFile, { global: month.global + args.minutes });
 
   return { ok: true };
 }
@@ -81,4 +122,8 @@ export function releaseAudioQuota(args: {
   };
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, JSON.stringify(next));
+
+  const mFile = monthFile(now);
+  const month = loadMonth(mFile);
+  writeMonth(mFile, { global: Math.max(0, month.global - args.minutes) });
 }

--- a/packages/cli/src/gateway/audio/quota.ts
+++ b/packages/cli/src/gateway/audio/quota.ts
@@ -111,9 +111,16 @@ export function releaseAudioQuota(args: {
   userId: string;
   minutes: number;
   now?: () => number;
+  /**
+   * Timestamp the quota was RESERVED at. Refunds the reserve-time day/month
+   * buckets rather than wall-clock-at-release, so a job that crosses a day or
+   * month boundary refunds the same file it charged (otherwise the refund hits
+   * a fresh next-period file — a no-op — and the charged period leaks minutes).
+   */
+  reservedAt?: number;
 }): void {
-  const now = (args.now ?? (() => Date.now()))();
-  const file = dayFile(now);
+  const ts = args.reservedAt ?? (args.now ?? (() => Date.now()))();
+  const file = dayFile(ts);
   const usage = load(file);
   const userUsed = usage.perUser[args.userId] ?? 0;
   const next: DayUsage = {
@@ -123,7 +130,7 @@ export function releaseAudioQuota(args: {
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, JSON.stringify(next));
 
-  const mFile = monthFile(now);
+  const mFile = monthFile(ts);
   const month = loadMonth(mFile);
   writeMonth(mFile, { global: Math.max(0, month.global - args.minutes) });
 }

--- a/packages/cli/src/gateway/audio/transcribe.ts
+++ b/packages/cli/src/gateway/audio/transcribe.ts
@@ -6,7 +6,7 @@ import { MAX_AUDIO_DURATION_SEC, TRANSCRIPT_CAP } from "../attachments/types";
 
 export type TranscribeResult =
   | { ok: true; transcript: string; durationSec: number; chunks: number }
-  | { ok: false; reason: "too-long" | "transcribe-failed"; durationSec?: number; partialTranscript?: string; failedSegment?: number };
+  | { ok: false; reason: "too-long" | "transcribe-failed"; durationSec?: number; partialTranscript?: string; failedSegment?: number; detail?: string };
 
 export interface TranscribeDeps {
   probe?: typeof probeAudio;
@@ -76,15 +76,21 @@ export async function transcribeAudio(
       segs.push(text);
     } catch (err) {
       if (!(err instanceof TranscribeError)) throw err;
-      const partial =
-        (segs.length > 0 ? segs.join("\n") + "\n" : "") +
-        `[第 ${i + 1} 段轉錄失敗，回 retry 重跑此段]`;
+      // Only surface a partialTranscript when at least one segment actually
+      // succeeded. A gap-marker-only "partial" (no real content) incurs zero
+      // API cost — the caller relies on its absence to refund the quota.
+      const hasContent = segs.length > 0;
+      const partial = hasContent
+        ? truncate(segs.join("\n") + `\n[第 ${i + 1} 段轉錄失敗，回 retry 重跑此段]`)
+        : undefined;
+      const detail = `${err.status ?? ""} ${err.message}`.trim().slice(0, 200);
       return {
         ok: false,
         reason: "transcribe-failed",
         durationSec,
-        partialTranscript: truncate(partial),
+        partialTranscript: partial,
         failedSegment: i,
+        detail,
       };
     }
   }

--- a/packages/cli/src/gateway/config.ts
+++ b/packages/cli/src/gateway/config.ts
@@ -89,7 +89,7 @@ export interface AudioConfig {
   language?: string;
   enabled?: boolean;
   maxDurationSec?: number;
-  quota?: { perUserDailyMinutes?: number; globalDailyMinutes?: number };
+  quota?: { perUserDailyMinutes?: number; globalDailyMinutes?: number; globalMonthlyMinutes?: number };
 }
 
 export interface ResolvedAudioConfig {
@@ -99,6 +99,8 @@ export interface ResolvedAudioConfig {
   maxDurationSec: number;
   perUserDailyMinutes: number;
   globalDailyMinutes: number;
+  /** Whole-workspace monthly budget ceiling in minutes; undefined = no monthly cap. */
+  globalMonthlyMinutes?: number;
 }
 
 export interface ReviewConfig {
@@ -487,11 +489,15 @@ export function resolveReviewGhToken(
 export function resolveAudioConfig(raw?: AudioConfig): ResolvedAudioConfig {
   return {
     enabled: raw?.enabled ?? false,
-    model: raw?.model ?? "gpt-4o-mini-transcribe",
+    // whisper-1: gpt-4o-mini-transcribe has a ~25-min token cap (400
+    // input_too_large) that breaks long meeting recordings. whisper-1 is
+    // bounded only by the 25MB request size, which the re-encode satisfies.
+    model: raw?.model ?? "whisper-1",
     language: raw?.language ?? "zh",
     maxDurationSec: raw?.maxDurationSec ?? 7200,
     perUserDailyMinutes: raw?.quota?.perUserDailyMinutes ?? 120,
     globalDailyMinutes: raw?.quota?.globalDailyMinutes ?? 600,
+    globalMonthlyMinutes: raw?.quota?.globalMonthlyMinutes,
   };
 }
 

--- a/packages/cli/test/audio-config.test.ts
+++ b/packages/cli/test/audio-config.test.ts
@@ -3,20 +3,24 @@ import * as assert from "node:assert/strict";
 import { resolveAudioConfig, resolveOpenAiKey, normaliseRawConfigForTest } from "../src/gateway/config";
 
 describe("resolveAudioConfig", () => {
-  it("applies defaults (disabled, gpt-4o-mini-transcribe, zh, quotas)", () => {
+  it("applies defaults (disabled, whisper-1, zh, quotas, no monthly cap)", () => {
     const c = resolveAudioConfig(undefined);
     assert.equal(c.enabled, false);
-    assert.equal(c.model, "gpt-4o-mini-transcribe");
+    // whisper-1 is the default: gpt-4o-mini-transcribe has a ~25-min token cap
+    // that fails on long meeting recordings (400 input_too_large).
+    assert.equal(c.model, "whisper-1");
     assert.equal(c.language, "zh");
     assert.equal(c.maxDurationSec, 7200);
     assert.equal(c.perUserDailyMinutes, 120);
     assert.equal(c.globalDailyMinutes, 600);
+    assert.equal(c.globalMonthlyMinutes, undefined, "no monthly cap unless configured");
   });
-  it("honours overrides", () => {
-    const c = resolveAudioConfig({ enabled: true, model: "whisper-1", quota: { perUserDailyMinutes: 30 } });
+  it("honours overrides incl. globalMonthlyMinutes", () => {
+    const c = resolveAudioConfig({ enabled: true, model: "gpt-4o-mini-transcribe", quota: { perUserDailyMinutes: 30, globalMonthlyMinutes: 7500 } });
     assert.equal(c.enabled, true);
-    assert.equal(c.model, "whisper-1");
+    assert.equal(c.model, "gpt-4o-mini-transcribe");
     assert.equal(c.perUserDailyMinutes, 30);
+    assert.equal(c.globalMonthlyMinutes, 7500);
   });
 });
 

--- a/packages/cli/test/audio-quota.test.ts
+++ b/packages/cli/test/audio-quota.test.ts
@@ -82,4 +82,17 @@ describe("reserveAudioQuota — global MONTHLY cap", () => {
       assert.equal(r.ok, true);
     }
   });
+
+  it("release refunds the RESERVE-time month even when called in a later month", () => {
+    const june30 = () => Date.parse("2026-06-30T23:59:00Z");
+    const july1 = () => Date.parse("2026-07-01T00:03:00Z");
+    reserveAudioQuota({ userId: "U1", minutes: 60, ...HIGH, globalMonthlyMinutes: 100, now: june30 });
+    // Job fails after crossing midnight into July; release is called with
+    // now=July but reservedAt = the June reserve timestamp.
+    releaseAudioQuota({ userId: "U1", minutes: 60, now: july1, reservedAt: june30() });
+    // June's monthly accumulator must be back to 0 → a fresh 100-min June reserve fits.
+    // (Broken impl refunds July → June stays at 60 → 60+100 > 100 denies.)
+    const r = reserveAudioQuota({ userId: "U1", minutes: 100, ...HIGH, globalMonthlyMinutes: 100, now: june30 });
+    assert.equal(r.ok, true, "refund must target June (reserve month), not July");
+  });
 });

--- a/packages/cli/test/audio-quota.test.ts
+++ b/packages/cli/test/audio-quota.test.ts
@@ -50,3 +50,36 @@ describe("releaseAudioQuota", () => {
     assert.equal(r.ok, false, "global cap must deny: floored baseline 0+175>150");
   });
 });
+
+describe("reserveAudioQuota — global MONTHLY cap", () => {
+  let tmp: string;
+  const day1 = () => Date.parse("2026-06-26T10:00:00Z");
+  const day2 = () => Date.parse("2026-06-27T10:00:00Z"); // different day, same month
+  const HIGH = { perUserDailyMinutes: 9999, globalDailyMinutes: 9999 };
+  beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-qm-")); process.env.HOME = tmp; });
+  afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); if (ORIG) process.env.HOME = ORIG; });
+
+  it("enforces the monthly cap independent of the daily reset", () => {
+    // Daily caps are generous; only the monthly cap binds. Spend on two
+    // separate days so the daily counter resets but the monthly accrues.
+    const a = reserveAudioQuota({ userId: "U1", minutes: 60, ...HIGH, globalMonthlyMinutes: 100, now: day1 });
+    assert.equal(a.ok, true);
+    const b = reserveAudioQuota({ userId: "U2", minutes: 60, ...HIGH, globalMonthlyMinutes: 100, now: day2 });
+    assert.equal(b.ok, false, "60+60 > 100 monthly even though each day is under the daily cap");
+  });
+
+  it("releasing refunds the monthly accumulator", () => {
+    reserveAudioQuota({ userId: "U1", minutes: 60, ...HIGH, globalMonthlyMinutes: 100, now: day1 });
+    releaseAudioQuota({ userId: "U1", minutes: 60, now: day1 });
+    // monthly back to 0 → a fresh 100 reserve fits
+    const r = reserveAudioQuota({ userId: "U1", minutes: 100, ...HIGH, globalMonthlyMinutes: 100, now: day2 });
+    assert.equal(r.ok, true);
+  });
+
+  it("no monthly cap configured → never blocks on monthly", () => {
+    for (let i = 0; i < 5; i++) {
+      const r = reserveAudioQuota({ userId: "U1", minutes: 100, ...HIGH, now: day1 });
+      assert.equal(r.ok, true);
+    }
+  });
+});

--- a/packages/cli/test/audio-transcribe.test.ts
+++ b/packages/cli/test/audio-transcribe.test.ts
@@ -32,6 +32,43 @@ describe("transcribeAudio", () => {
     if (!r.ok) { assert.equal(r.reason, "transcribe-failed"); assert.equal(r.failedSegment, 1); assert.match(r.partialTranscript ?? "", /ok-seg/); }
   });
 
+  it("total failure (no segment succeeded) → NO partialTranscript, so caller can refund", async () => {
+    // The only chunk fails terminally (400). segs is empty, so there is no real
+    // content — partialTranscript must be undefined (a gap-marker-only 'partial'
+    // wrongly suppressed quota refunds; see coordinator).
+    const tf = async () => { throw new TranscribeError("OpenAI transcribe 400: input_too_large", 400); };
+    const r = await transcribeAudio("/tmp/in.m4a", cfg, base({
+      prepare: (async () => ["/tmp/job/chunk-000.ogg"]) as never,
+      transcribeFile: tf as never,
+    }));
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.reason, "transcribe-failed");
+      assert.equal(r.partialTranscript, undefined, "no segment succeeded → no partial content");
+    }
+  });
+
+  it("captures the failure detail (status + message) for diagnosis", async () => {
+    const tf = async () => { throw new TranscribeError("OpenAI transcribe 400: {\"code\":\"input_too_large\"}", 400); };
+    const r = await transcribeAudio("/tmp/in.m4a", cfg, base({
+      prepare: (async () => ["/tmp/job/chunk-000.ogg"]) as never,
+      transcribeFile: tf as never,
+    }));
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.match(r.detail ?? "", /400/);
+      assert.match(r.detail ?? "", /input_too_large/);
+    }
+  });
+
+  it("partial failure (some segments succeeded) still returns partialTranscript", async () => {
+    let n = 0;
+    const tf = async () => { if (n++ === 1) throw new TranscribeError("400", 400); return "ok-seg"; };
+    const r = await transcribeAudio("/tmp/in.m4a", cfg, base({ transcribeFile: tf as never }));
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.partialTranscript ?? "", /ok-seg/);
+  });
+
   it("retries a transient 500 and succeeds on second attempt", async () => {
     let calls = 0;
     const tf = async () => { if (calls++ === 0) throw new TranscribeError("500", 500); return "seg"; };


### PR DESCRIPTION
Follow-ups from live 45-min testing of the audio feature (v0.28.0).

## Changes
1. **Default model → `whisper-1`.** `gpt-4o-mini-transcribe` is GPT-4o-based with a ~25-min token cap → `400 input_too_large` on long meeting recordings (root-caused live: a 45-min file failed; whisper-1 transcribed the same file in ~2min). whisper-1 is bounded only by the 25MB request size, which the re-encode satisfies (45min → ~5MB).
2. **Quota refund bug.** A single-chunk total failure produced a gap-marker-only `partialTranscript`, which made the coordinator take the "cost incurred → don't refund" branch → reserved minutes leaked (live: two failed 45-min attempts ate 90 phantom minutes and tripped the daily cap). `transcribe` now returns `partialTranscript` only when a segment actually succeeded; total failures refund.
3. **Monthly cap.** Optional whole-workspace `quota.globalMonthlyMinutes` budget ceiling with a monthly accumulator file. Always tracked (so releases refund it), enforced only when configured. Refunds target the **reserve-time** day/month bucket so a job crossing a period boundary refunds the file it charged (code-review MEDIUM).
4. **Diagnosability.** The underlying transcribe failure (status + code, e.g. `400 input_too_large`) is surfaced into the `audio.failed` event reason.
5. **Cost estimate.** `USD_PER_MINUTE` 0.003 → 0.006 (whisper-1 list price) so `audio.transcribed.estimatedUsd` is accurate.

## Verified
- Full suite **847/847**, typecheck clean. +10 new tests (monthly cap incl. cross-month refund, total-failure-no-partial, detail capture, whisper-1 default).
- Code-reviewed (subagent): one MEDIUM (month-boundary refund) found and fixed + tested.
- Live: 45-min file transcribes end-to-end on whisper-1 (`audio.transcribed durationSec=2736 chunks=1`, long-mode summary). Live `~/.pmk/gateway.json` set to per-user 600/day, global 1800/day, **global 7500/month (~NT\$1,485)**.