### PR TITLE
feat(gateway): add Codex review integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,15 @@ npx pmk gateway atoms approve <id-prefix>     # promote a pending atom to retrie
 # After bootstrap: in Slack DM with the bot, run `/pmk admin help` for the in-Slack surface (v0.9).
 ```
 
-**Slack in-DM / @-mention review commands** (requires `review.enabled: true` in `gateway.json`):
+**Slack in-DM / @-mention review commands** (requires `review.enabled: true` in `gateway.json`; default provider is Codex):
 
-- `:cr: <PR url>` — runs a full multi-agent mra review and posts inline findings. When `review.allowApprove: true` (gateway config, default `false`) and the verdict is APPROVED, the bot posts a real GitHub approval; otherwise the AI verdict is recorded as a COMMENT.
-- `:a: <PR url>` — runs a fast single-agent review, then **approves** the PR iff no CRITICAL/HIGH issue is found (minor issues allowed); otherwise requests changes. Per-invocation it is always allowed to approve.
+- `:cr: <PR url>` — asks MRA protocol v1 for a SHA-bound analysis artifact, then PMK posts the inline GitHub review. New installs default to `codex` + `standard`; pre-provider configs retain Claude/debate until an admin migrates them. `:cr:` never submits GitHub APPROVE by itself. When automatic approval is enabled and the artifact is complete and blocker-free, it creates a one-time thread offer.
+- `:a: <PR url>` — PMK-admin only. Runs the same analysis first and asks for an explicit thread `approve` confirmation; the trigger itself never approves.
 - React with `:cr:` on a user's PR-link message to trigger a review without re-typing the URL.
-- React with `:a:` on a user's PR-link message to trigger the fast-approve path.
+- A PMK admin may react with `:a:` on a user's PR-link message to start review plus approval intent.
+- Slack admins can switch the backend live with `/pmk admin review provider codex|claude|fallback|dual`. Automatic approval has a separate default-off kill switch: `/pmk admin review approval enable|disable`.
+- Provider switching applies to review. Only Codex protocol-v1 artifacts are sanitized approval evidence; Claude/fallback/dual runs stay review-only and never create an approve offer.
+- GitHub APPROVE publication currently has a release veto: admins cannot enable it until cross-process policy locking is shipped. `:cr:` and `:a:` analysis remain available and never approve on their own.
 
 The CLI delegates code-intelligence work to [**multi-repo-agent (mra)**](https://github.com/hanfour/multi-repo-agent) when present. The gateway specifically uses three integrated mechanisms:
 

--- a/apps/docs/docs/gateway/onboarding.md
+++ b/apps/docs/docs/gateway/onboarding.md
@@ -378,18 +378,22 @@ retained for follow-ups); linked Google/Box files and Office formats aren't supp
 
 Post a GitHub PR link with a trigger, or react on someone else's PR-link message:
 
-- **`:cr: <PR url>`** (or a `:cr:` reaction) — runs a full multi-agent mra review
-  and posts inline findings. The AI verdict is recorded as a **COMMENT** by default;
-  it becomes a real GitHub **approval** only when `review.allowApprove: true` is set
-  in `gateway.json` **and** the verdict is APPROVED.
-- **`:a: <PR url>`** (or a `:a:` reaction) — runs a fast single-agent review, then
-  **approves** the PR iff no CRITICAL/HIGH issue is found (minor issues allowed),
-  else requests changes. `:a:` is the explicit per-invocation opt-in to approve, so
-  it does not require `allowApprove` — but it still honors the same repo guards.
+- **`:cr: <PR url>`** (or a `:cr:` reaction) — runs an mra review and posts inline
+  findings. PMK prefers MRA protocol v1: MRA creates an analysis-only artifact,
+  while PMK owns the GitHub review write. New installs default to **Codex** plus
+  `standard`; legacy pre-provider configs retain Claude/debate. `:cr:` never
+  submits GitHub **APPROVE** by itself. When approval is enabled and a complete
+  artifact has no HIGH/CRITICAL blocker, PMK stores a one-time offer in the
+  Slack thread; a PMK admin can reply `approve` for that exact SHA and context.
+  Only Codex protocol-v1 artifacts are approval-eligible. Claude, fallback, and
+  dual remain selectable for review but do not create approve offers.
+- **`:a: <PR url>`** (or a `:a:` reaction) — admin-only review plus approval
+  intent. It still requires a separate thread `approve` confirmation.
 
 A live progress bar edits itself in place while the review runs; if the gateway is
 restarted mid-review it posts an interruption notice — reply `retry` in that thread
-to re-run (works for both `:cr:` and `:a:`).
+to retry an interrupted run. A PMK admin can reply `rerun` / `重跑` to intentionally
+re-review an already completed same-SHA claim; prior claim history is retained.
 
 The `review` config block (all optional, safe-by-default):
 
@@ -397,18 +401,32 @@ The `review` config block (all optional, safe-by-default):
 {
   "review": {
     "enabled": false,          // master switch for :cr: / :a:
-    "allowApprove": false,     // let a :cr: APPROVED verdict post a real GitHub approval
+    "approval": { "enabled": false }, // separate automatic-approval kill switch
     "allowPublicRepos": false, // default-deny: only private repos are reviewed
     "repoAllowlist": [],       // optional owner/repo allowlist (empty = all private repos)
     "expectedGhUser": "",      // abort if the posting gh identity isn't this user
-    "strategy": "debate",      // debate | personas | standard
+    "providerMode": "codex",   // codex | claude | fallback | dual
+    "strategy": "standard",    // new-install default; debate/personas are Claude-only
     "maxPrsPerTrigger": 3,
+    "maxConcurrent": 2,
+    "maxConcurrentPerUser": 1,
     "ghToken": ""              // pinned review token (falls back to github.token)
   }
 }
 ```
 
-Only workspace members who are **not** blocklisted can trigger a review or approve;
+Admins can switch the provider from Slack DM without restarting the gateway:
+`/pmk admin review provider codex`, `/pmk admin review provider claude`,
+`/pmk admin review provider fallback`, or `/pmk admin review provider dual`.
+Use `/pmk admin review status` to confirm the effective setting.
+GitHub APPROVE publication currently has a release veto, so
+`/pmk admin review approval enable` refuses to enable it. `:cr:` and `:a:`
+analysis remain available. The veto can be removed only after cross-process
+policy locking ships; repository readiness will still require protocol v1,
+expected identity, allowlist, stale-review dismissal, and latest-push approval.
+
+Workspace members who are **not** blocklisted can trigger `:cr:` review. GitHub
+approve (`:a:` reaction/message or thread `approve`) and forced rerun are PMK-admin only;
 the bot posts under its pinned gh identity (`expectedGhUser` guards against posting
 as the wrong account). Private-repo default-deny and the allowlist are checked
 **before** any work starts.

