### PR TITLE
ci: run unit tests + typecheck on PR/push (#71)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,5 +35,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Cross-workspace type declarations (@pmk/shared, @pmk/rag, @pmk/cli) come
+      # from each package's built dist/. A fresh `npm ci` has no dist, so tsc in
+      # dependent workspaces cannot resolve them. Build the library packages in
+      # dependency order before testing. (@pmk/core is plain JS — no build.)
+      - name: Build library packages
+        run: |
+          npm run build --workspace=@pmk/shared
+          npm run build --workspace=@pmk/rag
+          npm run build --workspace=@pmk/cli
+
       - name: Test (typecheck + unit)
         run: npm test --workspace=${{ matrix.workspace }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test (${{ matrix.workspace }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Workspaces whose `test` script runs `typecheck:test` (tsc) + node --test.
+        # packages/core is intentionally excluded until it has real tests (issue #73);
+        # its test script is currently a no-op echo and would be a misleading green check.
+        workspace:
+          - packages/cli
+          - packages/rag
+          - packages/shared
+          - apps/desktop
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test (typecheck + unit)
+        run: npm test --workspace=${{ matrix.workspace }}

--- a/packages/cli/test/review-workspace.test.ts
+++ b/packages/cli/test/review-workspace.test.ts
@@ -17,7 +17,10 @@ beforeEach(() => {
   reviewWs = path.join(root, "review-ws");
   mainClone = path.join(mainWs, "proj");
   // bare origin with a main branch + a PR branch, exposed as refs/pull/1/head
-  execFileSync("git", ["init", "-q", "--bare", origin]);
+  // -b main pins the bare repo's HEAD to main regardless of the host's
+  // init.defaultBranch (CI runners default to master), so the later
+  // `git clone origin` checks out a local main branch and the FIN-dev push works.
+  execFileSync("git", ["init", "-q", "--bare", "-b", "main", origin]);
   const seed = path.join(root, "seed");
   execFileSync("git", ["clone", "-q", origin, seed]);
   fs.writeFileSync(path.join(seed, "a.txt"), "base\n");


### PR DESCRIPTION
## 動機
`.github/workflows/` 目前只有 docs 部署、traceability、confluence-sync 三個 workflow,**沒有任何 CI 在 PR/push 時跑單元測試或 typecheck**。900+ 測試全靠本地紀律把關,回歸風險高。

Closes #71。

## 做法
新增 `test.yml`:
- 觸發:所有 PR + push main
- matrix 跑四個有真實測試的 workspace:`packages/cli`、`packages/rag`、`packages/shared`、`apps/desktop`
- 每個 workspace 的 `npm test` 已內建 `tsc -p tsconfig.test.json`(typecheck)+ `node --test`,無需額外框架
- `fail-fast: false`,一個 workspace 紅不掩蓋其他
- `packages/core` 刻意排除,待 #73 補上真實測試(現為 no-op echo,放進去會是誤導性綠燈)

## 本地驗證
四個 workspace 全綠:**1046 tests, 0 fail**(cli 988 / shared 32 / rag 13 / desktop 13)。此 PR 本身會觸發 test.yml,在真實 CI 上驗證。

## 後續
- 合併後於 repo settings 將 `test (packages/cli)` 等四個 job 設為 **required status check**
- #73 補完 core 測試後把 `packages/core` 加進 matrix