--- a/packages/cli/src/adapters/github.ts
+++ b/packages/cli/src/adapters/github.ts
@@ -8,7 +8,7 @@
  * are never put into a thrown message, a Slack reply, or a host log line.
  */
 import { execFile, execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { promisify } from "node:util";
@@ -169,7 +169,130 @@ export function buildGhArgs_getAuthUser(): string[] {
 
 /** Pure argv builder for `gh api repos/<slug>/pulls/<N> --jq ...` (exported for unit tests). */
 export function buildGhArgs_getPrHead(slug: string, pr: number): string[] {
-  return ["api", `repos/${slug}/pulls/${pr}`, "--jq", "{sha:.head.sha,base:.base.ref}"];
+  return ["api", `repos/${slug}/pulls/${pr}`, "--jq", "{sha:.head.sha,base:.base.ref,baseSha:.base.sha,title:.title,body:.body,updatedAt:.updated_at}"];
+}
+
+export function buildGhArgs_getApprovalProtection(slug: string, branch: string): string[] {
+  return ["api", `repos/${slug}/branches/${branch}/protection`, "--jq", "{dismissStale:.required_pull_request_reviews.dismiss_stale_reviews,requireLastPush:.required_pull_request_reviews.require_last_push_approval}"];
+}
+
+export function buildGhArgs_createPullRequestApproval(args: {
+  slug: string; pr: number; commitId: string; body: string;
+}): string[] {
+  return [
+    "api", "--method", "POST", `repos/${args.slug}/pulls/${args.pr}/reviews`,
+    "-f", "event=APPROVE", "-f", `commit_id=${args.commitId}`, "-f", `body=${args.body}`,
+  ];
+}
+
+export function buildGhArgs_hasPullRequestApproval(args: { slug: string; pr: number; commitId: string; artifactSha256: string; actor: string }): string[] {
+  return ["api", "--paginate", `repos/${args.slug}/pulls/${args.pr}/reviews`, "--jq",
+    `.[] | select(.state == \"APPROVED\" and .commit_id == \"${args.commitId}\" and .user.login == \"${args.actor}\" and (.body // \"\" | contains(\"${args.artifactSha256}\"))) | .id`];
+}
+
+export async function hasPullRequestApproval(
+  args: { slug: string; pr: number; commitId: string; artifactSha256: string; actor: string; token?: string },
+  deps: GithubDeps = {},
+): Promise<boolean | undefined> {
+  const exec = deps.exec ?? defaultExec;
+  const gh = (deps.findBinary ?? findGhBinary)();
+  if (!gh || !/^[0-9a-f]{40}$/i.test(args.commitId) || !/^[0-9a-f]{64}$/i.test(args.artifactSha256) || !/^[A-Za-z0-9-]+$/.test(args.actor)) return undefined;
+  try {
+    const env = args.token ? { ...process.env, GH_TOKEN: args.token } : process.env;
+    const { stdout } = await exec(gh, buildGhArgs_hasPullRequestApproval(args), { env, timeoutMs: 15_000 });
+    return stdout.trim().length > 0;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function approvalProtectionReady(
+  args: { slug: string; branch: string; token?: string },
+  deps: GithubDeps = {},
+): Promise<boolean> {
+  const exec = deps.exec ?? defaultExec;
+  const gh = (deps.findBinary ?? findGhBinary)();
+  if (!gh) return false;
+  try {
+    const env = args.token ? { ...process.env, GH_TOKEN: args.token } : process.env;
+    const { stdout } = await exec(gh, buildGhArgs_getApprovalProtection(args.slug, args.branch), { env, timeoutMs: 15_000 });
+    const protection = JSON.parse(stdout) as { dismissStale?: boolean; requireLastPush?: boolean };
+    // Require both controls. This is stronger than either setting alone and
+    // avoids treating a client-side head GET as a compare-and-set operation.
+    return protection.dismissStale === true && protection.requireLastPush === true;
+  } catch {
+    return false;
+  }
+}
+
+export interface PullRequestApprovalResult {
+  reviewId: number;
+  state: string;
+  commitId: string;
+  actor?: string;
+  htmlUrl?: string;
+}
+
+export interface PullRequestReviewFinding {
+  path: string;
+  line: number;
+  body: string;
+  severity?: string;
+}
+
+export async function createPullRequestReview(
+  args: {
+    slug: string; pr: number; commitId: string; body: string;
+    event: "COMMENT" | "REQUEST_CHANGES"; comments: PullRequestReviewFinding[]; token?: string;
+  },
+  deps: GithubDeps = {},
+): Promise<PullRequestApprovalResult> {
+  const exec = deps.exec ?? defaultExec;
+  const gh = (deps.findBinary ?? findGhBinary)();
+  if (!gh) throw new Error("gh is unavailable");
+  const dir = mkdtempSync(path.join(os.tmpdir(), "pmk-gh-review-"));
+  const input = path.join(dir, "review.json");
+  writeFileSync(input, JSON.stringify({
+    commit_id: args.commitId,
+    event: args.event,
+    body: args.body,
+    comments: args.comments.map((c) => ({ path: c.path, line: c.line, side: "RIGHT", body: c.severity ? `[${c.severity}] ${c.body}` : c.body })),
+  }), { mode: 0o600 });
+  try {
+    const env = args.token ? { ...process.env, GH_TOKEN: args.token } : process.env;
+    const { stdout } = await exec(gh, ["api", "--method", "POST", `repos/${args.slug}/pulls/${args.pr}/reviews`, "--input", input], { env, timeoutMs: 30_000 });
+    const review = JSON.parse(stdout) as { id?: number; state?: string; commit_id?: string; user?: { login?: string }; html_url?: string };
+    if (!review.id || !review.state || review.commit_id !== args.commitId)
+      throw new Error("GitHub returned an invalid review response");
+    return { reviewId: review.id, state: review.state, commitId: review.commit_id, actor: review.user?.login, htmlUrl: review.html_url };
+  } catch (err) {
+    const code = (err as { code?: number }).code ?? "?";
+    throw new Error(`GitHub review post failed (${code})`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+export async function createPullRequestApproval(
+  args: { slug: string; pr: number; commitId: string; body: string; token?: string },
+  deps: GithubDeps = {},
+): Promise<PullRequestApprovalResult> {
+  const exec = deps.exec ?? defaultExec;
+  const gh = (deps.findBinary ?? findGhBinary)();
+  if (!gh) throw new Error("gh is unavailable");
+  try {
+    const env = args.token ? { ...process.env, GH_TOKEN: args.token } : process.env;
+    const { stdout } = await exec(gh, buildGhArgs_createPullRequestApproval(args), { env, timeoutMs: 30_000 });
+    const review = JSON.parse(stdout) as {
+      id?: number; state?: string; commit_id?: string; user?: { login?: string }; html_url?: string;
+    };
+    if (!review.id || review.state?.toUpperCase() !== "APPROVED" || review.commit_id !== args.commitId)
+      throw new Error("GitHub returned an invalid approval response");
+    return { reviewId: review.id, state: review.state, commitId: review.commit_id, actor: review.user?.login, htmlUrl: review.html_url };
+  } catch (err) {
+    const code = (err as { code?: number }).code ?? "?";
+    throw new Error(`GitHub approval result is unknown (${code})`);
+  }
 }
 
 /**
@@ -201,7 +324,7 @@ export async function getAuthUser(
 export async function getPrHead(
   args: { slug: string; pr: number; token?: string },
   deps: GithubDeps = {},
-): Promise<{ sha: string; baseRef: string } | undefined> {
+): Promise<{ sha: string; baseRef: string; baseSha?: string; title?: string; body?: string; updatedAt?: string } | undefined> {
   const exec = deps.exec ?? defaultExec;
   const findBinary = deps.findBinary ?? findGhBinary;
   const gh = findBinary();
@@ -212,9 +335,9 @@ export async function getPrHead(
       env,
       timeoutMs: 15_000,
     });
-    const obj = JSON.parse(stdout) as { sha?: string; base?: string };
+    const obj = JSON.parse(stdout) as { sha?: string; base?: string; baseSha?: string; title?: string; body?: string; updatedAt?: string };
     if (!obj.sha || !obj.base) return undefined;
-    return { sha: obj.sha, baseRef: obj.base };
+    return { sha: obj.sha, baseRef: obj.base, baseSha: obj.baseSha, title: obj.title, body: obj.body, updatedAt: obj.updatedAt };
   } catch {
     return undefined;
   }

--- a/packages/cli/src/adapters/mra.ts
+++ b/packages/cli/src/adapters/mra.ts
@@ -16,7 +16,8 @@
  */
 
 import { execFileSync, spawn } from "node:child_process";
-import { existsSync, readFileSync, readdirSync, statSync, type Dirent } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, statSync, writeFileSync, type Dirent } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
 import * as os from "node:os";
 import * as path from "node:path";
 
@@ -43,6 +44,74 @@ const WORKSPACE_MARKER_FALLBACKS = [
   ".mra-config",
   "mra-workspace.json",
 ];
+
+const reviewProviderCapability = new Map<string, boolean>();
+
+export interface MraIntegrationCapabilities {
+  protocolVersion: "1.0";
+  capabilities: {
+    analysisOnly: true;
+    shaBinding: true;
+    sanitizedContext: true;
+    blockerUnion: true;
+    resultArtifact: true;
+  };
+  providers: ["codex"];
+}
+
+const integrationCapabilityCache = new Map<string, { expiresAt: number; value?: MraIntegrationCapabilities }>();
+
+function integrationCacheKey(binary: string): string {
+  try {
+    const real = realpathSync(binary);
+    const st = statSync(real);
+    return `${real}:${st.ino}:${st.size}:${st.mtimeMs}`;
+  } catch {
+    return binary;
+  }
+}
+
+export function mraIntegrationCapabilities(binary: string, fresh = false): MraIntegrationCapabilities | undefined {
+  const key = integrationCacheKey(binary);
+  const cached = integrationCapabilityCache.get(key);
+  if (!fresh && cached && cached.expiresAt > Date.now()) return cached.value;
+  let value: MraIntegrationCapabilities | undefined;
+  try {
+    const raw = execFileSync(binary, ["integration", "describe", "--json"], {
+      encoding: "utf8",
+      timeout: 5_000,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: strippedChildEnv(),
+    });
+    const parsed = JSON.parse(raw) as Partial<MraIntegrationCapabilities>;
+    const c = parsed.capabilities;
+    if (parsed.protocolVersion === "1.0" && c?.analysisOnly === true && c.shaBinding === true &&
+        c.sanitizedContext === true && c.blockerUnion === true && c.resultArtifact === true &&
+        Array.isArray(parsed.providers) && parsed.providers.length === 1 && parsed.providers[0] === "codex") {
+      value = parsed as MraIntegrationCapabilities;
+    }
+  } catch { /* legacy or unavailable */ }
+  integrationCapabilityCache.set(key, { expiresAt: Date.now() + 60_000, value });
+  return value;
+}
+
+export function mraSupportsReviewProvider(binary: string): boolean {
+  const cached = reviewProviderCapability.get(binary);
+  if (cached !== undefined) return cached;
+  let supported = false;
+  try {
+    const help = execFileSync(binary, ["--help"], {
+      encoding: "utf8",
+      timeout: 5_000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    supported = /--provider\b/.test(help);
+  } catch {
+    supported = false;
+  }
+  reviewProviderCapability.set(binary, supported);
+  return supported;
+}
 
 export interface MraDoctorReport {
   ok: boolean;
@@ -535,6 +604,12 @@ export interface MraReviewResult {
   ok: boolean;
   status?: string;
   commentCount?: number;
+  blockerCount?: number;
+  protocolVersion?: "1.0";
+  artifactSha256?: string;
+  analyzedHeadSha?: string;
+  summary?: string;
+  findings?: Array<{ path: string; line: number; body: string; severity?: string }>;
   /** True when mra posted a neutral REVIEW_INCOMPLETE placeholder (see parseReviewStdout). */
   incomplete?: boolean;
   stdout: string;
@@ -543,19 +618,25 @@ export interface MraReviewResult {
 }
 
 export type ReviewStrategy = "debate" | "personas" | "standard";
+export type ReviewProviderMode = "codex" | "claude" | "fallback" | "dual";
 
 /**
  * Build the argv for `mra review <project> --pr <pr>`. For strategy
  * "debate" appends `--strategy debate`; for "standard" appends
  * `--strategy standard`; for "personas" the flag is omitted and the
  * env var `MRA_REVIEW_PERSONAS=true` is used instead (see {@link reviewEnv}).
+ * Provider policy is always explicit. If the configured provider is unsupported
+ * by the installed mra, the review should fail visibly rather than silently
+ * running a different provider.
  */
 export function buildReviewArgv(
   project: string,
   pr: number,
   strategy: ReviewStrategy,
+  providerMode?: ReviewProviderMode,
 ): string[] {
   const base = ["review", project, "--pr", String(pr)];
+  if (providerMode) base.push("--provider", providerMode);
   if (strategy === "debate") return [...base, "--strategy", "debate"];
   if (strategy === "standard") return [...base, "--strategy", "standard"];
   return base; // personas → env flag only
@@ -587,10 +668,12 @@ export function buildReviewArgv(
 export function parseReviewStdout(stdout: string): {
   status?: string;
   commentCount?: number;
+  blockerCount?: number;
   incomplete: boolean;
 } {
   const status = [...stdout.matchAll(/status:\s*([A-Z_]+)/g)].at(-1)?.[1];
   const cc = [...stdout.matchAll(/\((\d+)\s+comments?\)/g)].at(-1)?.[1];
+  const blockers = [...stdout.matchAll(/blockers:\s*(\d+)/g)].at(-1)?.[1];
   // REVIEW_INCOMPLETE: mra's single-pass claude emitted no completion sentinel /
   // an empty / unparseable response, so mra EXITS 0 but posts a neutral placeholder
   // review whose GitHub event is COMMENT (review.sh:516 "posting REVIEW_INCOMPLETE";
@@ -602,34 +685,36 @@ export function parseReviewStdout(stdout: string): {
   return {
     status,
     commentCount: cc !== undefined ? Number(cc) : undefined,
+    ...(blockers !== undefined ? { blockerCount: Number(blockers) } : {}),
     incomplete,
   };
 }
 
-/** Clone process.env, strip secrets, pin the review token, set personas flag,
+/** Clone process.env, strip secrets, set the personas flag,
  * and cap the round-1 review agents' turns (see body). */
 export function reviewEnv(
   strategy: ReviewStrategy,
-  ghToken?: string,
-  opts: { allowApprove?: boolean; approveIfNoHigh?: boolean } = {},
+  opts: {
+    providerMode?: ReviewProviderMode;
+    expectedHeadSha?: string;
+  } = {},
 ): NodeJS.ProcessEnv {
   const env = strippedChildEnv();
-  // Privilege flags are derived SOLELY from `opts`/`strategy` below — never
-  // inherited. They are not secret-shaped (so the strip above leaves them), yet
-  // a stray parent-env MRA_REVIEW_ALLOW_APPROVE would silently turn an ordinary
-  // :cr: review (allowApprove: false) into a real GitHub approve. Delete them
-  // first so only the explicit intent from this call survives.
+  // Privilege flags are never inherited. They are not secret-shaped, so the
+  // general denylist does not remove them; delete them explicitly to preserve
+  // the analysis-only integration boundary.
   delete env.MRA_REVIEW_ALLOW_APPROVE;
   delete env.MRA_REVIEW_APPROVE_IF_NO_HIGH;
   delete env.MRA_REVIEW_PERSONAS;
-  // Pin the GitHub token for mra's `gh` POST. Set AFTER the strip so it is the
-  // ONLY github token in the review env; `GH_TOKEN` takes priority over the
-  // host's active gh account, so the posting identity is stable regardless of
-  // which account is active. Unset → mra falls back to ambient gh.
-  if (ghToken) env.GH_TOKEN = ghToken;
+  delete env.MRA_REVIEW_PROVIDER;
+  delete env.MRA_REVIEW_ADMIN_OVERRIDE;
+  delete env.MRA_REVIEW_EXPECTED_HEAD_SHA;
   if (strategy === "personas") env.MRA_REVIEW_PERSONAS = "true";
-  if (opts.allowApprove) env.MRA_REVIEW_ALLOW_APPROVE = "1";
-  if (opts.approveIfNoHigh) env.MRA_REVIEW_APPROVE_IF_NO_HIGH = "1";
+  if (opts.providerMode) {
+    env.MRA_REVIEW_PROVIDER = opts.providerMode;
+    env.MRA_REVIEW_ADMIN_OVERRIDE = "1";
+  }
+  if (opts.expectedHeadSha) env.MRA_REVIEW_EXPECTED_HEAD_SHA = opts.expectedHeadSha;
   // Cap the debate round-1 agents' turns generously. --max-turns is a CAP, not a
   // target: a PKB-backed review finishes well under it (the agent stops at its
   // verdict sentinel), so the headroom costs nothing on fast reviews and rescues
@@ -789,7 +874,7 @@ function spawnMraCommand(
 /**
  * Run `mra review <project> --pr <pr>` as a write-protected subprocess.
  * Secrets are stripped from the child env (see {@link REVIEW_SECRET_ENV_DENYLIST}).
- * No retry — a review either posts or it doesn't (unlike the flaky `mra ask`).
+ * No retry here; the coordinator owns retry policy.
  * Default timeout is 600s (reviews are substantially slower than asks).
  */
 export async function runMraReview(
@@ -800,12 +885,13 @@ export async function runMraReview(
     strategy: ReviewStrategy;
     cwd: string;
     timeoutMs?: number;
-    /** Pinned GitHub token for mra's POST (GH_TOKEN). Undefined → ambient gh. */
-    ghToken?: string;
     /** Abort to SIGTERM the review child (gateway shutdown / drain). */
     signal?: AbortSignal;
-    allowApprove?: boolean;
-    approveIfNoHigh?: boolean;
+    providerMode?: ReviewProviderMode;
+    expectedHeadSha?: string;
+    baseRef?: string;
+    baseSha?: string;
+    prContext?: { title?: string; body?: string; updatedAt?: string };
   },
   opts: { onProgress?: (line: string) => void } = {},
 ): Promise<MraReviewResult> {
@@ -813,19 +899,127 @@ export async function runMraReview(
   if (!binary) {
     return { ok: false, stdout: "", stderr: "", reason: "`mra` binary not found on PATH" };
   }
+  const protocol = args.providerMode === "codex" || args.providerMode === undefined
+    ? mraIntegrationCapabilities(binary)
+    : undefined;
+  if (protocol) {
+    const checkout = path.join(args.workspace, args.project);
+    const expectedHead = args.expectedHeadSha ?? "";
+    if (!/^[0-9a-f]{40}$/i.test(expectedHead)) {
+      return { ok: false, stdout: "", stderr: "", reason: "protocol review requires expectedHeadSha" };
+    }
+    let baseSha = args.baseSha ?? "";
+    if (!/^[0-9a-f]{40}$/i.test(baseSha)) {
+      const baseRef = args.baseRef ?? "main";
+      for (const candidate of [baseRef, `origin/${baseRef}`]) {
+        try {
+          baseSha = execFileSync("git", ["-C", checkout, "merge-base", expectedHead, candidate], {
+            encoding: "utf8", timeout: 10_000, stdio: ["ignore", "pipe", "pipe"],
+          }).trim();
+          if (/^[0-9a-f]{40}$/i.test(baseSha)) break;
+        } catch { /* try remote-tracking ref */ }
+      }
+      if (!/^[0-9a-f]{40}$/i.test(baseSha))
+        return { ok: false, stdout: "", stderr: "", reason: "cannot resolve protocol review base SHA" };
+    }
+    const runDir = mkdtempSync(path.join(os.tmpdir(), "pmk-mra-review-"));
+    const requestPath = path.join(runDir, "request.json");
+    const resultPath = path.join(runDir, "result.json");
+    const eventsPath = path.join(runDir, "events.jsonl");
+    const requestId = randomUUID();
+    const requestJson = JSON.stringify({
+      schema: "io.mra.integration.review-request/v1",
+      protocolVersion: "1.0",
+      requestId,
+      subject: { checkout, project: args.project, pullRequest: args.pr, baseSha, headSha: expectedHead },
+      review: { provider: args.providerMode ?? "codex", strategy: "standard" },
+      context: { pr: args.prContext ?? {} },
+    });
+    const requestSha256 = createHash("sha256").update(requestJson).digest("hex");
+    writeFileSync(requestPath, requestJson, { mode: 0o600 });
+    const env = strippedChildEnv();
+    const timeoutMs = args.timeoutMs ?? 1_200_000;
+    try {
+      const raw = await spawnMraCommand(binary, ["integration", "review", "--request", requestPath, "--result", resultPath, "--events", eventsPath], args.cwd, env, timeoutMs, opts.onProgress, args.signal);
+      if (!existsSync(resultPath)) return { ...raw, ok: false, reason: raw.reason ?? "mra protocol result artifact missing" };
+      const artifact = JSON.parse(readFileSync(resultPath, "utf8")) as {
+        schema?: string; protocolVersion?: string; requestId?: string; requestSha256?: string; artifactSha256?: string;
+        subject?: { headSha?: string; baseSha?: string }; producer?: { product?: string };
+        context?: { mode?: string; nativeRepositoryInstructions?: boolean };
+        providers?: Array<{ provider?: string; status?: string }>;
+        analysis?: { status?: string; verdict?: string };
+        findings?: unknown[]; blockerLedger?: unknown[]; errors?: unknown[];
+      };
+      const { artifactSha256, ...unsignedArtifact } = artifact;
+      const computedArtifactSha256 = createHash("sha256").update(JSON.stringify(unsignedArtifact)).digest("hex");
+      const findings = artifact.findings ?? [];
+      const findingIsValid = (f: unknown): f is { path: string; line: number; body: string; severity: "CRITICAL" | "HIGH" | "MEDIUM" | "LOW" } => {
+        if (!f || typeof f !== "object") return false;
+        const v = f as Record<string, unknown>;
+        return typeof v.path === "string" && v.path.length > 0 && Number.isInteger(v.line) &&
+          typeof v.body === "string" && v.body.length > 0 && ["CRITICAL", "HIGH", "MEDIUM", "LOW"].includes(String(v.severity));
+      };
+      const validFindings = Array.isArray(findings) && findings.every(findingIsValid);
+      const derivedBlockers = validFindings ? findings.filter((f) => f.severity === "CRITICAL" || f.severity === "HIGH") : [];
+      const ledgerMatches = Array.isArray(artifact.blockerLedger) && JSON.stringify(artifact.blockerLedger) === JSON.stringify(derivedBlockers);
+      const verdictMatches = artifact.analysis?.status === "complete" &&
+        ((artifact.analysis.verdict === "pass" && derivedBlockers.length === 0) ||
+         (artifact.analysis.verdict === "block" && derivedBlockers.length > 0));
+      const valid = artifact.schema === "io.mra.integration.review-result/v1" && artifact.protocolVersion === "1.0" &&
+        artifact.requestId === requestId && artifact.subject?.headSha === expectedHead && artifact.subject?.baseSha === baseSha &&
+        artifact.requestSha256 === requestSha256 && artifactSha256 === computedArtifactSha256 &&
+        artifact.producer?.product === "multi-repo-agent" && artifact.context?.mode === "sanitized-untrusted" &&
+        artifact.context.nativeRepositoryInstructions === false && artifact.providers?.length === 1 &&
+        artifact.providers[0]?.provider === "codex" && artifact.providers[0]?.status === "complete" &&
+        Array.isArray(artifact.errors) && artifact.errors.length === 0 && validFindings && ledgerMatches && verdictMatches;
+      if (!valid) return { ...raw, ok: false, reason: "invalid or mismatched mra protocol artifact" };
+      const blockers = derivedBlockers;
+      const complete = artifact.analysis?.status === "complete";
+      const status = artifact.analysis?.verdict === "pass" ? "COMMENT"
+        : artifact.analysis?.verdict === "block" ? "CHANGES_REQUESTED" : "COMMENT";
+      return {
+        ...raw,
+        ok: raw.ok && complete,
+        status,
+        commentCount: findings.length,
+        blockerCount: blockers.length,
+        incomplete: !complete,
+        protocolVersion: "1.0",
+        artifactSha256: artifact.artifactSha256,
+        analyzedHeadSha: expectedHead,
+        summary: typeof (artifact as { summary?: unknown }).summary === "string" ? (artifact as { summary: string }).summary : undefined,
+        findings: findings.map((f) => ({ path: f.path, line: f.line, body: f.body, severity: f.severity })),
+        reason: raw.ok && complete ? undefined : raw.reason ?? "mra protocol analysis incomplete",
+      };
+    } finally {
+      rmSync(runDir, { recursive: true, force: true });
+    }
+  }
+  if (args.providerMode && !mraSupportsReviewProvider(binary)) {
+    return {
+      ok: false,
+      stdout: "",
+      stderr: "",
+      reason: "installed `mra` does not support `review --provider`; upgrade multi-repo-agent before using PMK review provider selection",
+    };
+  }
   // 20 min: the debate pipeline runs sequential multi-agent stages (round 1 →
   // mailbox voting → synthesis); on a large PR (many files / >5 findings) that
   // legitimately exceeds 10 min even with a PKB, so 600s timed out mid-pipeline.
   const timeoutMs = args.timeoutMs ?? 1_200_000;
-  const argv = buildReviewArgv(args.project, args.pr, args.strategy);
-  const env = reviewEnv(args.strategy, args.ghToken, {
-    allowApprove: args.allowApprove,
-    approveIfNoHigh: args.approveIfNoHigh,
+  const argv = buildReviewArgv(args.project, args.pr, args.strategy, args.providerMode);
+  const env = reviewEnv(args.strategy, {
+    providerMode: args.providerMode,
+    expectedHeadSha: args.expectedHeadSha,
   });
 
   const raw = await spawnMraCommand(binary, argv, args.cwd, env, timeoutMs, opts.onProgress, args.signal);
-  const parsed = raw.ok ? parseReviewStdout(raw.stdout) : {};
-  return { ...raw, ...parsed };
+  const parsed: Partial<ReturnType<typeof parseReviewStdout>> = raw.ok ? parseReviewStdout(raw.stdout) : {};
+  // Legacy MRA is review-only. Human stdout can describe a posted comment but
+  // never establishes approval eligibility.
+  const incomplete = parsed.incomplete === true || !parsed.status;
+  return { ...raw, ...parsed, ok: raw.ok && !incomplete, incomplete, blockerCount: undefined, protocolVersion: undefined,
+    reason: raw.ok && incomplete ? "legacy mra did not emit a complete structured verdict" : raw.reason };
 }
 
 /**

--- a/packages/cli/src/gateway/config.ts
+++ b/packages/cli/src/gateway/config.ts
@@ -105,17 +105,24 @@ export interface ResolvedAudioConfig {
 
 export interface ReviewConfig {
   enabled: boolean;
+  approval: { enabled: boolean };
   allowPublicRepos: boolean;
   repoAllowlist?: string[];          // e.g. ["onead/OnePixel"]; undefined = any private repo in workspace
   maxPrsPerTrigger: number;
+  maxConcurrent: number;
+  maxConcurrentPerUser: number;
   strategy: "debate" | "personas" | "standard";
-  expectedGhUser?: string;           // gate: gh api user must equal this before posting
-  /** Allow an AI APPROVED verdict to post as a real GitHub APPROVE (sets
-   * MRA_REVIEW_ALLOW_APPROVE=1). Default false → verdict downgraded to COMMENT. */
-  allowApprove: boolean;
   /**
-   * Pinned GitHub token for ALL review GitHub interactions (PR head, repo
-   * visibility, actor-verify) AND mra's review POST. Literal or {env}/{cmd}
+   * Provider policy passed through to mra review. Defaults to codex so the
+   * Slack gateway does not consume Claude quota unless an admin opts in.
+   * "fallback" means mra tries primary then secondary; "dual" runs both and
+   * merges their findings when the installed mra supports it.
+   */
+  providerMode: "codex" | "claude" | "fallback" | "dual";
+  expectedGhUser?: string;           // gate: gh api user must equal this before posting
+  /**
+   * Pinned GitHub token for PMK-owned review interactions (PR head, repo
+   * visibility, actor verification, review publication, approval). Literal or {env}/{cmd}
    * secret reference. When set, the review uses THIS token's identity —
    * stable, independent of the host's active `gh` account. Recommended:
    * `{ "cmd": "gh auth token --user <work-account>" }` (no raw token on disk,
@@ -327,10 +334,18 @@ function normaliseRawConfig(raw: unknown): RawGatewayConfig {
         }
       : undefined;
   // `:cr:` review config. Carried through as a Partial<ReviewConfig>;
-  // `resolveReviewConfig` applies defaults / clamps / strategy guard at use
+  // `resolveReviewConfig` applies defaults / clamps / enum normalization at use
   // time. Only the known, well-typed fields survive (unknown keys dropped).
   const rawReview = (r as { review?: unknown }).review;
   const review = normaliseReviewConfig(rawReview);
+  // Existing configs predate provider selection and therefore had effective
+  // Claude/debate behavior. Preserve that on load; only genuinely new configs
+  // (no review block) receive the Codex/standard fresh-install default.
+  if (review && rawReview && typeof rawReview === "object" &&
+      !("providerMode" in (rawReview as Record<string, unknown>))) {
+    review.providerMode = "claude";
+    if (!("strategy" in (rawReview as Record<string, unknown>))) review.strategy = "debate";
+  }
   return {
     version: GATEWAY_CONFIG_VERSION,
     admins: asStringArray(r.admins),
@@ -358,17 +373,25 @@ function normaliseReviewConfig(raw: unknown): Partial<ReviewConfig> | undefined 
   const o = raw as Record<string, unknown>;
   const out: Partial<ReviewConfig> = {};
   if (typeof o.enabled === "boolean") out.enabled = o.enabled;
+  if (o.approval && typeof o.approval === "object") {
+    const approval = o.approval as Record<string, unknown>;
+    if (typeof approval.enabled === "boolean")
+      out.approval = { enabled: approval.enabled };
+  }
   if (typeof o.allowPublicRepos === "boolean")
     out.allowPublicRepos = o.allowPublicRepos;
   if (Array.isArray(o.repoAllowlist))
     out.repoAllowlist = asStringArray(o.repoAllowlist);
   if (typeof o.maxPrsPerTrigger === "number")
     out.maxPrsPerTrigger = o.maxPrsPerTrigger;
+  if (typeof o.maxConcurrent === "number") out.maxConcurrent = o.maxConcurrent;
+  if (typeof o.maxConcurrentPerUser === "number") out.maxConcurrentPerUser = o.maxConcurrentPerUser;
   if (o.strategy === "debate" || o.strategy === "personas" || o.strategy === "standard")
     out.strategy = o.strategy;
+  if (o.providerMode === "codex" || o.providerMode === "claude" || o.providerMode === "fallback" || o.providerMode === "dual")
+    out.providerMode = o.providerMode;
   if (typeof o.expectedGhUser === "string")
     out.expectedGhUser = o.expectedGhUser;
-  if (typeof o.allowApprove === "boolean") out.allowApprove = o.allowApprove;
   const ghToken = validateSecretSource(o.ghToken, "review.ghToken");
   if (ghToken !== undefined) out.ghToken = ghToken;
   return out;
@@ -461,25 +484,31 @@ export function resolveGithubToken(
 
 /**
  * Resolve the review config with safe defaults. Clamps `maxPrsPerTrigger`
- * to >=1 and normalizes `strategy` to "debate" unless explicitly "personas".
+ * to >=1, defaults providerMode to "codex", and normalizes `strategy` to
+ * "debate" unless explicitly "personas" or "standard".
  */
 export function resolveReviewConfig(raw?: Partial<ReviewConfig>): ReviewConfig {
   return {
     enabled: raw?.enabled ?? false,
+    approval: { enabled: raw?.approval?.enabled ?? false },
     allowPublicRepos: raw?.allowPublicRepos ?? false,
     repoAllowlist: raw?.repoAllowlist,
     maxPrsPerTrigger: Math.max(1, raw?.maxPrsPerTrigger ?? 5),
+    maxConcurrent: Math.max(1, raw?.maxConcurrent ?? 2),
+    maxConcurrentPerUser: Math.max(1, raw?.maxConcurrentPerUser ?? 1),
     strategy: raw?.strategy === "personas" ? "personas"
-      : raw?.strategy === "standard" ? "standard" : "debate",
+      : raw?.strategy === "debate" ? "debate" : "standard",
+    providerMode: raw?.providerMode === "claude" ? "claude"
+      : raw?.providerMode === "fallback" ? "fallback"
+      : raw?.providerMode === "dual" ? "dual" : "codex",
     expectedGhUser: raw?.expectedGhUser,
-    allowApprove: raw?.allowApprove ?? false,
     ghToken: raw?.ghToken,
   };
 }
 
 /**
  * Resolve the pinned review GitHub token (literal or {env}/{cmd}). When set,
- * every review GitHub call AND mra's review POST uses this token — a stable
+ * every PMK-owned review GitHub call uses this token — a stable
  * identity independent of the host's active `gh` account. Returns undefined
  * when unset (→ host ambient gh, the default). Resolved lazily at review time.
  */

--- a/packages/cli/src/gateway/doctor-checks/review.ts
+++ b/packages/cli/src/gateway/doctor-checks/review.ts
@@ -1,6 +1,6 @@
 import type { DoctorCheck, DoctorCheckResult } from "../doctor";
 import { resolveReviewConfig } from "../config";
-import { findMraBinary } from "../../adapters/mra";
+import { findMraBinary, mraIntegrationCapabilities, mraSupportsReviewProvider } from "../../adapters/mra";
 import { findGhBinary } from "../../adapters/github";
 
 /**
@@ -22,10 +22,14 @@ export const reviewDoctorCheck: DoctorCheck = async (
     };
   }
 
-  const mraPresent = !!findMraBinary();
+  const mraBinary = findMraBinary();
+  const mraPresent = !!mraBinary;
   const ghPresent = !!findGhBinary();
+  const protocol = mraBinary ? mraIntegrationCapabilities(mraBinary, true) : undefined;
   const problems: string[] = [];
   if (!mraPresent) problems.push("mra not on PATH");
+  else if (!protocol && !mraSupportsReviewProvider(mraBinary)) problems.push("mra is too old (review --provider unsupported)");
+  if (review.approval.enabled && !protocol) problems.push("automatic approval requires MRA integration protocol v1");
   if (!ghPresent) problems.push("gh not on PATH");
 
   const warnings: string[] = [];
@@ -34,8 +38,9 @@ export const reviewDoctorCheck: DoctorCheck = async (
       "review.expectedGhUser unset — actor verification skipped at review time",
     );
   }
+  if (!protocol) warnings.push("legacy MRA bridge is review-only; structured completion and approval are unavailable");
 
-  const detail = `mra=${mraPresent ? "found" : "missing"}; gh=${ghPresent ? "found" : "missing"}; strategy=${review.strategy}`;
+  const detail = `mra=${mraPresent ? "found" : "missing"}; protocol=${protocol ? "v1" : "legacy/unavailable"}; gh=${ghPresent ? "found" : "missing"}; provider=${review.providerMode}; strategy=${review.strategy}; approval=${review.approval.enabled ? "enabled" : "disabled"}`;
   const severity = problems.length ? "fail" : warnings.length ? "warn" : "pass";
   const message = problems.length
     ? `${detail} — ${problems.join("; ")}`

--- a/packages/cli/src/gateway/events.ts
+++ b/packages/cli/src/gateway/events.ts
@@ -205,6 +205,10 @@ export interface ReviewTriggeredEvent {
   actor: string;
   channelId: string;
   prCount: number;
+  intent?: "review" | "approve";
+  providerMode?: string;
+  strategy?: string;
+  forced?: boolean;
 }
 
 export interface ReviewPostedEvent {
@@ -214,6 +218,12 @@ export interface ReviewPostedEvent {
   pr: number;
   status: string;    // APPROVED | CHANGES_REQUESTED | COMMENT
   commentCount: number;
+  blockerCount?: number;
+  intent?: "review" | "approve";
+  providerMode?: string;
+  strategy?: string;
+  headSha?: string;
+  forced?: boolean;
   durationMs: number;
 }
 

--- a/packages/cli/src/gateway/index.ts
+++ b/packages/cli/src/gateway/index.ts
@@ -21,6 +21,7 @@ import {
 import { startKeepAwake } from "./keep-awake";
 import { installUnhandledRejectionGuard } from "./crash-guard";
 import { recoverReviewClaims } from "./review-claim";
+import { sweepApprovalOffers } from "./review-approval";
 import { sweepStaleAudioTemp } from "./audio/temp";
 import { sweepStaleAudioClaims } from "./audio/claim";
 import { sweepStaleAtomMarkers } from "./audio/atom-marker";
@@ -105,6 +106,8 @@ export async function runGateway(opts: GatewayRunOptions = {}): Promise<void> {
   if (recoveredClaims > 0) {
     log(`recovered ${recoveredClaims} orphaned review claim(s) from a prior run`);
   }
+  const sweptOffers = sweepApprovalOffers();
+  if (sweptOffers > 0) log(`swept ${sweptOffers} expired review approval offer(s)`);
 
   const sweptTempDirs = sweepStaleAudioTemp();
   if (sweptTempDirs > 0) {

--- a/packages/cli/src/gateway/review-approval.ts
+++ b/packages/cli/src/gateway/review-approval.ts
@@ -1,0 +1,230 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { gatewayDir } from "./config";
+
+export interface ApprovalOfferRef {
+  owner: string;
+  repo: string;
+  number: number;
+  url: string;
+  headSha: string;
+  baseRef: string;
+  artifactSha256: string;
+  contextVersion?: string;
+}
+
+interface ApprovalOffer {
+  channelId: string;
+  threadTs: string;
+  createdAt: string;
+  expiresAt: string;
+  refs: ApprovalOfferRef[];
+}
+
+export interface ApprovalReservation {
+  id: string;
+  channelId: string;
+  threadTs: string;
+  refs: ApprovalOfferRef[];
+  expiresAt: string;
+  reservedPath: string;
+}
+
+function safe(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+function offerDir(): string {
+  const dir = path.join(gatewayDir(), "review-approval-offers");
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function offerPath(channelId: string, threadTs: string): string {
+  return path.join(offerDir(), `${safe(channelId)}__${safe(threadTs)}.json`);
+}
+
+function writeOfferAtomic(target: string, offer: ApprovalOffer): void {
+  const tmp = `${target}.tmp.${process.pid}.${Math.random().toString(16).slice(2)}`;
+  const fd = fs.openSync(tmp, "wx", 0o600);
+  try {
+    fs.writeFileSync(fd, JSON.stringify(offer));
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+  fs.renameSync(tmp, target);
+}
+
+function acquireOfferLock(target: string): string | undefined {
+  const lock = `${target}.lock`;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      fs.mkdirSync(lock, { mode: 0o700 });
+      fs.writeFileSync(path.join(lock, "owner"), String(process.pid), { mode: 0o600 });
+      return lock;
+    } catch {
+      try {
+        const pid = Number(fs.readFileSync(path.join(lock, "owner"), "utf8"));
+        process.kill(pid, 0);
+        return undefined;
+      } catch {
+        try { fs.rmSync(lock, { recursive: true, force: true }); } catch { return undefined; }
+      }
+    }
+  }
+  return undefined;
+}
+
+function releaseOfferLock(lock: string): void {
+  try { fs.rmSync(lock, { recursive: true, force: true }); } catch { /* best-effort */ }
+}
+
+export function saveApprovalOffer(
+  channelId: string,
+  threadTs: string,
+  ref: ApprovalOfferRef,
+  ttlMs = 24 * 60 * 60_000,
+): void {
+  const p = offerPath(channelId, threadTs);
+  const lock = acquireOfferLock(p);
+  if (!lock) return;
+  try {
+  const reservedPrefix = `${path.basename(p)}.reserved.`;
+  if (fs.readdirSync(offerDir()).some((name) => name.startsWith(reservedPrefix))) return;
+  let refs: ApprovalOfferRef[] = [];
+  try {
+    const old = JSON.parse(fs.readFileSync(p, "utf8")) as ApprovalOffer;
+    if (Date.parse(old.expiresAt) > Date.now()) refs = old.refs;
+  } catch { /* new offer */ }
+  refs = [...refs.filter((r) => !(r.owner === ref.owner && r.repo === ref.repo && r.number === ref.number)), ref];
+  const offer: ApprovalOffer = {
+    channelId,
+    threadTs,
+    createdAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + ttlMs).toISOString(),
+    refs,
+  };
+  writeOfferAtomic(p, offer);
+  } finally {
+    releaseOfferLock(lock);
+  }
+}
+
+/** Consume exactly once by renaming before reading. */
+export function consumeApprovalOffer(channelId: string, threadTs: string): ApprovalOfferRef[] | undefined {
+  const p = offerPath(channelId, threadTs);
+  const consumed = `${p}.consumed.${Date.now()}.${process.pid}`;
+  try {
+    fs.renameSync(p, consumed);
+  } catch {
+    return undefined;
+  }
+  try {
+    const offer = JSON.parse(fs.readFileSync(consumed, "utf8")) as ApprovalOffer;
+    if (offer.channelId !== channelId || offer.threadTs !== threadTs) return undefined;
+    if (Date.parse(offer.expiresAt) <= Date.now()) return undefined;
+    return offer.refs;
+  } catch {
+    return undefined;
+  }
+}
+
+export function reserveApprovalOffer(channelId: string, threadTs: string): ApprovalReservation | undefined {
+  const p = offerPath(channelId, threadTs);
+  const lock = acquireOfferLock(p);
+  if (!lock) return undefined;
+  const id = `${Date.now()}.${process.pid}.${Math.random().toString(16).slice(2)}`;
+  const reservedPath = `${p}.reserved.${id}`;
+  try {
+    fs.renameSync(p, reservedPath);
+    const offer = JSON.parse(fs.readFileSync(reservedPath, "utf8")) as ApprovalOffer;
+    if (offer.channelId !== channelId || offer.threadTs !== threadTs || Date.parse(offer.expiresAt) <= Date.now()) {
+      fs.renameSync(reservedPath, `${reservedPath}.invalidated`);
+      return undefined;
+    }
+    return { id, channelId, threadTs, refs: offer.refs, expiresAt: offer.expiresAt, reservedPath };
+  } catch {
+    return undefined;
+  } finally {
+    releaseOfferLock(lock);
+  }
+}
+
+export function releaseApprovalReservation(reservation: ApprovalReservation): void {
+  const target = offerPath(reservation.channelId, reservation.threadTs);
+  const lock = acquireOfferLock(target);
+  if (!lock) return;
+  try {
+  if (Date.parse(reservation.expiresAt) <= Date.now()) {
+    try { fs.renameSync(reservation.reservedPath, `${reservation.reservedPath}.expired`); } catch { /* already terminal */ }
+    return;
+  }
+  const available = target;
+  if (fs.existsSync(available)) {
+    try { fs.renameSync(reservation.reservedPath, `${reservation.reservedPath}.invalidated`); } catch { /* already terminal */ }
+    return;
+  }
+  try { fs.renameSync(reservation.reservedPath, available); } catch { /* already terminal */ }
+  } finally {
+    releaseOfferLock(lock);
+  }
+}
+
+export function consumeApprovalReservation(reservation: ApprovalReservation): void {
+  fs.renameSync(reservation.reservedPath, `${reservation.reservedPath}.consumed`);
+}
+
+export function markApprovalPendingReconcile(reservation: ApprovalReservation): void {
+  fs.renameSync(reservation.reservedPath, `${reservation.reservedPath}.pending-reconcile`);
+}
+
+export function listPendingApprovalReconciliations(channelId: string, threadTs: string): ApprovalReservation[] {
+  const prefix = `${path.basename(offerPath(channelId, threadTs))}.reserved.`;
+  const out: ApprovalReservation[] = [];
+  for (const name of fs.readdirSync(offerDir())) {
+    if (!name.startsWith(prefix) || !name.endsWith(".pending-reconcile")) continue;
+    const pendingPath = path.join(offerDir(), name);
+    try {
+      const offer = JSON.parse(fs.readFileSync(pendingPath, "utf8")) as ApprovalOffer;
+      if (offer.channelId === channelId && offer.threadTs === threadTs)
+        out.push({ id: name, channelId, threadTs, refs: offer.refs, expiresAt: offer.expiresAt, reservedPath: pendingPath });
+    } catch { /* leave malformed evidence for operator inspection */ }
+  }
+  return out;
+}
+
+export function resolveApprovalReconciliation(reservation: ApprovalReservation, outcome: "consumed" | "absent"): void {
+  if (outcome === "consumed") {
+    fs.renameSync(reservation.reservedPath, `${reservation.reservedPath}.consumed`);
+    return;
+  }
+  const available = offerPath(reservation.channelId, reservation.threadTs);
+  if (Date.parse(reservation.expiresAt) <= Date.now() || fs.existsSync(available)) {
+    fs.renameSync(reservation.reservedPath, `${reservation.reservedPath}.invalidated`);
+    return;
+  }
+  fs.renameSync(reservation.reservedPath, available);
+}
+
+export function sweepApprovalOffers(now = Date.now(), terminalRetentionMs = 30 * 24 * 60 * 60_000): number {
+  const dir = offerDir();
+  let removed = 0;
+  for (const name of fs.readdirSync(dir)) {
+    const p = path.join(dir, name);
+    try {
+      const st = fs.statSync(p);
+      if (/\.(consumed|invalidated|expired)$/.test(name) && now - st.mtimeMs > terminalRetentionMs) {
+        fs.rmSync(p, { force: true });
+        removed++;
+      } else if (name.endsWith(".json")) {
+        const offer = JSON.parse(fs.readFileSync(p, "utf8")) as ApprovalOffer;
+        if (Date.parse(offer.expiresAt) <= now) {
+          fs.renameSync(p, `${p}.expired`);
+          removed++;
+        }
+      }
+    } catch { /* concurrent transition */ }
+  }
+  return removed;
+}

--- a/packages/cli/src/gateway/review-claim.ts
+++ b/packages/cli/src/gateway/review-claim.ts
@@ -6,6 +6,7 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { randomUUID } from "node:crypto";
 import { gatewayDir } from "./config"; // SAME base as issue-candidate.ts (imports gatewayDir from ./config)
 
 export interface ReviewRef {
@@ -13,22 +14,31 @@ export interface ReviewRef {
   repo: string;
   pr: number;
   headSha: string;
+  intent?: "review" | "approve";
+  contextVersion?: string;
 }
 
 interface ClaimRecord {
   key: string;
   claimedAt: string;
+  ownerPid?: number;
+  ownerId?: string;
   done?: boolean;
   status?: string;
   reviewUrl?: string;
 }
+
+const activeOwners = new Map<string, string>();
 
 function sanitize(s: string): string {
   return s.replace(/[^A-Za-z0-9._-]/g, "_");
 }
 
 export function reviewClaimKey(r: ReviewRef): string {
-  return [sanitize(r.owner), sanitize(r.repo), String(r.pr), sanitize(r.headSha)].join("__");
+  const base = [sanitize(r.owner), sanitize(r.repo), String(r.pr), sanitize(r.headSha)];
+  const intent = r.intent ?? "review";
+  const withIntent = intent === "review" ? base : [...base, sanitize(intent)];
+  return (r.contextVersion ? [...withIntent, sanitize(r.contextVersion)] : withIntent).join("__");
 }
 
 function reviewsDir(): string {
@@ -42,9 +52,12 @@ function claimPath(r: ReviewRef): string {
 }
 
 export function claimReview(r: ReviewRef): boolean {
-  const rec: ClaimRecord = { key: reviewClaimKey(r), claimedAt: nowIso() };
+  const key = reviewClaimKey(r);
+  const ownerId = randomUUID();
+  const rec: ClaimRecord = { key, claimedAt: nowIso(), ownerPid: process.pid, ownerId };
   try {
     fs.writeFileSync(claimPath(r), JSON.stringify(rec), { flag: "wx", mode: 0o600 });
+    activeOwners.set(key, ownerId);
     return true;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "EEXIST") return false;
@@ -52,21 +65,56 @@ export function claimReview(r: ReviewRef): boolean {
   }
 }
 
-export function finalizeReview(r: ReviewRef, info: { reviewUrl?: string; status?: string }): void {
+/** Archive a completed claim and atomically claim the same SHA again. */
+export function forceClaimReview(r: ReviewRef): boolean {
   const p = claimPath(r);
   let rec: ClaimRecord;
   try {
     rec = JSON.parse(fs.readFileSync(p, "utf8")) as ClaimRecord;
   } catch {
-    rec = { key: reviewClaimKey(r), claimedAt: nowIso() };
+    return claimReview(r);
   }
+  if (rec.done !== true) return false;
+  const archive = path.join(
+    reviewsDir(),
+    `${reviewClaimKey(r)}.history.${Date.now()}.${process.pid}.json`,
+  );
+  try {
+    fs.renameSync(p, archive);
+  } catch {
+    return false;
+  }
+  if (claimReview(r)) return true;
+  try { fs.renameSync(archive, p); } catch { /* best-effort restore */ }
+  return false;
+}
+
+export function finalizeReview(r: ReviewRef, info: { reviewUrl?: string; status?: string }): void {
+  const p = claimPath(r);
+  const key = reviewClaimKey(r);
+  const ownerId = activeOwners.get(key);
+  if (!ownerId) return;
+  let rec: ClaimRecord;
+  try {
+    rec = JSON.parse(fs.readFileSync(p, "utf8")) as ClaimRecord;
+  } catch {
+    return;
+  }
+  if (rec.ownerId !== ownerId) return;
   const updated: ClaimRecord = { ...rec, done: true, status: info.status, reviewUrl: info.reviewUrl };
   fs.writeFileSync(p, JSON.stringify(updated), { mode: 0o600 });
+  activeOwners.delete(key);
 }
 
 export function releaseReview(r: ReviewRef): void {
+  const key = reviewClaimKey(r);
+  const ownerId = activeOwners.get(key);
+  if (!ownerId) return;
   try {
+    const rec = JSON.parse(fs.readFileSync(claimPath(r), "utf8")) as ClaimRecord;
+    if (rec.ownerId !== ownerId) return;
     fs.rmSync(claimPath(r), { force: true });
+    activeOwners.delete(key);
   } catch {
     /* best-effort */
   }
@@ -119,12 +167,21 @@ export function recoverReviewClaims(
     if (!name.endsWith(".json")) continue;
     const p = path.join(dir, name);
     let done = false;
+    let ownerPid: number | undefined;
     try {
-      done = (JSON.parse(fs.readFileSync(p, "utf8")) as ClaimRecord).done === true;
+      const record = JSON.parse(fs.readFileSync(p, "utf8")) as ClaimRecord;
+      done = record.done === true;
+      ownerPid = record.ownerPid;
     } catch {
       done = false; // unreadable / malformed — treat as a non-finalized orphan
     }
     if (done) continue; // completed review — keep (idempotency record)
+    if (ownerPid && ownerPid > 0) {
+      try {
+        process.kill(ownerPid, 0);
+        continue; // another live gateway still owns this review
+      } catch { /* owner exited; age gate below still applies */ }
+    }
     let ageMs: number;
     try {
       // clamp to 0 against sub-ms / future-skew, mirroring recoverIssueClaims

--- a/packages/cli/src/gateway/review-policy.ts
+++ b/packages/cli/src/gateway/review-policy.ts
@@ -1,0 +1,25 @@
+import type { ReviewProviderMode, ReviewStrategy } from "../adapters/mra";
+
+// Release veto: the analysis/review integration is production-ready, but a
+// GitHub APPROVE mutation remains disabled until config writers and the POST
+// path share one cross-process authorization lock.
+export const AUTOMATIC_APPROVAL_RELEASE_READY = false;
+
+export function effectiveMraReviewStrategy(
+  configured: ReviewStrategy,
+  providerMode: ReviewProviderMode,
+  isApprove: boolean,
+): ReviewStrategy {
+  if (isApprove) return "standard";
+  if (providerMode === "claude") return configured;
+  return "standard";
+}
+
+export function reviewStrategySummary(
+  configured: ReviewStrategy,
+  providerMode: ReviewProviderMode,
+): string {
+  const cr = effectiveMraReviewStrategy(configured, providerMode, false);
+  const approve = effectiveMraReviewStrategy(configured, providerMode, true);
+  return `strategy configured \`${configured}\` · effective :cr: \`${cr}\` · :a: \`${approve}\``;
+}

--- a/packages/cli/src/gateway/slack/admin.ts
+++ b/packages/cli/src/gateway/slack/admin.ts
@@ -33,6 +33,7 @@ import {
 import {
   isAdmin,
   loadRawGatewayConfig,
+  resolveReviewConfig,
   saveGatewayConfig,
   type GatewayConfig,
   type RawGatewayConfig,
@@ -43,6 +44,7 @@ import {
   loadAtoms,
   rejectAtom,
 } from "../knowledge";
+import { AUTOMATIC_APPROVAL_RELEASE_READY, reviewStrategySummary } from "../review-policy";
 import { appendAdminLog, readAdminLog } from "../admin-log";
 import { verdict } from "../health-verdict";
 import { lastHeartbeatAt } from "../heartbeat";
@@ -129,6 +131,8 @@ export async function handleAdminSlash(
       return adminAudience(args.actor, rest);
     case "escalation":
       return adminEscalation(args.actor, rest);
+    case "review":
+      return adminReview(args.actor, rest);
     case "atoms":
       return adminAtoms(args.actor, rest);
     case "admins":
@@ -156,6 +160,9 @@ function helpText(): string {
     "• `/pmk admin audience example list [biz|pm]`",
     "• `/pmk admin escalation add <repo|default> @user`",
     "• `/pmk admin escalation remove <repo|default> @user`",
+    "• `/pmk admin review provider <codex|claude|fallback|dual>`",
+    "• `/pmk admin review strategy <standard|debate|personas>`",
+    "• `/pmk admin review status`",
     "• `/pmk admin atoms list [pending|approved|all]`",
     "• `/pmk admin atoms show <id-prefix>`",
     "• `/pmk admin atoms approve <id-prefix>`",
@@ -172,10 +179,14 @@ function helpText(): string {
 
 function adminStatus(actor: string): AdminSlashResult {
   const cfg = loadRawGatewayConfig();
+  const review = resolveReviewConfig(cfg.review);
   const lines: string[] = ["*gateway status*"];
   lines.push(`• mra workspace: ${cfg.mraWorkspace ?? "_(not configured)_"}`);
   lines.push(
     `• default ingest: ${cfg.defaultIngest ?? "_(none)_"}`,
+  );
+  lines.push(
+    `• review: ${review.enabled ? "enabled" : "disabled"} · provider \`${review.providerMode}\` · ${reviewStrategySummary(review.strategy, review.providerMode)}`,
   );
   lines.push(`• audience default: \`${cfg.audience.default}\``);
   lines.push(`• admins: ${cfg.admins.length}`);
@@ -186,6 +197,103 @@ function adminStatus(actor: string): AdminSlashResult {
   lines.push(`• escalation repo pools: ${repoCount}`);
   logAdmin(actor, "status", true);
   return { text: lines.join("\n") };
+}
+
+// ────────────────── review ──────────────────
+
+const REVIEW_PROVIDER_MODES = ["codex", "claude", "fallback", "dual"] as const;
+type ReviewProviderMode = (typeof REVIEW_PROVIDER_MODES)[number];
+function isReviewProviderMode(v: string | undefined): v is ReviewProviderMode {
+  return !!v && (REVIEW_PROVIDER_MODES as readonly string[]).includes(v);
+}
+
+const REVIEW_STRATEGIES = ["standard", "debate", "personas"] as const;
+type ReviewStrategySetting = (typeof REVIEW_STRATEGIES)[number];
+function isReviewStrategySetting(v: string | undefined): v is ReviewStrategySetting {
+  return !!v && (REVIEW_STRATEGIES as readonly string[]).includes(v);
+}
+
+function reviewStatusText(cfg: RawGatewayConfig): string {
+  const review = resolveReviewConfig(cfg.review);
+  return [
+    "*review config*",
+    `• enabled: \`${review.enabled}\``,
+    `• provider: \`${review.providerMode}\``,
+    `• ${reviewStrategySummary(review.strategy, review.providerMode)}`,
+    `• automatic approval: \`${review.approval.enabled}\` (PMK admin confirmation + protected repo required)`,
+    `• concurrency: global \`${review.maxConcurrent}\` · per user \`${review.maxConcurrentPerUser}\``,
+    `• allow public repos: \`${review.allowPublicRepos}\``,
+  ].join("\n");
+}
+
+function adminReview(actor: string, tokens: string[]): AdminSlashResult {
+  const [sub, value] = tokens;
+  const cfg = loadRawGatewayConfig();
+  switch (sub) {
+    case undefined:
+    case "status":
+      logAdmin(actor, "review.status", true);
+      return { text: reviewStatusText(cfg) };
+    case "provider": {
+      if (!isReviewProviderMode(value)) {
+        logAdmin(actor, "review.provider", false, value, "invalid provider");
+        return {
+          text: ":x: usage: `/pmk admin review provider <codex|claude|fallback|dual>`",
+        };
+      }
+      cfg.review = { ...(cfg.review ?? {}), providerMode: value };
+      saveGatewayConfig(cfg);
+      logAdmin(actor, "review.provider", true, value);
+      return {
+        text: `:white_check_mark: review provider set to \`${value}\`（下一次 :cr: / :a: 立即套用）`,
+      };
+    }
+    case "enable":
+    case "disable": {
+      const enabled = sub === "enable";
+      cfg.review = { ...(cfg.review ?? {}), enabled };
+      saveGatewayConfig(cfg);
+      logAdmin(actor, `review.${sub}`, true);
+      return { text: `:white_check_mark: review ${enabled ? "enabled" : "disabled"}` };
+    }
+    case "approval": {
+      if (value !== "enable" && value !== "disable") {
+        return { text: ":x: usage: `/pmk admin review approval <enable|disable>`" };
+      }
+      const enabled = value === "enable";
+      if (enabled && !AUTOMATIC_APPROVAL_RELEASE_READY) {
+        logAdmin(actor, "review.approval.enable", false, undefined, "release veto active");
+        return { text: ":lock: automatic approval 尚未 release；`:cr:` review 可正常使用，但目前不能開啟 GitHub APPROVE。" };
+      }
+      cfg.review = { ...(cfg.review ?? {}), approval: { enabled } };
+      saveGatewayConfig(cfg);
+      logAdmin(actor, `review.approval.${value}`, true);
+      return {
+        text: enabled
+          ? ":warning: automatic approval enabled; each repo must still pass protocol, identity, head-SHA, allowlist, and branch-protection readiness checks"
+          : ":white_check_mark: automatic approval disabled; `:cr:` review remains available",
+      };
+    }
+    case "strategy": {
+      if (!isReviewStrategySetting(value)) {
+        logAdmin(actor, "review.strategy", false, value, "invalid strategy");
+        return {
+          text: ":x: usage: `/pmk admin review strategy <standard|debate|personas>`",
+        };
+      }
+      cfg.review = { ...(cfg.review ?? {}), strategy: value };
+      saveGatewayConfig(cfg);
+      logAdmin(actor, "review.strategy", true, value);
+      return {
+        text: `:white_check_mark: review strategy set to \`${value}\`（下一次 :cr: 立即套用；:a: 固定使用 \`standard\`）`,
+      };
+    }
+    default:
+      logAdmin(actor, "review", false, tokens.join(" "), "bad args");
+      return {
+        text: ":x: usage: `/pmk admin review status|enable|disable|provider|strategy|approval ...`",
+      };
+  }
 }
 
 // ────────────────── audience ──────────────────

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -55,7 +55,7 @@ import {
   runMraAsk as runMraAskImpl,
 } from "../../adapters/mra";
 import { IssueCoordinator, realGithubGateway, type GithubGateway } from "./issue";
-import { ReviewCoordinator, realReviewGateway, isReviewRequest, isRetryRequest, isApproveRequest } from "./review";
+import { ReviewCoordinator, realReviewGateway, isReviewRequest, isRetryRequest, isRerunRequest, isApproveRequest, isApproveConfirmationRequest } from "./review";
 import { AudioCoordinator, isAudioMessage } from "../audio/coordinator";
 import { needsConsentNotice } from "../audio/consent";
 import { pickAudience } from "../config";
@@ -317,6 +317,7 @@ export class SlackAdapter {
       config: this.config,
       onLog: this.onLog,
       gateway: realReviewGateway,
+      strictLiveConfigReload: true,
     });
     this.audio = new AudioCoordinator({
       web: this.web,
@@ -692,7 +693,7 @@ export class SlackAdapter {
     // mandatory so a detached rejection can't crash the process.
     // `retry` in a review-result thread → re-run that thread's PR review
     // (re-fetches the thread root `:cr:` message). Detached + .catch like below.
-    if (this.review.isEnabled() && isApproveRequest(text)) {
+    if (isApproveRequest(text) && this.review.isEnabled()) {
       void this.review
         .fromApproveMessage({ channelId, threadTs: replyThreadTs, userId, text })
         .catch((err) =>
@@ -700,7 +701,7 @@ export class SlackAdapter {
         );
       return;
     }
-    if (this.review.isEnabled() && isReviewRequest(text)) {
+    if (isReviewRequest(text) && this.review.isEnabled()) {
       void this.review
         .fromMessage({ channelId, threadTs: replyThreadTs, userId, text })
         .catch((err) =>
@@ -713,6 +714,14 @@ export class SlackAdapter {
     // review. audio.retryInThread returns false (and posts nothing) for
     // non-audio threads; the caller then falls through to review. Nothing is
     // silently swallowed regardless of which coordinators are enabled.
+    if (isRerunRequest(text)) {
+      if (this.review.isEnabled()) {
+        await this.review.rerunInThread({ channelId, threadTs: replyThreadTs, userId }).catch((err) =>
+          this.onLog(`review: mention rerun failed: ${(err as Error).message}`),
+        );
+      }
+      return;
+    }
     if (isRetryRequest(text)) {
       const botToken = this.config.slack.botToken ?? "";
       const tier = pickAudience(this.config, userId, channelId);
@@ -729,6 +738,24 @@ export class SlackAdapter {
         // of silently dropping the bare retry.
         await this.web.chat
           .postMessage({ channel: channelId, thread_ts: replyThreadTs, text: "這個 thread 沒有可重試的音訊或 PR review。" })
+          .catch(() => {});
+      }
+      return;
+    }
+
+    // `approve` in a review thread is the explicit authorization step offered
+    // by a clean `:cr:` result. It runs the approve path; `:cr:` itself never
+    // submits GitHub APPROVE.
+    if (isApproveConfirmationRequest(text)) {
+      if (this.review.isEnabled()) {
+        await this.review
+          .confirmApproveInThread({ channelId, threadTs: replyThreadTs, userId })
+          .catch((err) =>
+            this.onLog(`review: mention approve confirmation failed: ${(err as Error).message}`),
+          );
+      } else {
+        await this.web.chat
+          .postMessage({ channel: channelId, thread_ts: replyThreadTs, text: "PR review 功能未啟用，無法執行 approve。" })
           .catch(() => {});
       }
       return;
@@ -848,7 +875,7 @@ export class SlackAdapter {
     // immediately and posts each PR's result when done. MUST .catch — a
     // detached rejection would crash the process (unhandled rejection).
     // `retry` in a review-result thread → re-run that thread's PR review.
-    if (this.review.isEnabled() && isApproveRequest(text)) {
+    if (isApproveRequest(text) && this.review.isEnabled()) {
       void this.review
         .fromApproveMessage({ channelId, threadTs, userId, text })
         .catch((err) =>
@@ -856,7 +883,7 @@ export class SlackAdapter {
         );
       return;
     }
-    if (this.review.isEnabled() && isReviewRequest(text)) {
+    if (isReviewRequest(text) && this.review.isEnabled()) {
       void this.review
         .fromMessage({ channelId, threadTs, userId, text })
         .catch((err) =>
@@ -869,6 +896,14 @@ export class SlackAdapter {
     // review. audio.retryInThread returns false (and posts nothing) for
     // non-audio threads; the caller then falls through to review. Nothing is
     // silently swallowed regardless of which coordinators are enabled.
+    if (isRerunRequest(text)) {
+      if (this.review.isEnabled()) {
+        await this.review.rerunInThread({ channelId, threadTs, userId }).catch((err) =>
+          this.onLog(`review: DM rerun failed: ${(err as Error).message}`),
+        );
+      }
+      return;
+    }
     if (isRetryRequest(text)) {
       const botToken = this.config.slack.botToken ?? "";
       const tier = pickAudience(this.config, userId);
@@ -885,6 +920,24 @@ export class SlackAdapter {
         // of silently dropping the bare retry.
         await this.web.chat
           .postMessage({ channel: channelId, thread_ts: threadTs, text: "這個 thread 沒有可重試的音訊或 PR review。" })
+          .catch(() => {});
+      }
+      return;
+    }
+
+    // `approve` in a `:cr:` result thread confirms that pmk may run the
+    // approval path. The approve gate still re-reviews and only approves when
+    // no HIGH/CRITICAL blocker is found.
+    if (isApproveConfirmationRequest(text)) {
+      if (this.review.isEnabled()) {
+        await this.review
+          .confirmApproveInThread({ channelId, threadTs, userId })
+          .catch((err) =>
+            this.onLog(`review: DM approve confirmation failed: ${(err as Error).message}`),
+          );
+      } else {
+        await this.web.chat
+          .postMessage({ channel: channelId, thread_ts: threadTs, text: "PR review 功能未啟用，無法執行 approve。" })
           .catch(() => {});
       }
       return;

--- a/packages/cli/src/gateway/slack/review-progress.ts
+++ b/packages/cli/src/gateway/slack/review-progress.ts
@@ -21,11 +21,11 @@ export function phaseFromLine(line: string): Phase | undefined {
   if (line.includes("posting inline review")) return "posting";
   // Analyze markers. `loaded existing PR discussion` is CONDITIONAL (only when the
   // PR already has discussion), so a fresh PR would never reach analyze on that
-  // line alone. `running Claude` (single-pass, review.sh:461) is UNCONDITIONAL on
+  // line alone. `running <provider>` (single-pass, review.sh) is UNCONDITIONAL on
   // stdout; the debate round markers are on stderr (usually invisible here) but
   // matched too, in case stderr is ever merged into the progress stream.
   if (
-    line.includes("running Claude") ||
+    /running (Claude|claude|Codex|codex|fallback|dual)\b/.test(line) ||
     line.includes("loaded existing PR discussion") ||
     line.includes("independent analysis") ||
     line.includes("mailbox voting") ||

--- a/packages/cli/src/gateway/slack/review.ts
+++ b/packages/cli/src/gateway/slack/review.ts
@@ -12,28 +12,51 @@
  *   on any pre-post failure: releaseReview + review.skipped + thread note;
  *   always: teardownReviewClone.
  */
+import * as fs from "node:fs";
+import { randomUUID } from "node:crypto";
+import * as path from "node:path";
 import type { WebClient } from "@slack/web-api";
 import type { GatewayConfig } from "../config";
 import { ReviewProgress } from "./review-progress";
 import {
+  gatewayConfigPath,
+  loadRawGatewayConfig,
   resolveReviewConfig,
   resolveGithubToken,
   resolveReviewGhToken,
   reviewWorkspaceDir,
+  isAdmin,
 } from "../config";
 import { appendGatewayEvent } from "../events";
 import { parsePrRefs, type PrRef } from "../pr-ref";
-import { claimReview, finalizeReview, releaseReview, type ReviewRef } from "../review-claim";
+import { claimReview, forceClaimReview, finalizeReview, releaseReview, type ReviewRef } from "../review-claim";
+import {
+  consumeApprovalReservation,
+  listPendingApprovalReconciliations,
+  markApprovalPendingReconcile,
+  releaseApprovalReservation,
+  reserveApprovalOffer,
+  resolveApprovalReconciliation,
+  saveApprovalOffer,
+  type ApprovalOfferRef,
+  type ApprovalReservation,
+} from "../review-approval";
 import {
   resolveProjectByRemote as resolveProjectByRemoteImpl,
   runMraReview as runMraReviewImpl,
   runMraAnalyze as runMraAnalyzeImpl,
 } from "../../adapters/mra";
+import { AUTOMATIC_APPROVAL_RELEASE_READY, effectiveMraReviewStrategy } from "../review-policy";
+export { effectiveMraReviewStrategy } from "../review-policy";
 import {
   resolveRepoSlug as resolveRepoSlugImpl,
   repoVisibility as repoVisibilityImpl,
   getAuthUser as getAuthUserImpl,
   getPrHead as getPrHeadImpl,
+  approvalProtectionReady as approvalProtectionReadyImpl,
+  createPullRequestApproval as createPullRequestApprovalImpl,
+  hasPullRequestApproval as hasPullRequestApprovalImpl,
+  createPullRequestReview as createPullRequestReviewImpl,
 } from "../../adapters/github";
 import {
   prepareReviewClone as prepareReviewCloneImpl,
@@ -50,6 +73,10 @@ export interface ReviewGateway {
   repoVisibility: typeof repoVisibilityImpl;
   getAuthUser: typeof getAuthUserImpl;
   getPrHead: typeof getPrHeadImpl;
+  approvalProtectionReady: typeof approvalProtectionReadyImpl;
+  createPullRequestApproval: typeof createPullRequestApprovalImpl;
+  hasPullRequestApproval: typeof hasPullRequestApprovalImpl;
+  createPullRequestReview: typeof createPullRequestReviewImpl;
   prepareReviewClone: typeof prepareReviewCloneImpl;
   teardownReviewClone: typeof teardownReviewCloneImpl;
   ensureReviewWorkspaceMeta: typeof ensureReviewWorkspaceMetaImpl;
@@ -64,6 +91,10 @@ export const realReviewGateway: ReviewGateway = {
   repoVisibility: repoVisibilityImpl,
   getAuthUser: getAuthUserImpl,
   getPrHead: getPrHeadImpl,
+  approvalProtectionReady: approvalProtectionReadyImpl,
+  createPullRequestApproval: createPullRequestApprovalImpl,
+  hasPullRequestApproval: hasPullRequestApprovalImpl,
+  createPullRequestReview: createPullRequestReviewImpl,
   prepareReviewClone: prepareReviewCloneImpl,
   teardownReviewClone: teardownReviewCloneImpl,
   ensureReviewWorkspaceMeta: ensureReviewWorkspaceMetaImpl,
@@ -88,19 +119,61 @@ export function isApproveRequest(text: string): boolean {
   return text.includes(":a:") && parsePrRefs(text).length > 0;
 }
 
-/** Fields of an mra review result that shape the Slack result line. */
-interface ReviewOutcome {
-  status?: string;
-  commentCount?: number;
-  /** mra posted a neutral REVIEW_INCOMPLETE placeholder — the review never evaluated the PR. */
-  incomplete?: boolean;
+/**
+ * Bare confirmation inside a review thread. This is intentionally narrower than
+ * ordinary chat: `:cr:` may offer approval, but GitHub APPROVE only happens after
+ * an explicit user confirmation.
+ */
+export function isApproveConfirmationRequest(text: string): boolean {
+  const t = text
+    .trim()
+    .toLowerCase()
+    .replace(/[。.!！]+$/g, "")
+    .replace(/\s+/g, " ");
+  return [
+    "approve",
+    "approve pr",
+    "approve this",
+    "confirm approve",
+    "yes approve",
+    "確認 approve",
+    "確認approve",
+    "請 approve",
+    "可以 approve",
+    "進行 approve",
+    "核准",
+  ].includes(t);
 }
 
-/** Result line for a plain `:cr:` review (reports whatever status mra posted). */
-export function reviewResultText(slug: string, ref: PrRef, res: ReviewOutcome): string {
+/** Fields of an mra review result that shape the Slack result line. */
+export interface ReviewOutcome {
+  status?: string;
+  commentCount?: number;
+  blockerCount?: number;
+  /** mra posted a neutral REVIEW_INCOMPLETE placeholder — the review never evaluated the PR. */
+  incomplete?: boolean;
+  protocolVersion?: "1.0";
+  artifactSha256?: string;
+  analyzedHeadSha?: string;
+}
+
+export function canConfirmApproveFromReview(res: ReviewOutcome): boolean {
+  if (res.incomplete === true) return false;
+  return res.protocolVersion === "1.0" && typeof res.artifactSha256 === "string" &&
+    typeof res.analyzedHeadSha === "string" && res.blockerCount === 0 &&
+    (res.status === "COMMENT" || res.status === "COMMENTED");
+}
+
+/** Result line for a plain `:cr:` review. It never claims GitHub approval. */
+export function reviewResultText(slug: string, ref: PrRef, res: ReviewOutcome, approvalEnabled = true): string {
   if (res.incomplete)
-    return `:warning: ${slug}#${ref.number} review 未完成（mra 回報 REVIEW_INCOMPLETE，未真正評估此 PR — 可能 max-turns 截斷或 claude 呼叫失敗）；已貼中性佔位，claim 已釋放，請重試 :cr:：${ref.url}`;
-  return `:white_check_mark: 已對 ${slug}#${ref.number} 貼 review（${res.status ?? "COMMENT"}，${res.commentCount ?? 0} 則）：${ref.url}`;
+    return `:warning: ${slug}#${ref.number} review 未完成（mra 回報 REVIEW_INCOMPLETE，未真正評估此 PR — 可能 max-turns 截斷或 provider 呼叫失敗）；已貼中性佔位，claim 已釋放，請重試 :cr:：${ref.url}`;
+  const status = res.status ?? "COMMENT";
+  const count = res.commentCount ?? 0;
+  if (approvalEnabled && canConfirmApproveFromReview(res)) {
+    return `:mag: 已完成 ${slug}#${ref.number} review（GitHub action: ${status}；${count} 則）。這個結果沒有 HIGH/CRITICAL blocker，可進一步 approve，但 :cr: 不會主動 approve；請由 PMK admin 在此 channel thread @PMK 回覆 \`approve\` 授權（DM 可直接回覆）：${ref.url}`;
+  }
+  return `:mag: 已完成 ${slug}#${ref.number} review（GitHub action: ${status}；${count} 則；未執行 GitHub approve）：${ref.url}`;
 }
 
 /**
@@ -115,7 +188,7 @@ export function reviewResultText(slug: string, ref: PrRef, res: ReviewOutcome): 
 export function approveResultText(slug: string, ref: PrRef, res: ReviewOutcome): string {
   const cc = res.commentCount ?? 0;
   if (res.incomplete)
-    return `:warning: 未 approve ${slug}#${ref.number} — review 未完成（mra 回報 REVIEW_INCOMPLETE，可能 max-turns 截斷或 claude 呼叫失敗），未做任何 approve；請重試 :a: 或手動 review：${ref.url}`;
+    return `:warning: 未 approve ${slug}#${ref.number} — review 未完成（mra 回報 REVIEW_INCOMPLETE，可能 max-turns 截斷或 provider 呼叫失敗），未做任何 approve；請重試 :a: 或手動 review：${ref.url}`;
   if (res.status === "APPROVED")
     return `:white_check_mark: 已 approve ${slug}#${ref.number}（無重大問題；${cc} 則 minor 建議）：${ref.url}`;
   if (res.status === "CHANGES_REQUESTED")
@@ -137,11 +210,11 @@ function lastNonEmptyLine(s?: string): string | undefined {
 }
 
 /**
- * Turn an mra failure into something actionable. mra runs `claude` under
- * `set -euo pipefail` with `2>/dev/null`, so a non-zero claude exit becomes a
- * silent `mra exited with code=1` with no stderr — `detail` then falls back to
- * the last stdout phase (e.g. "running Claude") so the Slack message says WHERE
- * it died; `logDump` records the full picture for the operator's gateway log.
+ * Turn an mra failure into something actionable. Older mra review paths ran
+ * providers under `set -euo pipefail` with `2>/dev/null`, so a non-zero provider
+ * exit can become a silent `mra exited with code=1` with no stderr — `detail`
+ * then falls back to the last stdout phase so the Slack message says WHERE it
+ * died; `logDump` records the full picture for the operator's gateway log.
  */
 export function describeMraFailure(res: {
   reason?: string;
@@ -159,7 +232,7 @@ export function describeMraFailure(res: {
     `reason=${res.reason ?? "unknown"}`,
     errTail
       ? `stderr=${errTail}`
-      : "stderr=(empty — mra likely swallowed claude's error via 2>/dev/null)",
+      : "stderr=(empty — mra likely swallowed the provider error via 2>/dev/null)",
     outTail ? `stdout(last)=${outTail}` : "",
   ]
     .filter(Boolean)
@@ -175,7 +248,12 @@ export function describeMraFailure(res: {
  */
 export function isRetryRequest(text: string): boolean {
   const t = text.trim().toLowerCase();
-  return t === "retry" || t === "重試" || t === "重跑";
+  return t === "retry" || t === "重試";
+}
+
+export function isRerunRequest(text: string): boolean {
+  const t = text.trim().toLowerCase();
+  return t === "rerun" || t === "重跑";
 }
 
 export interface ReviewCoordinatorOptions {
@@ -185,6 +263,8 @@ export interface ReviewCoordinatorOptions {
   gateway: ReviewGateway;
   /** Injectable sleep for the transient-failure retry backoff (tests pass a no-op). */
   sleep?: (ms: number) => Promise<void>;
+  /** Production mode: stale startup review credentials must not survive a bad live reload. */
+  strictLiveConfigReload?: boolean;
 }
 
 /** A review currently running detached — tracked so shutdown can drain it (A). */
@@ -195,6 +275,8 @@ interface InFlightReview {
   /** Where to post the "interrupted by restart" notice on shutdown (B). */
   channelId: string;
   threadTs: string;
+  actorUserId: string;
+  projectKey: string;
 }
 
 export class ReviewCoordinator {
@@ -202,6 +284,33 @@ export class ReviewCoordinator {
   private readonly inFlight = new Set<InFlightReview>();
 
   constructor(private readonly opts: ReviewCoordinatorOptions) {}
+
+  private currentConfig(): GatewayConfig {
+    try {
+      // Tests and embedding callers may construct the coordinator without a
+      // gateway.json. In the daemon, once the file exists, treat its review policy
+      // as authoritative so deleting a token/approval flag/review block is a live
+      // revocation rather than a stale merge with startup config.
+      if (!fs.existsSync(gatewayConfigPath())) {
+        if (!this.opts.strictLiveConfigReload) return this.opts.config;
+        this.opts.onLog("review: live config missing; review disabled fail-closed");
+        return { ...this.opts.config, github: undefined, review: undefined };
+      }
+      const loaded = loadRawGatewayConfig();
+      return {
+        ...this.opts.config,
+        admins: loaded.admins,
+        blocklist: loaded.blocklist,
+        mraWorkspace: process.env.PMK_MRA_WORKSPACE ?? loaded.mraWorkspace,
+        github: loaded.github,
+        review: loaded.review,
+      };
+    } catch (err) {
+      this.opts.onLog(`review: live config reload failed: ${(err as Error).message}`);
+      if (!this.opts.strictLiveConfigReload) return this.opts.config;
+      return { ...this.opts.config, github: undefined, review: undefined };
+    }
+  }
 
   /**
    * A (graceful drain): on gateway shutdown, abort every in-flight review —
@@ -264,7 +373,7 @@ export class ReviewCoordinator {
 
   /** Whether the `:cr:` review flow is enabled (config-gated). */
   isEnabled(): boolean {
-    return resolveReviewConfig(this.opts.config.review).enabled;
+    return resolveReviewConfig(this.currentConfig().review).enabled;
   }
 
   /** `:cr:` REACTION on a message → fetch the message text, then review. */
@@ -317,8 +426,8 @@ export class ReviewCoordinator {
   }
 
   /**
-   * Inline `:a:` in a DM or @-mention message → fast review then approve if
-   * no high-severity issue found. The caller gates with `isEnabled()` +
+   * Inline `:a:` in a DM or @-mention message starts review plus approval
+   * intent. A separate thread confirmation is still required. The caller gates with `isEnabled()` +
    * `isApproveRequest()` before routing here.
    */
   async fromApproveMessage(args: {
@@ -341,11 +450,32 @@ export class ReviewCoordinator {
     threadTs: string;
     actorUserId: string;
     text: string;
+    offeredRefs?: ApprovalOfferRef[];
+    forced?: boolean;
   }): Promise<void> {
     const { channelId, threadTs, actorUserId, text } = args;
-    const { config, gateway, onLog } = this.opts;
+    const { gateway, onLog } = this.opts;
+    const config = this.currentConfig();
     const review = resolveReviewConfig(config.review);
     if (!review.enabled) return;
+    if (!review.approval.enabled) {
+      await this.reply(channelId, threadTs, ":lock: GitHub automatic approval 目前為安全停用狀態；`:cr:` review 仍可正常使用。");
+      return;
+    }
+    if (!isAdmin(config, actorUserId)) {
+      await this.reply(channelId, threadTs, ":no_entry: GitHub approve 只能由 PMK admin 明確授權；`:cr:` review 仍可由一般使用者執行。");
+      return;
+    }
+    if (!args.offeredRefs) {
+      await this.reply(channelId, threadTs, ":mag: `:a:` 會先執行安全 review；完成且沒有 blocker 後，我會再請你於 thread 明確回覆 `approve`，不會直接核准。");
+      await this.processReviewRequest({
+        channelId,
+        threadTs,
+        actorUserId,
+        text: text.replace(":a:", ":cr:"),
+      });
+      return;
+    }
 
     const workspace = config.mraWorkspace;
     if (!workspace) {
@@ -353,7 +483,8 @@ export class ReviewCoordinator {
       return;
     }
 
-    const refs = parsePrRefs(text, { cap: review.maxPrsPerTrigger });
+    const refs = args.offeredRefs?.map(({ owner, repo, number, url }) => ({ owner, repo, number, url }))
+      ?? parsePrRefs(text, { cap: review.maxPrsPerTrigger });
     if (refs.length === 0) return;
 
     appendGatewayEvent({
@@ -361,6 +492,10 @@ export class ReviewCoordinator {
       actor: actorUserId,
       channelId,
       prCount: refs.length,
+      intent: "approve",
+      providerMode: review.providerMode,
+      strategy: effectiveMraReviewStrategy(review.strategy, review.providerMode, true),
+      forced: args.forced,
     });
 
     // Multi-PR summary ack only. For a single PR the per-PR progress bar (posted
@@ -374,11 +509,13 @@ export class ReviewCoordinator {
       );
     }
 
-    const reviewWorkspace = reviewWorkspaceDir();
-    gateway.ensureReviewWorkspaceMeta(workspace, reviewWorkspace);
+    const reviewWorkspaceRoot = reviewWorkspaceDir();
     const token = resolveReviewGhToken(config.review) ?? resolveGithubToken(config.github);
 
     for (const ref of refs) {
+      const reviewWorkspace = path.join(reviewWorkspaceRoot, "runs", randomUUID());
+      gateway.ensureReviewWorkspaceMeta(workspace, reviewWorkspace);
+      try {
       await this.runOne(ref, {
         channelId,
         threadTs,
@@ -387,7 +524,14 @@ export class ReviewCoordinator {
         reviewWorkspace,
         review,
         token,
+        authorizedHeads: args.offeredRefs
+          ? new Map(args.offeredRefs.map((r) => [`${r.owner}/${r.repo}#${r.number}`, r.headSha]))
+          : undefined,
+        forceRerun: args.forced,
       }, "approve");
+      } finally {
+        try { fs.rmSync(reviewWorkspace, { recursive: true, force: true }); } catch { /* best-effort */ }
+      }
     }
   }
 
@@ -405,7 +549,7 @@ export class ReviewCoordinator {
     threadTs: string;
     userId: string;
   }): Promise<void> {
-    if (!resolveReviewConfig(this.opts.config.review).enabled) return;
+    if (!resolveReviewConfig(this.currentConfig().review).enabled) return;
     const rootText = await this.fetchMessageText(args.channelId, args.threadTs);
     // An approve thread (`:a:`) is drained the same way as a `:cr:` review and its
     // interruption notice tells the user to reply `retry` — so retry must re-run
@@ -428,8 +572,170 @@ export class ReviewCoordinator {
       actorUserId: args.userId,
       text: rootText,
     };
+    if (approve && !resolveReviewConfig(this.currentConfig().review).approval.enabled) {
+      await this.reply(args.channelId, args.threadTs, ":lock: GitHub automatic approval 目前為安全停用狀態；請改用 `:cr:` 重跑 review。");
+    } else if (approve) await this.processApproveRequest(req);
+    else await this.processReviewRequest(req);
+  }
+
+  /** Admin-only forced re-review of an already finalized same-SHA claim. */
+  async rerunInThread(args: { channelId: string; threadTs: string; userId: string }): Promise<void> {
+    const config = this.currentConfig();
+    if (!resolveReviewConfig(config.review).enabled) return;
+    if (!isAdmin(config, args.userId)) {
+      await this.reply(args.channelId, args.threadTs, ":no_entry: `rerun` 會略過同 commit 的完成紀錄，只允許 PMK admin 執行。");
+      return;
+    }
+    const rootText = await this.fetchMessageText(args.channelId, args.threadTs);
+    const approve = rootText ? isApproveRequest(rootText) : false;
+    const review = rootText ? isReviewRequest(rootText) : false;
+    if (!rootText || (!approve && !review)) {
+      await this.reply(args.channelId, args.threadTs, ":information_source: 這個 thread 沒有可重跑的 PR review。");
+      return;
+    }
+    const req = { channelId: args.channelId, threadTs: args.threadTs, actorUserId: args.userId, text: rootText, forced: true };
     if (approve) await this.processApproveRequest(req);
     else await this.processReviewRequest(req);
+  }
+
+  /**
+   * `approve` posted in a `:cr:` review thread → explicit authorization to run
+   * the approve path for the same PR. This keeps `:cr:` review-only while giving
+   * users a clear one-step confirmation when the review result is approvable.
+   */
+  async confirmApproveInThread(args: {
+    channelId: string;
+    threadTs: string;
+    userId: string;
+  }): Promise<void> {
+    const config = this.currentConfig();
+    const review = resolveReviewConfig(config.review);
+    if (!review.enabled) return;
+    if (!AUTOMATIC_APPROVAL_RELEASE_READY || !review.approval.enabled) {
+      await this.reply(args.channelId, args.threadTs, ":lock: GitHub automatic approval 目前為安全停用狀態；這個 review 不會執行 approve。");
+      return;
+    }
+    if (!isAdmin(config, args.userId)) {
+      await this.reply(args.channelId, args.threadTs, ":no_entry: approve 授權只接受 PMK admin；請 admin 在此 thread 回覆 `approve`。");
+      return;
+    }
+    const pending = listPendingApprovalReconciliations(args.channelId, args.threadTs);
+    if (pending.length > 0) {
+      const token = resolveReviewGhToken(config.review) ?? resolveGithubToken(config.github);
+      const actor = review.expectedGhUser ?? await this.opts.gateway.getAuthUser({ token });
+      if (!actor) {
+        await this.reply(args.channelId, args.threadTs, ":warning: pending approve 無法確認 GitHub identity，未自動重送。");
+        return;
+      }
+      for (const item of pending) {
+        const matches = await Promise.all(item.refs.map((ref) => this.opts.gateway.hasPullRequestApproval({
+          slug: `${ref.owner}/${ref.repo}`, pr: ref.number, commitId: ref.headSha,
+          artifactSha256: ref.artifactSha256, actor, token,
+        })));
+        if (matches.every((v) => v === true)) {
+          resolveApprovalReconciliation(item, "consumed");
+          await this.reply(args.channelId, args.threadTs, ":information_source: 已由 GitHub review ledger 確認先前 approve 成功，不會重送。");
+          return;
+        }
+        // A negative list result is not proof that a timed-out POST will never
+        // become visible. Keep pending until an operator explicitly resolves it.
+        if (matches.every((v) => v === false)) {
+          await this.reply(args.channelId, args.threadTs, ":warning: GitHub 尚未找到先前 approve，但為避免 eventual-consistency 重複送出，維持 pending reconcile，需由 operator 處理。");
+          return;
+        }
+        await this.reply(args.channelId, args.threadTs, ":warning: pending approve 對帳結果不完整，維持 pending reconcile，不會自動重送。");
+        return;
+      }
+    }
+    const reservation = reserveApprovalOffer(args.channelId, args.threadTs);
+    if (!reservation?.refs.length) {
+      await this.reply(
+        args.channelId,
+        args.threadTs,
+        ":information_source: 這個 thread 沒有有效、未使用的 approve offer。請先完成 `:cr: <PR 連結>` review；offer 使用一次或逾時後需重新 review。",
+      );
+      return;
+    }
+    await this.publishApprovalReservation(reservation, args.userId);
+  }
+
+  private async publishApprovalReservation(reservation: ApprovalReservation, actorUserId: string): Promise<void> {
+    const { gateway } = this.opts;
+    let mutationStarted = false;
+    try {
+      if (reservation.refs.length !== 1)
+        throw new Error("multi-PR approval must be confirmed in separate review threads");
+      for (const ref of reservation.refs) {
+        const live = this.currentConfig();
+        const review = resolveReviewConfig(live.review);
+        const slug = `${ref.owner}/${ref.repo}`;
+        if (!AUTOMATIC_APPROVAL_RELEASE_READY || !review.enabled || !review.approval.enabled || !isAdmin(live, actorUserId) || live.blocklist.includes(actorUserId))
+          throw new Error("approval policy or admin authorization was revoked");
+        if (review.repoAllowlist && !review.repoAllowlist.includes(slug))
+          throw new Error("repository is no longer allowlisted");
+        const token = resolveReviewGhToken(live.review) ?? resolveGithubToken(live.github);
+        const policyRevision = JSON.stringify({
+          admins: [...live.admins].sort(), blocklist: [...live.blocklist].sort(), review,
+          actorUserId, slug, token,
+        });
+        const authUser = await gateway.getAuthUser({ token });
+        if (!authUser || (review.expectedGhUser && authUser !== review.expectedGhUser))
+          throw new Error("GitHub identity is not approval-ready");
+        const before = await gateway.getPrHead({ slug, pr: ref.number, token });
+        if (!before || before.sha !== ref.headSha || before.baseRef !== ref.baseRef ||
+            (ref.contextVersion && before.updatedAt !== ref.contextVersion))
+          throw new Error("PR head, base, or review context changed after review");
+        if (!await gateway.approvalProtectionReady({ slug, branch: ref.baseRef, token }))
+          throw new Error("repository protection is not approval-ready");
+        const finalLive = this.currentConfig();
+        const finalReview = resolveReviewConfig(finalLive.review);
+        const finalToken = resolveReviewGhToken(finalLive.review) ?? resolveGithubToken(finalLive.github);
+        const finalRevision = JSON.stringify({
+          admins: [...finalLive.admins].sort(), blocklist: [...finalLive.blocklist].sort(), review: finalReview,
+          actorUserId, slug, token: finalToken,
+        });
+        if (finalRevision !== policyRevision || finalToken !== token)
+          throw new Error("approval policy changed during preflight");
+        const finalActor = await gateway.getAuthUser({ token: finalToken });
+        const finalHead = await gateway.getPrHead({ slug, pr: ref.number, token: finalToken });
+        if (finalActor !== authUser || !finalHead || finalHead.sha !== ref.headSha || finalHead.baseRef !== ref.baseRef ||
+            (ref.contextVersion && finalHead.updatedAt !== ref.contextVersion))
+          throw new Error("approval identity or PR changed during final preflight");
+        const postFence = this.currentConfig();
+        const postFenceReview = resolveReviewConfig(postFence.review);
+        const postFenceToken = resolveReviewGhToken(postFence.review) ?? resolveGithubToken(postFence.github);
+        const postFenceRevision = JSON.stringify({
+          admins: [...postFence.admins].sort(), blocklist: [...postFence.blocklist].sort(), review: postFenceReview,
+          actorUserId, slug, token: postFenceToken,
+        });
+        if (postFenceRevision !== policyRevision || postFenceToken !== token)
+          throw new Error("approval policy changed immediately before publication");
+        mutationStarted = true;
+        const posted = await gateway.createPullRequestApproval({
+          slug,
+          pr: ref.number,
+          commitId: ref.headSha,
+          token,
+          body: `PMK approval for MRA artifact ${ref.artifactSha256}`,
+        });
+        const after = await gateway.getPrHead({ slug, pr: ref.number, token });
+        if (!after || after.sha !== ref.headSha)
+          throw new Error(`approval ${posted.reviewId} became stale during publication`);
+        await this.reply(reservation.channelId, reservation.threadTs,
+          `:white_check_mark: 已真實 approve ${slug}#${ref.number}（commit \`${ref.headSha.slice(0, 7)}\`，GitHub review #${posted.reviewId}）。`);
+      }
+      consumeApprovalReservation(reservation);
+    } catch (err) {
+      if (mutationStarted) {
+        markApprovalPendingReconcile(reservation);
+        await this.reply(reservation.channelId, reservation.threadTs,
+          `:warning: approve 結果無法確定，已進入 pending reconcile，不會自動重送：${(err as Error).message}`);
+      } else {
+        releaseApprovalReservation(reservation);
+        await this.reply(reservation.channelId, reservation.threadTs,
+          `:no_entry: approve preflight 未通過，授權尚未消耗：${(err as Error).message}`);
+      }
+    }
   }
 
   /** Shared core: parse PR refs from the text, then review each (fail-soft). */
@@ -438,9 +744,11 @@ export class ReviewCoordinator {
     threadTs: string;
     actorUserId: string;
     text: string;
+    forced?: boolean;
   }): Promise<void> {
     const { channelId, threadTs, actorUserId, text } = args;
-    const { config, gateway, onLog } = this.opts;
+    const { gateway, onLog } = this.opts;
+    const config = this.currentConfig();
     const review = resolveReviewConfig(config.review);
     if (!review.enabled) return;
 
@@ -458,6 +766,10 @@ export class ReviewCoordinator {
       actor: actorUserId,
       channelId,
       prCount: refs.length,
+      intent: "review",
+      providerMode: review.providerMode,
+      strategy: effectiveMraReviewStrategy(review.strategy, review.providerMode, false),
+      forced: args.forced,
     });
 
     // Multi-PR summary ack only — a single PR's own progress bar (runOne) is its
@@ -471,23 +783,29 @@ export class ReviewCoordinator {
       );
     }
 
-    const reviewWorkspace = reviewWorkspaceDir(); // ~/.pmk/review-workspace
-    gateway.ensureReviewWorkspaceMeta(workspace, reviewWorkspace);
+    const reviewWorkspaceRoot = reviewWorkspaceDir(); // ~/.pmk/review-workspace
     // Pinned review token (stable identity, independent of the host's active
     // gh account) takes priority; fall back to the issue-flow github token, else
-    // undefined → host ambient gh. Used for ALL review gh calls + mra's POST.
+    // undefined → host ambient gh. Used only by PMK-owned GitHub calls.
     const token = resolveReviewGhToken(config.review) ?? resolveGithubToken(config.github);
 
     for (const ref of refs) {
-      await this.runOne(ref, {
-        channelId,
-        threadTs,
-        reactorUserId: actorUserId,
-        workspace,
-        reviewWorkspace,
-        review,
-        token,
-      }, "review");
+      const reviewWorkspace = path.join(reviewWorkspaceRoot, "runs", randomUUID());
+      gateway.ensureReviewWorkspaceMeta(workspace, reviewWorkspace);
+      try {
+        await this.runOne(ref, {
+          channelId,
+          threadTs,
+          reactorUserId: actorUserId,
+          workspace,
+          reviewWorkspace,
+          review,
+          token,
+          forceRerun: args.forced,
+        }, "review");
+      } finally {
+        try { fs.rmSync(reviewWorkspace, { recursive: true, force: true }); } catch { /* best-effort */ }
+      }
     }
   }
 
@@ -511,17 +829,19 @@ export class ReviewCoordinator {
       reviewWorkspace: string;
       review: ReturnType<typeof resolveReviewConfig>;
       token?: string;
+      authorizedHeads?: Map<string, string>;
+      forceRerun?: boolean;
     },
     mode: "review" | "approve",
   ): Promise<void> {
     const { gateway, onLog } = this.opts;
     const isApprove = mode === "approve";
     const verb = isApprove ? "approve" : "review";
-    // approve always runs the fast single-agent pass; :cr: honors the config
-    // strategy. The progress-bar pacing MUST match the strategy actually run,
-    // else a fast approve creeps at the slow debate cadence (and never reaches
-    // the result before jumping to done).
-    const strategy = isApprove ? "standard" : ctx.review.strategy;
+    // approve always runs the fast single-agent pass. :cr: must run the
+    // configured review strategy for the selected provider; mra is responsible
+    // for rejecting unsupported provider+strategy pairs explicitly.
+    // The progress-bar pacing MUST match the strategy actually run.
+    const strategy = effectiveMraReviewStrategy(ctx.review.strategy, ctx.review.providerMode, isApprove);
     const slugDisplay = `${ref.owner}/${ref.repo}`;
 
     let progress: ReviewProgress | undefined = undefined;
@@ -561,6 +881,11 @@ export class ReviewCoordinator {
       await skip("pr-head", `:warning: 取不到 PR #${ref.number} 的 head，略過`);
       return;
     }
+    const authorizedHead = ctx.authorizedHeads?.get(`${ref.owner}/${ref.repo}#${ref.number}`);
+    if (authorizedHead && authorizedHead !== head.sha) {
+      await skip("approval-head-changed", `:warning: PR #${ref.number} 在 approve 授權後已有新 commit；未 approve，請重新執行 :cr:。`);
+      return;
+    }
 
     // public-repo / allowlist guard (checked BEFORE claim to avoid wasted claims)
     if (ctx.review.repoAllowlist && !ctx.review.repoAllowlist.includes(slug)) {
@@ -591,17 +916,29 @@ export class ReviewCoordinator {
       repo: slugRepo,
       pr: ref.number,
       headSha: head.sha,
+      intent: isApprove ? "approve" as const : "review" as const,
+      contextVersion: head.updatedAt,
     };
-    if (!claimReview(claimRef)) {
+    const projectKey = `${slugOwner}/${slugRepo}`;
+    const actorActive = [...this.inFlight].filter((r) => r.actorUserId === ctx.reactorUserId).length;
+    if (this.inFlight.size >= ctx.review.maxConcurrent || actorActive >= ctx.review.maxConcurrentPerUser || [...this.inFlight].some((r) => r.projectKey === projectKey)) {
+      await skip("busy", `:hourglass: review 目前已達併發上限，或同一 repo 正在 review；請稍後重試。`);
+      return;
+    }
+    const claimed = ctx.forceRerun ? forceClaimReview(claimRef) : claimReview(claimRef);
+    if (!claimed) {
       // Idempotency: this exact commit was already reviewed. Don't re-review
       // (avoids duplicate posts) — but DON'T be silent: the user got the "收到"
       // ack, so tell them why no result follows. (Benign; no review.skipped
       // event so it doesn't read as a failure.)
       onLog(`review: already done ${slug}#${ref.number}@${head.sha.slice(0, 8)}`);
+      const alreadyDone = isApprove
+        ? `:information_source: ${slug}#${ref.number} 這個 commit（\`${head.sha.slice(0, 7)}\`）已經執行過 approve check，略過（同一 commit 不重複 approve）。要重新判斷請推新 commit 後再發 :a:。`
+        : `:information_source: ${slug}#${ref.number} 這個 commit（\`${head.sha.slice(0, 7)}\`）已經 review 過了，略過（同一 commit 不重複審）。要重審請推新 commit 後再發。`;
       await this.reply(
         ctx.channelId,
         ctx.threadTs,
-        `:information_source: ${slug}#${ref.number} 這個 commit（\`${head.sha.slice(0, 7)}\`）已經 review 過了，略過（同一 commit 不重複審）。要重審請推新 commit 後再發。`,
+        alreadyDone,
       );
       return;
     }
@@ -615,6 +952,8 @@ export class ReviewCoordinator {
       label: `${slug}#${ref.number}`,
       channelId: ctx.channelId,
       threadTs: ctx.threadTs,
+      actorUserId: ctx.reactorUserId,
+      projectKey,
     };
     this.inFlight.add(inflight);
 
@@ -639,7 +978,7 @@ export class ReviewCoordinator {
       // + the honest verdict cover it). One-time ~few-min cost the first time a
       // repo is reviewed (or after it goes stale).
       const mainClone = `${ctx.workspace}/${project}`;
-      if (gateway.pkbNeedsBuild(mainClone)) {
+      if (ctx.review.providerMode === "claude" && gateway.pkbNeedsBuild(mainClone)) {
         onLog(`pkb: ${project} 缺/過時 PKB — 先建(一次性,之後 review 又快又完整)`);
         const built = await gateway.runMraAnalyze(
           { project, cwd: ctx.workspace, signal: controller.signal },
@@ -689,12 +1028,12 @@ export class ReviewCoordinator {
         pr: ref.number,
         strategy,
         cwd: ctx.reviewWorkspace,
-        ghToken: ctx.token, // pin mra's POST identity (GH_TOKEN), stable vs active gh
+        providerMode: ctx.review.providerMode,
+        expectedHeadSha: head.sha,
+        baseRef: prep.baseRef,
+        baseSha: head.baseSha,
+        prContext: { title: head.title, body: head.body, updatedAt: head.updatedAt },
         signal: controller.signal, // A: shutdown aborts → SIGTERM the review child
-        // :a: is the explicit per-invocation opt-in to approve; :cr: honors the
-        // config gate. approveIfNoHigh only makes sense on the approve path.
-        allowApprove: isApprove ? true : ctx.review.allowApprove,
-        ...(isApprove ? { approveIfNoHigh: true } : {}),
       };
       const onProgress = (line: string) => {
         onLog(`mra ${verb} ${slug}#${ref.number}: ${line}`);
@@ -702,14 +1041,12 @@ export class ReviewCoordinator {
       };
       let res = await gateway.runMraReview(mraArgs, { onProgress });
       let retried = false;
-      // Retry once on a transient failure OR a REVIEW_INCOMPLETE. mra runs `claude`
-      // under set -e with 2>/dev/null: an intermittent non-zero claude exit
-      // (rate-limit / overload under concurrent load) surfaces as a bare `exited
-      // with code=1` (res.ok=false), while an empty / unparseable claude response
-      // makes mra EXIT 0 but post a neutral REVIEW_INCOMPLETE placeholder
-      // (res.ok=true, res.incomplete=true). Both are the same flaky single-pass
-      // claude and both routinely recover on a re-run, so retry either. Skip the
-      // retry if aborted (shutdown drain) — not transient, clone about to be torn down.
+      // Retry once on a transient failure OR a REVIEW_INCOMPLETE. Provider
+      // overload/rate-limit can surface as a bare `exited with code=1`
+      // (res.ok=false), while an empty / unparseable response makes mra EXIT 0
+      // but post a neutral REVIEW_INCOMPLETE placeholder. Both routinely recover
+      // on a re-run. Skip the retry if aborted (shutdown drain) — not transient,
+      // clone about to be torn down.
       if ((!res.ok || res.incomplete) && !controller.signal.aborted) {
         const why = res.ok
           ? "回報 REVIEW_INCOMPLETE"
@@ -747,8 +1084,54 @@ export class ReviewCoordinator {
         return;
       }
 
+      if (res.protocolVersion === "1.0") {
+        const live = this.currentConfig();
+        const liveReview = resolveReviewConfig(live.review);
+        if (!liveReview.enabled || live.blocklist.includes(ctx.reactorUserId)) {
+          await skip("policy-revoked", ":no_entry: review policy 在分析期間已撤銷，未貼 GitHub review。");
+          return;
+        }
+        if (liveReview.repoAllowlist && !liveReview.repoAllowlist.includes(slug)) {
+          await skip("policy-revoked", ":no_entry: repository 已不在 review allowlist，未貼 GitHub review。");
+          return;
+        }
+        const liveToken = resolveReviewGhToken(live.review) ?? resolveGithubToken(live.github);
+        const liveActor = await gateway.getAuthUser({ token: liveToken });
+        if (!liveActor || (liveReview.expectedGhUser && liveActor !== liveReview.expectedGhUser)) {
+          await skip("gh-actor-revoked", ":no_entry: GitHub review identity 在分析期間已改變，未貼 review。");
+          return;
+        }
+        const liveHead = await gateway.getPrHead({ slug, pr: ref.number, token: liveToken });
+        if (!liveHead || liveHead.sha !== head.sha) {
+          await skip("review-head-changed", `:warning: PR #${ref.number} 在分析期間已有新 commit；未貼過期 review。`);
+          return;
+        }
+        const postedReview = await gateway.createPullRequestReview({
+          slug,
+          pr: ref.number,
+          commitId: head.sha,
+          token: liveToken,
+          event: res.status === "CHANGES_REQUESTED" ? "REQUEST_CHANGES" : "COMMENT",
+          body: `${res.summary ?? "MRA review completed"}\n\nMRA artifact: ${res.artifactSha256}`,
+          comments: res.findings ?? [],
+        });
+        res.status = postedReview.state;
+      }
+
       posted = true;
       finalizeReview(claimRef, { status: res.status });
+      if (!isApprove && ctx.review.approval.enabled && canConfirmApproveFromReview(res)) {
+        saveApprovalOffer(ctx.channelId, ctx.threadTs, {
+          owner: slugOwner,
+          repo: slugRepo,
+          number: ref.number,
+          url: ref.url,
+          headSha: head.sha,
+          baseRef: head.baseRef,
+          artifactSha256: res.artifactSha256!,
+          contextVersion: head.updatedAt,
+        });
+      }
       appendGatewayEvent({
         type: "review.posted",
         actor: ctx.reactorUserId,
@@ -756,11 +1139,17 @@ export class ReviewCoordinator {
         pr: ref.number,
         status: res.status ?? "COMMENT",
         commentCount: res.commentCount ?? 0,
+        blockerCount: res.blockerCount,
+        intent: mode,
+        providerMode: ctx.review.providerMode,
+        strategy,
+        headSha: head.sha,
+        forced: ctx.forceRerun,
         durationMs: Date.now() - t0,
       });
       const resultText = isApprove
         ? approveResultText(slug, ref, res)
-        : reviewResultText(slug, ref, res);
+        : reviewResultText(slug, ref, res, ctx.review.approval.enabled);
       if (progress) await progress.finish(resultText);
       else await this.reply(ctx.channelId, ctx.threadTs, resultText);
     } catch (err) {

--- a/packages/cli/test/gateway.test.ts
+++ b/packages/cli/test/gateway.test.ts
@@ -2326,6 +2326,41 @@ describe("Slack admin handler (#31)", () => {
     assert.match(r.text, /`wat`/);
   });
 
+  it("review provider command mutates the admin-selected mra provider", async () => {
+    const { handleAdminSlash } = await import("../src/gateway/slack/admin");
+    const r = await handleAdminSlash({
+      actor: "U0OWNER",
+      tokens: ["review", "provider", "claude"],
+    });
+    assert.match(r.text, /review provider set to `claude`/);
+    const reload = loadGatewayConfig();
+    assert.equal(reload.review?.providerMode, "claude");
+  });
+
+  it("review status shows the effective provider default", async () => {
+    const { handleAdminSlash } = await import("../src/gateway/slack/admin");
+    const r = await handleAdminSlash({
+      actor: "U0OWNER",
+      tokens: ["review", "status"],
+    });
+    assert.match(r.text, /review config/);
+    assert.match(r.text, /provider: `codex`/);
+    assert.match(r.text, /strategy configured `standard`/);
+    assert.match(r.text, /effective :cr: `standard`/);
+    assert.match(r.text, /:a: `standard`/);
+  });
+
+  it("review provider rejects unknown values", async () => {
+    const { handleAdminSlash } = await import("../src/gateway/slack/admin");
+    const r = await handleAdminSlash({
+      actor: "U0OWNER",
+      tokens: ["review", "provider", "bad-provider"],
+    });
+    assert.match(r.text, /usage: `\/pmk admin review provider/);
+    const reload = loadGatewayConfig();
+    assert.equal(reload.review?.providerMode, undefined);
+  });
+
   it("audience set @user pm mutates per-user override", async () => {
     const { handleAdminSlash } = await import("../src/gateway/slack/admin");
     // Seed an admin so the trust path mirrors prod (handler trusts caller).

--- a/packages/cli/test/github-review-helpers.test.ts
+++ b/packages/cli/test/github-review-helpers.test.ts
@@ -1,7 +1,16 @@
 // packages/cli/test/github-review-helpers.test.ts
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { buildGhArgs_getPrHead, buildGhArgs_getAuthUser } from "../src/adapters/github";
+import {
+  approvalProtectionReady,
+  buildGhArgs_createPullRequestApproval,
+  buildGhArgs_getApprovalProtection,
+  buildGhArgs_getPrHead,
+  buildGhArgs_hasPullRequestApproval,
+  buildGhArgs_getAuthUser,
+  createPullRequestApproval,
+  createPullRequestReview,
+} from "../src/adapters/github";
 
 describe("github review helper argv", () => {
   it("getAuthUser argv", () => {
@@ -9,7 +18,59 @@ describe("github review helper argv", () => {
   });
   it("getPrHead argv", () => {
     assert.deepEqual(buildGhArgs_getPrHead("o/r", 12), [
-      "api", "repos/o/r/pulls/12", "--jq", "{sha:.head.sha,base:.base.ref}",
+      "api", "repos/o/r/pulls/12", "--jq", "{sha:.head.sha,base:.base.ref,baseSha:.base.sha,title:.title,body:.body,updatedAt:.updated_at}",
     ]);
+  });
+  it("builds a SHA-bound APPROVE request", () => {
+    assert.deepEqual(buildGhArgs_createPullRequestApproval({ slug: "o/r", pr: 12, commitId: "abc", body: "artifact d" }), [
+      "api", "--method", "POST", "repos/o/r/pulls/12/reviews",
+      "-f", "event=APPROVE", "-f", "commit_id=abc", "-f", "body=artifact d",
+    ]);
+  });
+  it("builds a commit, artifact, and actor-bound reconciliation query", () => {
+    const args = buildGhArgs_hasPullRequestApproval({ slug: "o/r", pr: 12, commitId: "a".repeat(40), artifactSha256: "b".repeat(64), actor: "pmk-bot" });
+    assert.match(args.at(-1)!, /commit_id.*user\.login.*contains/);
+  });
+  it("requires both stale-review protection controls", async () => {
+    assert.deepEqual(buildGhArgs_getApprovalProtection("o/r", "main"), [
+      "api", "repos/o/r/branches/main/protection", "--jq",
+      "{dismissStale:.required_pull_request_reviews.dismiss_stale_reviews,requireLastPush:.required_pull_request_reviews.require_last_push_approval}",
+    ]);
+    const ready = await approvalProtectionReady({ slug: "o/r", branch: "main", token: "secret" }, {
+      findBinary: () => "gh",
+      exec: async (_file, _args, opts) => {
+        assert.equal(opts.env?.GH_TOKEN, "secret");
+        return { stdout: JSON.stringify({ dismissStale: true, requireLastPush: true }) };
+      },
+    });
+    assert.equal(ready, true);
+  });
+  it("accepts only a matching GitHub APPROVED response", async () => {
+    const result = await createPullRequestApproval({ slug: "o/r", pr: 12, commitId: "abc", body: "artifact", token: "secret" }, {
+      findBinary: () => "gh",
+      exec: async () => ({ stdout: JSON.stringify({ id: 9, state: "APPROVED", commit_id: "abc", user: { login: "bot" } }) }),
+    });
+    assert.deepEqual(result, { reviewId: 9, state: "APPROVED", commitId: "abc", actor: "bot", htmlUrl: undefined });
+  });
+  it("posts inline findings from a private JSON input file", async () => {
+    let argv: string[] = [];
+    const result = await createPullRequestReview({
+      slug: "o/r", pr: 12, commitId: "abc", event: "REQUEST_CHANGES", body: "summary",
+      comments: [{ path: "src/a.ts", line: 7, severity: "HIGH", body: "fix it" }], token: "secret",
+    }, {
+      findBinary: () => "gh",
+      exec: async (_file, args, opts) => {
+        argv = args;
+        assert.equal(opts.env?.GH_TOKEN, "secret");
+        const input = args.at(-1)!;
+        const payload = JSON.parse((await import("node:fs")).readFileSync(input, "utf8"));
+        assert.equal(payload.commit_id, "abc");
+        assert.equal(payload.event, "REQUEST_CHANGES");
+        assert.deepEqual(payload.comments, [{ path: "src/a.ts", line: 7, side: "RIGHT", body: "[HIGH] fix it" }]);
+        return { stdout: JSON.stringify({ id: 10, state: "CHANGES_REQUESTED", commit_id: "abc" }) };
+      },
+    });
+    assert.deepEqual(argv.slice(0, 4), ["api", "--method", "POST", "repos/o/r/pulls/12/reviews"]);
+    assert.equal(result.state, "CHANGES_REQUESTED");
   });
 });

--- a/packages/cli/test/mra-review.test.ts
+++ b/packages/cli/test/mra-review.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { execFileSync } from "node:child_process";
-import { resolveProjectByRemote, parseReviewStdout, buildReviewArgv, reviewEnv, strippedChildEnv } from "../src/adapters/mra";
+import { resolveProjectByRemote, parseReviewStdout, buildReviewArgv, reviewEnv, strippedChildEnv, mraSupportsReviewProvider } from "../src/adapters/mra";
 
 let ws: string;
 function mkRepo(dir: string, originUrl: string) {
@@ -37,10 +37,30 @@ describe("review argv + stdout parse", () => {
     assert.deepEqual(buildReviewArgv("superdsp-ui", 547, "standard"),
       ["review", "superdsp-ui", "--pr", "547", "--strategy", "standard"]);
   });
+  it("buildReviewArgv passes the default codex provider explicitly", () => {
+    assert.deepEqual(buildReviewArgv("onepixel", 12, "standard", "codex"),
+      ["review", "onepixel", "--pr", "12", "--provider", "codex", "--strategy", "standard"]);
+  });
+  it("buildReviewArgv passes a non-default admin-selected provider", () => {
+    assert.deepEqual(buildReviewArgv("onepixel", 12, "standard", "claude"),
+      ["review", "onepixel", "--pr", "12", "--provider", "claude", "--strategy", "standard"]);
+  });
   it("parseReviewStdout pulls status + comment count", () => {
     // EXACT sample lines from Task 0 spike — replace with real captured output:
     const out = "reviewing onepixel ...\nposting inline review to onead/OnePixel#12 (3 comments)...\nstatus: CHANGES_REQUESTED | comments: 3\n";
     assert.deepEqual(parseReviewStdout(out), { status: "CHANGES_REQUESTED", commentCount: 3, incomplete: false });
+  });
+  it("parseReviewStdout pulls blocker count from the authoritative summary", () => {
+    const out = "posting inline review to onead/OnePixel#12 (2 comments)...\nstatus: CHANGES_REQUESTED | comments: 2 | blockers: 0\n";
+    assert.deepEqual(parseReviewStdout(out), { status: "CHANGES_REQUESTED", commentCount: 2, blockerCount: 0, incomplete: false });
+  });
+  it("detects whether the installed mra supports explicit review providers", () => {
+    const current = path.join(ws, "mra-current");
+    const old = path.join(ws, "mra-old");
+    fs.writeFileSync(current, "#!/bin/sh\necho 'review --provider codex|claude'\n", { mode: 0o755 });
+    fs.writeFileSync(old, "#!/bin/sh\necho 'review --pr N'\n", { mode: 0o755 });
+    assert.equal(mraSupportsReviewProvider(current), true);
+    assert.equal(mraSupportsReviewProvider(old), false);
   });
   it("parseReviewStdout takes the LAST status/count (mra's authoritative line), not PR content echoed earlier", () => {
     // A malicious/decoy PR diff echoed in progress output contains a fake status
@@ -107,30 +127,41 @@ describe("reviewEnv", () => {
       else process.env.MRA_REVIEW_AGENT_MAX_TURNS = prev;
     }
   });
-  it("strips secrets, pins GH_TOKEN, sets the personas flag", () => {
+  it("strips secrets and GitHub credentials, sets the personas flag", () => {
     const prev = process.env.ANTHROPIC_API_KEY;
+    const prevGh = process.env.GH_TOKEN;
     process.env.ANTHROPIC_API_KEY = "sk-test";
     try {
-      const env = reviewEnv("personas", "ghtok");
+      process.env.GH_TOKEN = "ghtok";
+      const env = reviewEnv("personas");
       assert.equal(env.ANTHROPIC_API_KEY, undefined);
       assert.equal(env.MRA_REVIEW_PERSONAS, "true");
-      assert.equal(env.GH_TOKEN, "ghtok");
+      assert.equal(env.GH_TOKEN, undefined);
     } finally {
       if (prev === undefined) delete process.env.ANTHROPIC_API_KEY;
       else process.env.ANTHROPIC_API_KEY = prev;
+      if (prevGh === undefined) delete process.env.GH_TOKEN;
+      else process.env.GH_TOKEN = prevGh;
     }
   });
-  it("sets MRA_REVIEW_ALLOW_APPROVE=1 when allowApprove is true", () => {
-    assert.equal(reviewEnv("debate", undefined, { allowApprove: true }).MRA_REVIEW_ALLOW_APPROVE, "1");
-  });
-  it("does not set MRA_REVIEW_ALLOW_APPROVE when allowApprove is absent", () => {
+  it("never sets MRA_REVIEW_ALLOW_APPROVE", () => {
     assert.equal(reviewEnv("debate").MRA_REVIEW_ALLOW_APPROVE, undefined);
   });
-  it("does not set MRA_REVIEW_APPROVE_IF_NO_HIGH when approveIfNoHigh is absent", () => {
+  it("never sets MRA_REVIEW_APPROVE_IF_NO_HIGH", () => {
     assert.equal(reviewEnv("debate").MRA_REVIEW_APPROVE_IF_NO_HIGH, undefined);
   });
-  it("sets MRA_REVIEW_APPROVE_IF_NO_HIGH=1 when approveIfNoHigh is true", () => {
-    assert.equal(reviewEnv("standard", undefined, { approveIfNoHigh: true }).MRA_REVIEW_APPROVE_IF_NO_HIGH, "1");
+  it("passes the exact PR head SHA to mra", () => {
+    assert.equal(reviewEnv("standard", { expectedHeadSha: "abc123" }).MRA_REVIEW_EXPECTED_HEAD_SHA, "abc123");
+  });
+  it("sets provider override env for the default codex provider", () => {
+    const env = reviewEnv("standard", { providerMode: "codex" });
+    assert.equal(env.MRA_REVIEW_PROVIDER, "codex");
+    assert.equal(env.MRA_REVIEW_ADMIN_OVERRIDE, "1");
+  });
+  it("sets MRA_REVIEW_PROVIDER with admin override for non-default providers", () => {
+    const env = reviewEnv("standard", { providerMode: "claude" });
+    assert.equal(env.MRA_REVIEW_PROVIDER, "claude");
+    assert.equal(env.MRA_REVIEW_ADMIN_OVERRIDE, "1");
   });
 
   // H2: the approve-privilege flags are set ONLY from opts, never inherited from
@@ -164,6 +195,22 @@ describe("reviewEnv", () => {
     } finally {
       if (prev === undefined) delete process.env.MRA_REVIEW_PERSONAS;
       else process.env.MRA_REVIEW_PERSONAS = prev;
+    }
+  });
+  it("does NOT inherit MRA_REVIEW_PROVIDER from the parent env when providerMode is absent", () => {
+    const prevProvider = process.env.MRA_REVIEW_PROVIDER;
+    const prevAdmin = process.env.MRA_REVIEW_ADMIN_OVERRIDE;
+    process.env.MRA_REVIEW_PROVIDER = "claude";
+    process.env.MRA_REVIEW_ADMIN_OVERRIDE = "1";
+    try {
+      const env = reviewEnv("standard");
+      assert.equal(env.MRA_REVIEW_PROVIDER, undefined);
+      assert.equal(env.MRA_REVIEW_ADMIN_OVERRIDE, undefined);
+    } finally {
+      if (prevProvider === undefined) delete process.env.MRA_REVIEW_PROVIDER;
+      else process.env.MRA_REVIEW_PROVIDER = prevProvider;
+      if (prevAdmin === undefined) delete process.env.MRA_REVIEW_ADMIN_OVERRIDE;
+      else process.env.MRA_REVIEW_ADMIN_OVERRIDE = prevAdmin;
     }
   });
 

--- a/packages/cli/test/review-approval.test.ts
+++ b/packages/cli/test/review-approval.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { consumeApprovalOffer, consumeApprovalReservation, listPendingApprovalReconciliations, markApprovalPendingReconcile, releaseApprovalReservation, reserveApprovalOffer, resolveApprovalReconciliation, saveApprovalOffer, sweepApprovalOffers } from "../src/gateway/review-approval";
+
+const originalHome = process.env.HOME;
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-review-offer-"));
+  process.env.HOME = tmp;
+});
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("review approval offers", () => {
+  it("persists refs and consumes the offer exactly once", () => {
+    const ref = { owner: "o", repo: "r", number: 3, url: "https://github.com/o/r/pull/3", headSha: "abc", baseRef: "main", artifactSha256: "digest" };
+    saveApprovalOffer("C1", "1.1", ref);
+    assert.deepEqual(consumeApprovalOffer("C1", "1.1"), [ref]);
+    assert.equal(consumeApprovalOffer("C1", "1.1"), undefined);
+  });
+
+  it("rejects an expired offer", () => {
+    saveApprovalOffer("C1", "1.1", { owner: "o", repo: "r", number: 3, url: "u", headSha: "abc", baseRef: "main", artifactSha256: "digest" }, -1);
+    assert.equal(consumeApprovalOffer("C1", "1.1"), undefined);
+  });
+
+  it("releases a reservation after preflight failure and consumes only after publish", () => {
+    const ref = { owner: "o", repo: "r", number: 3, url: "u", headSha: "abc", baseRef: "main", artifactSha256: "digest" };
+    saveApprovalOffer("C1", "1.1", ref);
+    const first = reserveApprovalOffer("C1", "1.1");
+    assert.ok(first);
+    assert.equal(reserveApprovalOffer("C1", "1.1"), undefined);
+    releaseApprovalReservation(first);
+    const second = reserveApprovalOffer("C1", "1.1");
+    assert.ok(second);
+    consumeApprovalReservation(second);
+    assert.equal(reserveApprovalOffer("C1", "1.1"), undefined);
+  });
+  it("sweeps expired available offers into terminal state", () => {
+    saveApprovalOffer("C1", "1.1", { owner: "o", repo: "r", number: 3, url: "u", headSha: "abc", baseRef: "main", artifactSha256: "digest" }, -1);
+    assert.equal(sweepApprovalOffers(), 1);
+    assert.equal(reserveApprovalOffer("C1", "1.1"), undefined);
+  });
+  it("does not overwrite a newer available offer when releasing an old reservation", () => {
+    const oldRef = { owner: "o", repo: "r", number: 3, url: "old", headSha: "old", baseRef: "main", artifactSha256: "old" };
+    const newRef = { ...oldRef, url: "new", headSha: "new", artifactSha256: "new" };
+    saveApprovalOffer("C1", "1.1", oldRef);
+    const reservation = reserveApprovalOffer("C1", "1.1");
+    assert.ok(reservation);
+    const available = reservation.reservedPath.split(".reserved.")[0]!;
+    fs.writeFileSync(available, JSON.stringify({
+      channelId: "C1", threadTs: "1.1", createdAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 60_000).toISOString(), refs: [newRef],
+    }), { mode: 0o600 });
+    releaseApprovalReservation(reservation);
+    assert.deepEqual(consumeApprovalOffer("C1", "1.1"), [newRef]);
+  });
+  it("recovers a confirmed-absent pending publication exactly once", () => {
+    const ref = { owner: "o", repo: "r", number: 3, url: "u", headSha: "a".repeat(40), baseRef: "main", artifactSha256: "b".repeat(64) };
+    saveApprovalOffer("C1", "1.1", ref);
+    const reservation = reserveApprovalOffer("C1", "1.1");
+    assert.ok(reservation);
+    markApprovalPendingReconcile(reservation);
+    const [pending] = listPendingApprovalReconciliations("C1", "1.1");
+    assert.ok(pending);
+    resolveApprovalReconciliation(pending, "absent");
+    assert.deepEqual(consumeApprovalOffer("C1", "1.1"), [ref]);
+  });
+});

--- a/packages/cli/test/review-claim.test.ts
+++ b/packages/cli/test/review-claim.test.ts
@@ -45,6 +45,24 @@ describe("review-claim", () => {
     claimReview(r);
     assert.equal(claimReview({ ...r, headSha: "def456" }), true);
   });
+
+  it("review and approve intents are separate claims for the same headSha", async () => {
+    const { claimReview } = await import("../src/gateway/review-claim");
+    assert.equal(claimReview({ ...r, intent: "review" }), true);
+    assert.equal(claimReview({ ...r, intent: "review" }), false);
+    assert.equal(claimReview({ ...r, intent: "approve" }), true);
+    assert.equal(claimReview({ ...r, intent: "approve" }), false);
+  });
+
+  it("forceClaimReview archives a finalized claim and reclaims the same SHA", async () => {
+    const { claimReview, finalizeReview, forceClaimReview } = await import("../src/gateway/review-claim");
+    claimReview(r);
+    finalizeReview(r, { status: "COMMENT" });
+    assert.equal(forceClaimReview(r), true);
+    assert.equal(forceClaimReview(r), false, "an active forced claim cannot be stolen");
+    const files = fs.readdirSync(path.join(tmp, ".pmk", "gateway", "reviews"));
+    assert.ok(files.some((name) => name.includes(".history.")), "prior finalized claim history is retained");
+  });
 });
 
 describe("recoverReviewClaims (B self-heal)", () => {
@@ -61,7 +79,10 @@ describe("recoverReviewClaims (B self-heal)", () => {
   it("releases a stale non-finalized claim → PR can be re-claimed", async () => {
     const { claimReview, recoverReviewClaims } = await import("../src/gateway/review-claim");
     claimReview(r);
-    ageFile(await claimFilePath(), 60 * 60 * 1000); // 1h old (orphaned mid-review)
+    const claimPath = await claimFilePath();
+    const record = JSON.parse(fs.readFileSync(claimPath, "utf8"));
+    fs.writeFileSync(claimPath, JSON.stringify({ ...record, ownerPid: 999_999_999 }));
+    ageFile(claimPath, 60 * 60 * 1000); // 1h old (orphaned mid-review)
     const warns: string[] = [];
     const n = recoverReviewClaims(10 * 60 * 1000, (m) => warns.push(m)); // 10m window
     assert.equal(n, 1);
@@ -85,6 +106,13 @@ describe("recoverReviewClaims (B self-heal)", () => {
     claimReview(r); // mtime ~ now
     assert.equal(recoverReviewClaims(45 * 60 * 1000, () => {}), 0); // 45m window
     assert.equal(claimReview(r), false); // still claimed
+  });
+
+  it("keeps a stale claim while its owner process is still alive", async () => {
+    const { claimReview, recoverReviewClaims } = await import("../src/gateway/review-claim");
+    claimReview(r);
+    ageFile(await claimFilePath(), 60 * 60 * 1000);
+    assert.equal(recoverReviewClaims(1000, () => {}), 0);
   });
 
   it("returns 0 safely when no claims exist", async () => {

--- a/packages/cli/test/review-config-parse.test.ts
+++ b/packages/cli/test/review-config-parse.test.ts
@@ -27,6 +27,7 @@ describe("review config parse", () => {
       expectedGhUser: "HanfourHuangOneAD",
       strategy: "debate",
       allowPublicRepos: false,
+      providerMode: "claude",
     });
     // and it resolves to an enabled, debate-strategy config
     const resolved = resolveReviewConfig(c.review);

--- a/packages/cli/test/review-config.test.ts
+++ b/packages/cli/test/review-config.test.ts
@@ -1,28 +1,41 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { resolveReviewConfig } from "../src/gateway/config";
+import { normaliseRawConfigForTest, resolveReviewConfig } from "../src/gateway/config";
 
 describe("resolveReviewConfig", () => {
   it("applies safe defaults", () => {
     const c = resolveReviewConfig(undefined);
     assert.equal(c.enabled, false);          // off until configured
+    assert.equal(c.approval.enabled, false); // separate kill switch
     assert.equal(c.allowPublicRepos, false);
     assert.equal(c.maxPrsPerTrigger, 5);
-    assert.equal(c.strategy, "debate");
+    assert.equal(c.maxConcurrent, 2);
+    assert.equal(c.maxConcurrentPerUser, 1);
+    assert.equal(c.strategy, "standard");
+    assert.equal(c.providerMode, "codex");
+  });
+  it("preserves Claude/debate for an existing pre-provider review block", () => {
+    const raw = normaliseRawConfigForTest({ version: 1, admins: [], blocklist: [], slack: {}, review: { enabled: true } });
+    const review = resolveReviewConfig(raw.review);
+    assert.equal(review.providerMode, "claude");
+    assert.equal(review.strategy, "debate");
   });
   it("respects overrides and clamps the cap to >=1", () => {
-    const c = resolveReviewConfig({ enabled: true, maxPrsPerTrigger: 0, strategy: "personas" });
+    const c = resolveReviewConfig({
+      enabled: true,
+      approval: { enabled: true },
+      maxPrsPerTrigger: 0,
+      strategy: "personas",
+      providerMode: "claude",
+    });
     assert.equal(c.enabled, true);
+    assert.equal(c.approval.enabled, true);
     assert.equal(c.maxPrsPerTrigger, 1);
     assert.equal(c.strategy, "personas");
+    assert.equal(c.providerMode, "claude");
   });
-});
-
-describe("allowApprove", () => {
-  it("defaults to false", () => {
-    assert.equal(resolveReviewConfig({}).allowApprove, false);
-  });
-  it("passes through when true", () => {
-    assert.equal(resolveReviewConfig({ allowApprove: true }).allowApprove, true);
+  it("supports fallback and dual provider modes", () => {
+    assert.equal(resolveReviewConfig({ providerMode: "fallback" }).providerMode, "fallback");
+    assert.equal(resolveReviewConfig({ providerMode: "dual" }).providerMode, "dual");
   });
 });

--- a/packages/cli/test/review-coordinator.test.ts
+++ b/packages/cli/test/review-coordinator.test.ts
@@ -5,8 +5,8 @@ import * as os from "node:os";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { FakeWebClient } from "./harness/slack-fakes";
-import { ReviewCoordinator, isReviewRequest, isRetryRequest, isApproveRequest, reviewResultText, approveResultText, describeMraFailure, type ReviewGateway } from "../src/gateway/slack/review";
-import { resolveReviewConfig } from "../src/gateway/config";
+import { ReviewCoordinator, effectiveMraReviewStrategy, isReviewRequest, isRetryRequest, isRerunRequest, isApproveRequest, isApproveConfirmationRequest, canConfirmApproveFromReview, reviewResultText, approveResultText, describeMraFailure, type ReviewGateway } from "../src/gateway/slack/review";
+import { gatewayConfigPath, resolveReviewConfig, saveGatewayConfig } from "../src/gateway/config";
 
 const ORIG_HOME = process.env.HOME; // gatewayDir() is HOME-based; isolate via HOME (not PMK_HOME)
 let tmp: string;
@@ -19,6 +19,9 @@ function gw(over: Partial<ReviewGateway> = {}): ReviewGateway {
     getPrHead: async () => ({ sha: "headsha", baseRef: "main" }),
     repoVisibility: async () => "private",
     getAuthUser: async () => "expected-bot",
+    approvalProtectionReady: async () => true,
+    createPullRequestApproval: async (a: { commitId: string }) => ({ reviewId: 99, state: "APPROVED", commitId: a.commitId, actor: "expected-bot" }),
+    createPullRequestReview: async (a: { commitId: string; event: string }) => ({ reviewId: 98, state: a.event === "REQUEST_CHANGES" ? "CHANGES_REQUESTED" : "COMMENTED", commitId: a.commitId, actor: "expected-bot" }),
     ensureReviewWorkspaceMeta: () => {},
     prepareReviewClone: async () => ({ ok: true, cloneDir: path.join(tmp, "proj"), baseRef: "main" }),
     teardownReviewClone: () => {},
@@ -30,14 +33,22 @@ function gw(over: Partial<ReviewGateway> = {}): ReviewGateway {
   } as unknown as ReviewGateway;
 }
 
-function coord(web: FakeWebClient, gateway: ReviewGateway, onLog: (m: string) => void = () => {}) {
+function coord(web: FakeWebClient, gateway: ReviewGateway, onLog: (m: string) => void = () => {}, reviewOverrides: Record<string, unknown> = {}) {
   const config = {
-    version: 1 as const, admins: [], blocklist: [], audience: {} as never,
+    version: 1 as const, admins: ["U1"], blocklist: [], audience: {} as never,
     escalation: {} as never, slack: {}, mraWorkspace: path.join(tmp, "ws"),
-    review: { enabled: true, expectedGhUser: "expected-bot" },
+    review: { enabled: true, approval: { enabled: true }, expectedGhUser: "expected-bot", ...reviewOverrides },
   } as never;
   // sleep is a no-op in tests so the transient-failure retry backoff doesn't wait.
   return new ReviewCoordinator({ web: web as never, config, onLog, gateway, sleep: async () => {} });
+}
+
+function eligibleReviewResult(headSha = "headsha") {
+  return {
+    ok: true, status: "COMMENT", commentCount: 0, blockerCount: 0,
+    protocolVersion: "1.0" as const, artifactSha256: "a".repeat(64), analyzedHeadSha: headSha,
+    stdout: "", stderr: "",
+  };
 }
 
 describe("ReviewCoordinator.fromReaction", () => {
@@ -60,7 +71,7 @@ describe("ReviewCoordinator.fromReaction", () => {
       pkbNeedsBuild: () => true,
       runMraAnalyze: async () => { analyzed = true; return { ok: true, stdout: "", stderr: "" }; },
       runMraReview: async () => { builtBeforeReview = analyzed; return { ok: true, status: "APPROVED", stdout: "", stderr: "" }; },
-    })).fromReaction({ channelId: "C1", messageTs: "1.1", reactorUserId: "U1" });
+    }), () => {}, { providerMode: "claude" }).fromReaction({ channelId: "C1", messageTs: "1.1", reactorUserId: "U1" });
     assert.equal(analyzed, true, "a missing PKB must be built");
     assert.equal(builtBeforeReview, true, "the PKB build must run BEFORE the review");
   });
@@ -226,7 +237,7 @@ describe("ReviewCoordinator.fromMessage (B-lite inline trigger)", () => {
 });
 
 describe("ReviewCoordinator pinned ghToken threading", () => {
-  it("threads review.ghToken to getAuthUser (actor-verify) AND runMraReview", async () => {
+  it("uses review.ghToken for PMK GitHub checks but never passes it to MRA", async () => {
     const web = new FakeWebClient();
     let authOpts: { token?: string } | undefined;
     let mraArgs: { ghToken?: string } | undefined;
@@ -251,12 +262,297 @@ describe("ReviewCoordinator pinned ghToken threading", () => {
       text: ":cr: https://github.com/onead/OnePixel/pull/12",
     });
     assert.equal(authOpts?.token, "gho_pinned", "actor-verify must use the pinned token");
-    assert.equal(mraArgs?.ghToken, "gho_pinned", "mra POST must use the pinned token");
+    assert.equal(mraArgs?.ghToken, undefined, "MRA analysis subprocess must not receive the pinned token");
   });
 });
 
-describe("ReviewCoordinator allowApprove forwarding", () => {
-  it("passes review.allowApprove=true from config into runMraReview", async () => {
+describe("ReviewCoordinator provider strategy selection", () => {
+  it("effectiveMraReviewStrategy preserves configured :cr: strategy only for Claude", () => {
+    assert.equal(effectiveMraReviewStrategy("debate", "claude", false), "debate");
+    assert.equal(effectiveMraReviewStrategy("personas", "claude", false), "personas");
+    assert.equal(effectiveMraReviewStrategy("debate", "codex", false), "standard");
+    assert.equal(effectiveMraReviewStrategy("personas", "fallback", false), "standard");
+    assert.equal(effectiveMraReviewStrategy("debate", "dual", false), "standard");
+    assert.equal(effectiveMraReviewStrategy("debate", "claude", true), "standard");
+  });
+
+  it(":cr: defaults to provider=codex and standard strategy for mra", async () => {
+    const web = new FakeWebClient();
+    let mraArgs: { strategy?: string; providerMode?: string } | undefined;
+    const gateway = gw({
+      runMraReview: async (a: { strategy?: string; providerMode?: string }) => {
+        mraArgs = a;
+        return { ok: true, status: "COMMENT", commentCount: 0, stdout: "", stderr: "" };
+      },
+    } as unknown as Partial<ReviewGateway>);
+    await coord(web, gateway).fromMessage({
+      channelId: "C1",
+      threadTs: "1.1",
+      userId: "U1",
+      text: ":cr: https://github.com/onead/OnePixel/pull/12",
+    });
+    assert.equal(mraArgs?.providerMode, "codex");
+    assert.equal(mraArgs?.strategy, "standard");
+    assert.equal((mraArgs as Record<string, unknown>)?.expectedHeadSha, "headsha");
+  });
+
+  it(":cr: preserves debate when the admin-selected provider is claude", async () => {
+    const web = new FakeWebClient();
+    let mraArgs: { strategy?: string; providerMode?: string } | undefined;
+    const gateway = gw({
+      runMraReview: async (a: { strategy?: string; providerMode?: string }) => {
+        mraArgs = a;
+        return { ok: true, status: "COMMENT", commentCount: 0, stdout: "", stderr: "" };
+      },
+    } as unknown as Partial<ReviewGateway>);
+    const config = {
+      version: 1, admins: [], blocklist: [], audience: {}, escalation: {}, slack: {},
+      mraWorkspace: path.join(tmp, "ws"),
+      review: {
+        enabled: true,
+        expectedGhUser: "expected-bot",
+        strategy: "debate",
+        providerMode: "claude",
+      },
+    } as never;
+    const c = new ReviewCoordinator({ web: web as never, config, onLog: () => {}, gateway, sleep: async () => {} });
+    await c.fromMessage({
+      channelId: "C1",
+      threadTs: "1.1",
+      userId: "U1",
+      text: ":cr: https://github.com/onead/OnePixel/pull/12",
+    });
+    assert.equal(mraArgs?.providerMode, "claude");
+    assert.equal(mraArgs?.strategy, "debate");
+  });
+});
+
+describe("ReviewCoordinator live review config reload", () => {
+  it("revokes approve access immediately when an admin is removed from live config", async () => {
+    const web = new FakeWebClient();
+    let reviewed = false;
+    const startupConfig = {
+      version: 1, admins: ["U1"], blocklist: [], audience: {}, escalation: {}, slack: {},
+      mraWorkspace: path.join(tmp, "ws"), review: { enabled: true, approval: { enabled: true } },
+    } as never;
+    saveGatewayConfig({
+      version: 1, admins: [], blocklist: [], audience: {} as never, escalation: {} as never,
+      slack: {}, mraWorkspace: path.join(tmp, "ws"), review: { enabled: true, approval: { enabled: true } },
+    });
+    const c = new ReviewCoordinator({ web: web as never, config: startupConfig, onLog: () => {}, gateway: gw({
+      runMraReview: async () => { reviewed = true; return { ok: true, status: "APPROVED", stdout: "", stderr: "" }; },
+    } as unknown as Partial<ReviewGateway>) });
+    await c.fromApproveMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: ":a: https://github.com/onead/OnePixel/pull/12" });
+    assert.equal(reviewed, false);
+    assert.ok(web.posted.some((p) => /只能由 PMK admin/.test(p.text ?? "")));
+  });
+
+  it("reloads raw review config without resolving unrelated Slack secret commands", async () => {
+    const web = new FakeWebClient();
+    const logs: string[] = [];
+    let mraArgs: { strategy?: string; providerMode?: string } | undefined;
+    const gateway = gw({
+      runMraReview: async (a: { strategy?: string; providerMode?: string }) => {
+        mraArgs = a;
+        return { ok: true, status: "COMMENT", commentCount: 0, stdout: "", stderr: "" };
+      },
+    } as unknown as Partial<ReviewGateway>);
+    const startupConfig = {
+      version: 1, admins: [], blocklist: [], audience: {}, escalation: {}, slack: {},
+      mraWorkspace: path.join(tmp, "ws-startup"),
+      review: {
+        enabled: true,
+        expectedGhUser: "expected-bot",
+        strategy: "debate",
+        providerMode: "codex",
+      },
+    } as never;
+    saveGatewayConfig({
+      version: 1,
+      admins: [],
+      blocklist: [],
+      audience: {} as never,
+      escalation: {} as never,
+      slack: {
+        appToken: { cmd: `${process.execPath} -e "process.exit(9)"` },
+        botToken: { cmd: `${process.execPath} -e "process.exit(9)"` },
+      },
+      mraWorkspace: path.join(tmp, "ws-live"),
+      review: {
+        enabled: true,
+        expectedGhUser: "expected-bot",
+        strategy: "debate",
+        providerMode: "claude",
+      },
+    });
+    const c = new ReviewCoordinator({
+      web: web as never,
+      config: startupConfig,
+      onLog: (m) => logs.push(m),
+      gateway,
+      sleep: async () => {},
+    });
+    await c.fromMessage({
+      channelId: "C1",
+      threadTs: "1.1",
+      userId: "U1",
+      text: ":cr: https://github.com/onead/OnePixel/pull/12",
+    });
+    assert.equal(mraArgs?.providerMode, "claude");
+    assert.equal(mraArgs?.strategy, "debate");
+    assert.equal(logs.some((m) => m.includes("live config reload failed")), false);
+  });
+
+  it("treats the live review block as authoritative when fields are removed", async () => {
+    const web = new FakeWebClient();
+    let mraArgs: { allowApprove?: boolean; ghToken?: string } | undefined;
+    const gateway = gw({
+      runMraReview: async (a: { allowApprove?: boolean; ghToken?: string }) => {
+        mraArgs = a;
+        return { ok: true, status: "COMMENT", commentCount: 0, stdout: "", stderr: "" };
+      },
+    } as unknown as Partial<ReviewGateway>);
+    const startupConfig = {
+      version: 1, admins: [], blocklist: [], audience: {}, escalation: {}, slack: {},
+      mraWorkspace: path.join(tmp, "ws"),
+      review: {
+        enabled: true,
+        expectedGhUser: "expected-bot",
+        allowApprove: true,
+        ghToken: "gho_startup",
+      },
+    } as never;
+    saveGatewayConfig({
+      version: 1,
+      admins: [],
+      blocklist: [],
+      audience: {} as never,
+      escalation: {} as never,
+      slack: {},
+      mraWorkspace: path.join(tmp, "ws"),
+      review: { enabled: true },
+    });
+    const c = new ReviewCoordinator({ web: web as never, config: startupConfig, onLog: () => {}, gateway, sleep: async () => {} });
+    await c.fromMessage({
+      channelId: "C1",
+      threadTs: "1.1",
+      userId: "U1",
+      text: ":cr: https://github.com/onead/OnePixel/pull/12",
+    });
+    assert.equal(mraArgs?.allowApprove, undefined);
+    assert.equal(mraArgs?.ghToken, undefined);
+  });
+
+  it("disables reviews live when the review block is removed", async () => {
+    const web = new FakeWebClient();
+    let reviewed = false;
+    const gateway = gw({
+      runMraReview: async () => {
+        reviewed = true;
+        return { ok: true, status: "COMMENT", commentCount: 0, stdout: "", stderr: "" };
+      },
+    } as unknown as Partial<ReviewGateway>);
+    const startupConfig = {
+      version: 1, admins: [], blocklist: [], audience: {}, escalation: {}, slack: {},
+      mraWorkspace: path.join(tmp, "ws"),
+      review: { enabled: true, expectedGhUser: "expected-bot" },
+    } as never;
+    saveGatewayConfig({
+      version: 1,
+      admins: [],
+      blocklist: [],
+      audience: {} as never,
+      escalation: {} as never,
+      slack: {},
+      mraWorkspace: path.join(tmp, "ws"),
+    });
+    const c = new ReviewCoordinator({ web: web as never, config: startupConfig, onLog: () => {}, gateway, sleep: async () => {} });
+    await c.fromMessage({
+      channelId: "C1",
+      threadTs: "1.1",
+      userId: "U1",
+      text: ":cr: https://github.com/onead/OnePixel/pull/12",
+    });
+    assert.equal(reviewed, false);
+  });
+
+  it("strict live reload disables reviews when gateway.json is missing", async () => {
+    const web = new FakeWebClient();
+    const logs: string[] = [];
+    let reviewed = false;
+    const gateway = gw({
+      runMraReview: async () => {
+        reviewed = true;
+        return { ok: true, status: "COMMENT", commentCount: 0, stdout: "", stderr: "" };
+      },
+    } as unknown as Partial<ReviewGateway>);
+    const startupConfig = {
+      version: 1, admins: [], blocklist: [], audience: {}, escalation: {}, slack: {},
+      mraWorkspace: path.join(tmp, "ws"),
+      review: { enabled: true, expectedGhUser: "expected-bot" },
+    } as never;
+    const c = new ReviewCoordinator({
+      web: web as never,
+      config: startupConfig,
+      onLog: (m) => logs.push(m),
+      gateway,
+      sleep: async () => {},
+      strictLiveConfigReload: true,
+    });
+    await c.fromMessage({
+      channelId: "C1",
+      threadTs: "1.1",
+      userId: "U1",
+      text: ":cr: https://github.com/onead/OnePixel/pull/12",
+    });
+    assert.equal(reviewed, false);
+    assert.equal(logs.some((m) => m.includes("live config missing")), true);
+  });
+
+  it("strict live reload disables reviews when gateway.json is corrupt", async () => {
+    const web = new FakeWebClient();
+    const logs: string[] = [];
+    let reviewed = false;
+    const gateway = gw({
+      runMraReview: async () => {
+        reviewed = true;
+        return { ok: true, status: "COMMENT", commentCount: 0, stdout: "", stderr: "" };
+      },
+    } as unknown as Partial<ReviewGateway>);
+    const startupConfig = {
+      version: 1, admins: [], blocklist: [], audience: {}, escalation: {}, slack: {},
+      mraWorkspace: path.join(tmp, "ws"),
+      review: {
+        enabled: true,
+        expectedGhUser: "expected-bot",
+        allowApprove: true,
+        ghToken: "gho_startup",
+      },
+    } as never;
+    const file = gatewayConfigPath();
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, "{not json", "utf8");
+    const c = new ReviewCoordinator({
+      web: web as never,
+      config: startupConfig,
+      onLog: (m) => logs.push(m),
+      gateway,
+      sleep: async () => {},
+      strictLiveConfigReload: true,
+    });
+    await c.fromMessage({
+      channelId: "C1",
+      threadTs: "1.1",
+      userId: "U1",
+      text: ":cr: https://github.com/onead/OnePixel/pull/12",
+    });
+    assert.equal(reviewed, false);
+    assert.equal(logs.some((m) => m.includes("live config reload failed")), true);
+  });
+});
+
+describe("ReviewCoordinator approve intent forwarding", () => {
+  it("does not let :cr: submit GitHub approval", async () => {
     const web = new FakeWebClient();
     let mraArgs: { allowApprove?: boolean } | undefined;
     const gateway = gw({
@@ -268,14 +564,14 @@ describe("ReviewCoordinator allowApprove forwarding", () => {
     const config = {
       version: 1, admins: [], blocklist: [], audience: {}, escalation: {}, slack: {},
       mraWorkspace: path.join(tmp, "ws"),
-      review: { enabled: true, expectedGhUser: "expected-bot", allowApprove: true },
+      review: { enabled: true, expectedGhUser: "expected-bot" },
     } as never;
     const c = new ReviewCoordinator({ web: web as never, config, onLog: () => {}, gateway });
     await c.fromMessage({
       channelId: "C1", threadTs: "1.1", userId: "U1",
       text: ":cr: https://github.com/onead/OnePixel/pull/12",
     });
-    assert.equal(mraArgs?.allowApprove, true, "runMraReview must receive allowApprove=true from config");
+    assert.equal(mraArgs?.allowApprove, undefined, ":cr: analysis subprocess has no approval capability");
   });
 });
 
@@ -452,14 +748,30 @@ describe("ReviewCoordinator.drainOnShutdown (A graceful drain)", () => {
 });
 
 describe("isRetryRequest", () => {
-  it("matches a bare retry / 重試 / 重跑 (trimmed, case-insensitive)", () => {
-    for (const t of ["retry", "  Retry ", "RETRY", "重試", "重跑"]) {
+  it("matches a bare retry / 重試 (trimmed, case-insensitive)", () => {
+    for (const t of ["retry", "  Retry ", "RETRY", "重試"]) {
       assert.equal(isRetryRequest(t), true, `should match: '${t}'`);
     }
+    assert.equal(isRetryRequest("重跑"), false, "重跑 is the explicit forced-rerun command");
+    assert.equal(isRerunRequest("重跑"), true);
+    assert.equal(isRerunRequest("rerun"), true);
   });
   it("does NOT match chat that merely contains 'retry'", () => {
     for (const t of ["please retry", "retry the build", "", ":cr: x"]) {
       assert.equal(isRetryRequest(t), false, `should not match: '${t}'`);
+    }
+  });
+});
+
+describe("isApproveConfirmationRequest", () => {
+  it("matches explicit approve confirmations only", () => {
+    for (const t of ["approve", "confirm approve", "確認 approve", "確認approve", "核准"]) {
+      assert.equal(isApproveConfirmationRequest(t), true, `should match: '${t}'`);
+    }
+  });
+  it("does NOT match ordinary chat that merely mentions approve", () => {
+    for (const t of ["please approve after deploy", "approval status?", "", ":a: https://github.com/o/r/pull/1"]) {
+      assert.equal(isApproveConfirmationRequest(t), false, `should not match: '${t}'`);
     }
   });
 });
@@ -505,20 +817,83 @@ describe("ReviewCoordinator.retryInThread", () => {
         return { ok: true, status: "APPROVED", commentCount: 0, stdout: "", stderr: "" };
       },
     } as unknown as Partial<ReviewGateway>)).retryInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
-    assert.equal(approveArgs?.["approveIfNoHigh"], true, "retry of an :a: thread must re-run the approve flow (approveIfNoHigh=true)");
+    assert.equal(approveArgs?.["allowApprove"], undefined, "retry of an :a: thread re-runs analysis without approval flags");
     const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
     assert.ok(!allTexts.some((t) => /沒有可重試/.test(t)), "must NOT post the nudge for an :a: thread root");
   });
 });
 
+describe("ReviewCoordinator.confirmApproveInThread", () => {
+  it("keeps an eligible protocol artifact review-only while the approval release veto is active", async () => {
+    const web = new FakeWebClient();
+    const calls: Array<Record<string, unknown>> = [];
+    const gateway = gw({
+      runMraReview: async (a: Record<string, unknown>) => {
+        calls.push(a);
+        return eligibleReviewResult();
+      },
+    } as unknown as Partial<ReviewGateway>);
+    const c = coord(web, gateway);
+    const rootText = ":cr: https://github.com/onead/OnePixel/pull/12";
+    await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: rootText });
+    web.conversationsHistoryResponse = { ok: true, messages: [{ text: rootText }] };
+
+    await c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+
+    assert.equal(calls.length, 1, "confirmation must reuse the SHA-bound artifact");
+    assert.equal(calls[0]?.["allowApprove"], undefined, ":cr: remains analysis-only");
+    const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
+    assert.ok(allTexts.some((t) => /回覆 `approve`|授權 GitHub approve/.test(t)), ":cr: result should ask for explicit authorization");
+    assert.ok(allTexts.some((t) => /安全停用|不會執行 approve/.test(t)), "release veto must block the GitHub mutation");
+    assert.ok(!allTexts.some((t) => /已真實 approve/.test(t)));
+  });
+
+  it("does not consume the review artifact while approval is release-vetoed", async () => {
+    const web = new FakeWebClient();
+    let calls = 0;
+    const gateway = gw({
+      runMraReview: async () => {
+        calls++;
+        return eligibleReviewResult();
+      },
+    } as unknown as Partial<ReviewGateway>);
+    const c = coord(web, gateway);
+    const rootText = ":cr: https://github.com/onead/OnePixel/pull/12";
+    await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: rootText });
+    web.conversationsHistoryResponse = { ok: true, messages: [{ text: rootText }] };
+    await c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+    assert.equal(calls, 1, "first confirmation reuses the earlier artifact");
+
+    await c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+    assert.equal(calls, 1, "second confirmation for the same artifact is idempotent");
+    const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
+    assert.ok(allTexts.filter((t) => /安全停用|不會執行 approve/.test(t)).length >= 2, "each confirmation must report the release veto");
+  });
+});
+
 describe("ReviewCoordinator.fromApproveMessage (:a: approve flow)", () => {
-  it("APPROVED path: runMraReview called with strategy=standard/allowApprove=true/approveIfNoHigh=true and posts '已 approve'", async () => {
+  it("rejects a non-admin before running mra", async () => {
+    const web = new FakeWebClient();
+    let called = false;
+    const config = {
+      version: 1, admins: [], blocklist: [], audience: {}, escalation: {}, slack: {},
+      mraWorkspace: path.join(tmp, "ws"), review: { enabled: true, approval: { enabled: true } },
+    } as never;
+    const c = new ReviewCoordinator({ web: web as never, config, onLog: () => {}, gateway: gw({
+      runMraReview: async () => { called = true; return { ok: true, status: "APPROVED", stdout: "", stderr: "" }; },
+    } as unknown as Partial<ReviewGateway>) });
+    await c.fromApproveMessage({ channelId: "C1", threadTs: "1.1", userId: "U2", text: ":a: https://github.com/onead/OnePixel/pull/12" });
+    assert.equal(called, false);
+    assert.ok(web.posted.some((p) => /只能由 PMK admin/.test(p.text ?? "")));
+  });
+
+  it(":a: runs analysis first and never passes approval authority to MRA", async () => {
     const web = new FakeWebClient();
     let capturedArgs: Record<string, unknown> | undefined;
     const gateway = gw({
       runMraReview: async (a: Record<string, unknown>) => {
         capturedArgs = a;
-        return { ok: true, status: "APPROVED", commentCount: 1, stdout: "", stderr: "" };
+        return eligibleReviewResult();
       },
     } as unknown as Partial<ReviewGateway>);
     await coord(web, gateway).fromApproveMessage({
@@ -528,13 +903,14 @@ describe("ReviewCoordinator.fromApproveMessage (:a: approve flow)", () => {
       text: ":a: https://github.com/onead/OnePixel/pull/12",
     });
     assert.equal(capturedArgs?.["strategy"], "standard", "strategy must be 'standard'");
-    assert.equal(capturedArgs?.["allowApprove"], true, "allowApprove must be true");
-    assert.equal(capturedArgs?.["approveIfNoHigh"], true, "approveIfNoHigh must be true");
+    assert.equal(capturedArgs?.["allowApprove"], undefined);
+    assert.equal(capturedArgs?.["approveIfNoHigh"], undefined);
     const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
-    assert.ok(allTexts.some((t) => /已 approve/.test(t)), "APPROVED result must post '已 approve'");
+    assert.ok(allTexts.some((t) => /回覆 `approve`/.test(t)), "eligible analysis must ask for explicit confirmation");
+    assert.ok(!allTexts.some((t) => /真實 approve/.test(t)), ":a: alone must not approve");
   });
 
-  it("CHANGES_REQUESTED path: posts '未 approve'", async () => {
+  it("CHANGES_REQUESTED path reports review blockers without approval", async () => {
     const web = new FakeWebClient();
     const gateway = gw({
       runMraReview: async () => ({
@@ -548,14 +924,14 @@ describe("ReviewCoordinator.fromApproveMessage (:a: approve flow)", () => {
       text: ":a: https://github.com/onead/OnePixel/pull/12",
     });
     const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
-    assert.ok(allTexts.some((t) => /未 approve/.test(t)), "CHANGES_REQUESTED result must post '未 approve'");
+    assert.ok(allTexts.some((t) => /CHANGES_REQUESTED|未執行 GitHub approve/.test(t)));
   });
 
   // M1: on mra's batch-fallback path there is no `status:` line → status is
   // undefined. The old code computed approved=false and claimed "未 approve —
   // 發現重大問題", which is a false statement on both axes (GitHub may actually
   // have approved). The honest result points the user to GitHub instead.
-  it("undefined-status (batch-fallback) path: does NOT falsely claim '發現重大問題'; points to GitHub", async () => {
+  it("undefined legacy status never claims approval", async () => {
     const web = new FakeWebClient();
     const gateway = gw({
       runMraReview: async () => ({
@@ -570,13 +946,63 @@ describe("ReviewCoordinator.fromApproveMessage (:a: approve flow)", () => {
     });
     const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
     assert.ok(
-      allTexts.some((t) => /確認是否已 approve|未回報 approve/.test(t)),
-      "undefined status must produce an informational GitHub-check message",
+      allTexts.some((t) => /未執行 GitHub approve/.test(t)),
+      "undefined legacy status must remain review-only",
     );
     assert.ok(
       !allTexts.some((t) => /發現重大問題/.test(t)),
       "must NOT claim 發現重大問題 when the approve verdict is unknown",
     );
+  });
+});
+
+describe("ReviewCoordinator exact-head approval offer", () => {
+  it("release veto takes precedence over exact-head approval preflight", async () => {
+    const web = new FakeWebClient();
+    let head = "head-1";
+    let calls = 0;
+    const c = coord(web, gw({
+      getPrHead: async () => ({ sha: head, baseRef: "main" }),
+      runMraReview: async () => { calls++; return eligibleReviewResult(head); },
+    } as unknown as Partial<ReviewGateway>));
+    await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: ":cr: https://github.com/onead/OnePixel/pull/12" });
+    head = "head-2";
+    await c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+    assert.equal(calls, 1, "changed head must not reach the approval model pass");
+    assert.ok(web.posted.some((p) => /安全停用|不會執行 approve/.test(p.text ?? "")));
+  });
+});
+
+describe("ReviewCoordinator forced rerun", () => {
+  it("lets an admin rerun a finalized same-SHA review", async () => {
+    const web = new FakeWebClient();
+    let calls = 0;
+    const c = coord(web, gw({ runMraReview: async () => { calls++; return { ok: true, status: "COMMENT", commentCount: 0, stdout: "", stderr: "" }; } } as unknown as Partial<ReviewGateway>));
+    const root = ":cr: https://github.com/onead/OnePixel/pull/12";
+    await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: root });
+    web.conversationsHistoryResponse = { ok: true, messages: [{ text: root }] };
+    await c.rerunInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+    assert.equal(calls, 2);
+  });
+});
+
+describe("ReviewCoordinator project concurrency", () => {
+  it("does not run two reviews against the same shared project checkout", async () => {
+    const web = new FakeWebClient();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    let calls = 0;
+    const c = coord(web, gw({
+      getPrHead: async ({ pr }: { pr: number }) => ({ sha: `head-${pr}`, baseRef: "main" }),
+      runMraReview: async () => { calls++; await gate; return { ok: true, status: "COMMENT", commentCount: 0, stdout: "", stderr: "" }; },
+    } as unknown as Partial<ReviewGateway>), () => {}, { maxConcurrent: 2, maxConcurrentPerUser: 2 });
+    const first = c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: ":cr: https://github.com/onead/OnePixel/pull/12" });
+    await new Promise((resolve) => setImmediate(resolve));
+    await c.fromMessage({ channelId: "C1", threadTs: "1.2", userId: "U1", text: ":cr: https://github.com/onead/OnePixel/pull/13" });
+    assert.equal(calls, 1);
+    assert.ok(web.posted.some((p) => /同一 repo 正在 review|併發上限/.test(p.text ?? "")));
+    release();
+    await first;
   });
 });
 
@@ -598,7 +1024,7 @@ describe("ReviewCoordinator REVIEW_INCOMPLETE handling", () => {
     });
     assert.equal(calls, 2, "an incomplete first review must trigger exactly one retry");
     const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
-    assert.ok(allTexts.some((t) => /已 approve/.test(t)), "the recovered (approved) outcome must be delivered");
+    assert.ok(allTexts.some((t) => /已完成.*review|未執行 GitHub approve/.test(t)), "the recovered review outcome must be delivered without approval");
   });
 
   it(":a: still REVIEW_INCOMPLETE after the retry → honest '未完成' message, and the claim is released so a same-commit :a: re-runs", async () => {
@@ -633,8 +1059,17 @@ describe("ReviewCoordinator REVIEW_INCOMPLETE handling", () => {
 
 describe("review/approve result text (pure)", () => {
   const ref = { owner: "onead", repo: "OnePixel", number: 12, url: "https://x/pull/12" } as never;
-  it("reviewResultText always reports the posted status/count", () => {
-    assert.match(reviewResultText("onead/OnePixel", ref, { status: "COMMENT", commentCount: 3 } as never), /已對 .*貼 review.*COMMENT.*3/);
+  it("reviewResultText reports COMMENT without claiming GitHub approval", () => {
+    const t = reviewResultText("onead/OnePixel", ref, { ...eligibleReviewResult(), commentCount: 3 } as never);
+    assert.match(t, /GitHub action: COMMENT/);
+    assert.match(t, /回覆 `approve`|授權 GitHub approve/);
+    assert.doesNotMatch(t, /已 approve/);
+  });
+  it("canConfirmApproveFromReview only offers confirmation for complete COMMENT review results", () => {
+    assert.equal(canConfirmApproveFromReview(eligibleReviewResult()), true);
+    assert.equal(canConfirmApproveFromReview({ status: "COMMENT", commentCount: 0 }), false);
+    assert.equal(canConfirmApproveFromReview({ status: "CHANGES_REQUESTED", commentCount: 1 }), false);
+    assert.equal(canConfirmApproveFromReview({ status: "COMMENT", incomplete: true }), false);
   });
   it("approveResultText: APPROVED → 已 approve", () => {
     assert.match(approveResultText("onead/OnePixel", ref, { status: "APPROVED", commentCount: 1 } as never), /已 approve/);
@@ -703,7 +1138,7 @@ describe("ReviewCoordinator transient-failure retry", () => {
     });
     assert.equal(calls, 2, "a transient mra failure must trigger exactly one retry");
     const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
-    assert.ok(allTexts.some((t) => /已 approve/.test(t)), "the retry's success result must be delivered");
+    assert.ok(allTexts.some((t) => /已完成.*review|未執行 GitHub approve/.test(t)), "the retry's review result must be delivered");
     assert.ok(!allTexts.some((t) => /失敗/.test(t)), "no failure message when the retry succeeds");
   });
 
@@ -789,10 +1224,10 @@ describe("ReviewCoordinator in-place progress bar", () => {
       "at least one chat.update must contain a progress bar render (▰)",
     );
 
-    // The LAST chat.update must contain the result text (已對), NOT a new postMessage
+    // The LAST chat.update must contain the result text, NOT a new postMessage
     const lastUpdate = web.updated[web.updated.length - 1];
     assert.ok(
-      (lastUpdate?.text ?? "").includes("已對"),
+      /已完成 .*review|GitHub action/.test(lastUpdate?.text ?? ""),
       "the result text must be delivered via the last chat.update (in-place), not a separate postMessage",
     );
   });

--- a/packages/cli/test/review-progress.test.ts
+++ b/packages/cli/test/review-progress.test.ts
@@ -16,11 +16,12 @@ test("phaseFromLine — analyze", () => {
   );
 });
 
-test("phaseFromLine — analyze fires on the unconditional 'running Claude' line (fresh PR / standard)", () => {
-  // review.sh:461 logs this to stdout on every single-pass review, unlike the
+test("phaseFromLine — analyze fires on the unconditional provider running line (fresh PR / standard)", () => {
+  // review.sh logs this to stdout on every single-pass review, unlike the
   // conditional 'loaded existing PR discussion' line — so a fresh PR still enters
   // analyze instead of freezing at prepare/pkb.
   assert.equal(phaseFromLine("[review] running Claude (sonnet)..."), "analyze");
+  assert.equal(phaseFromLine("[review] running codex (default model)..."), "analyze");
 });
 
 test("phaseFromLine — analyze fires on debate round markers", () => {

--- a/packages/cli/test/slack-adapter.test.ts
+++ b/packages/cli/test/slack-adapter.test.ts
@@ -1097,12 +1097,27 @@ describe("SlackAdapter integration: :cr: reaction routes to ReviewCoordinator", 
     // .collab/repos.json so resolveProjectByRemote returns undefined → ReviewCoordinator
     // posts the "不在 mra workspace，略過" skip note. This proves the gate let :cr:
     // through without requiring a real mra binary or GitHub token.
-    const mraWorkspace = h?.home ?? "/tmp"; // will be set below
     h = buildHarness({
       config: {
         review: { enabled: true },
         mraWorkspace: "/tmp/no-such-workspace-cr-test",
       },
+    });
+    saveGatewayConfig({
+      version: 1,
+      admins: [],
+      blocklist: [],
+      audience: { default: "tech", users: {}, channels: {} },
+      escalation: { default: [], repos: {} },
+      slack: {
+        appToken: "xapp-test",
+        botToken: "xoxb-test",
+        botUserId: "UBOTID",
+        workspaceName: "test-workspace",
+      },
+      github: { token: "ghp-test-token" },
+      review: { enabled: true },
+      mraWorkspace: "/tmp/no-such-workspace-cr-test",
     });
 
     // conversations.history should return a message containing a GitHub PR link


### PR DESCRIPTION
## Summary
- route PMK review through MRA protocol v1 with Codex as the default provider
- keep :cr: as analysis/review-only and keep true GitHub APPROVE behind disabled approval policy
- add admin/config surfaces for provider mode and review approval gates
- add SHA-bound review artifacts, approval offers, Slack confirmation flow, and doctor coverage

## Dependency
- Depends on MRA protocol support: https://github.com/hanfour/multi-repo-agent/pull/9

## Verification
- npm --workspace packages/cli test (passed earlier in this rollout)
- PMK live doctor: passed=11 warned=1 failed=0; review=mra=found; protocol=v1; gh=found; provider=codex; strategy=standard; approval=disabled
- PMK gateway launchd running and Slack socket connected
- real MRA Codex protocol smoke: complete/pass, 0 findings, 0 blockers