### PR TITLE
refactor: extract pure review classifiers + formatters from review.ts (#76)

### DIFF
--- a/apps/docs/docs/changelog.md
+++ b/apps/docs/docs/changelog.md
@@ -22,6 +22,10 @@ Merged to `main`, not yet tagged.
 
 - **Flaky traceability-check** ([#80](https://github.com/hanfour/pm-workspace-kit/pull/80)) — the generated matrix's `Last generated: <date>` line was its only volatile field, so any PR touching `traceability.js` on a later day failed the CI diff purely on the date. Dropped the stamp; matrix output is now deterministic.
 
+### Changed
+
+- **review.ts decomposition, phase 1** ([#76](https://github.com/hanfour/pm-workspace-kit/issues/76)) — extracted the pure `:cr:`/`:a:` request classifiers into `review-requests.ts` and the outcome types + Slack result-line formatters + `describeMraFailure` into `review-messages.ts`, re-exported from `review.ts` for back-compat (no import changes for callers). `review.ts` 1186 → 1058 lines; behaviour-preserving (996 cli tests unchanged). The deeper `runOne` codex/mra backend extraction is deferred — it sits on the live review path and warrants host live-verification.
+
 ### Security
 
 - **Atom title now injection-scanned + redaction hardening** ([#74](https://github.com/hanfour/pm-workspace-kit/issues/74)) — closes the four security follow-ups deferred at v0.29.0. The atom `title`/`question` is injected into retrieval context just like the body but was only redacted, never injection-scanned; a shared `scanAtomFields` now scans both fields on the audio (📚) and escalation save paths (same flag-not-block policy). `countHighEntropyTokens` recognises `=`-padded base64 secrets (was anchored on `\b`, which can't terminate on `=`). Phone redaction no longer over-matches 3-group numeric IDs / amounts / ticket refs (`1234 5678 9012`, `100-2000-3000`) — the domestic form now requires a trunk-prefixed (leading `0`) or parenthesised area code. Added a `glpat-` (GitLab PAT) redaction test.

--- a/packages/cli/src/gateway/slack/review-messages.ts
+++ b/packages/cli/src/gateway/slack/review-messages.ts
@@ -1,0 +1,98 @@
+/**
+ * Slack result-line formatting for review / approve outcomes, plus the mra
+ * failure describer. Pure functions extracted from review.ts (re-exported there
+ * for back-compat) so the coordinator holds orchestration, not copy.
+ */
+import type { PrRef } from "../pr-ref";
+
+/** Fields of an mra review result that shape the Slack result line. */
+export interface ReviewOutcome {
+  status?: string;
+  commentCount?: number;
+  blockerCount?: number;
+  /** mra posted a neutral REVIEW_INCOMPLETE placeholder — the review never evaluated the PR. */
+  incomplete?: boolean;
+  protocolVersion?: "1.0";
+  artifactSha256?: string;
+  analyzedHeadSha?: string;
+}
+
+export function canConfirmApproveFromReview(res: ReviewOutcome): boolean {
+  if (res.incomplete === true) return false;
+  return res.protocolVersion === "1.0" && typeof res.artifactSha256 === "string" &&
+    typeof res.analyzedHeadSha === "string" && res.blockerCount === 0 &&
+    (res.status === "COMMENT" || res.status === "COMMENTED");
+}
+
+/** Result line for a plain `:cr:` review. It never claims GitHub approval. */
+export function reviewResultText(slug: string, ref: PrRef, res: ReviewOutcome, approvalEnabled = true): string {
+  if (res.incomplete)
+    return `:warning: ${slug}#${ref.number} review 未完成（mra 回報 REVIEW_INCOMPLETE，未真正評估此 PR — 可能 max-turns 截斷或 provider 呼叫失敗）；已貼中性佔位，claim 已釋放，請重試 :cr:：${ref.url}`;
+  const status = res.status ?? "COMMENT";
+  const count = res.commentCount ?? 0;
+  if (approvalEnabled && canConfirmApproveFromReview(res)) {
+    return `:mag: 已完成 ${slug}#${ref.number} review（GitHub action: ${status}；${count} 則）。這個結果沒有 HIGH/CRITICAL blocker，可進一步 approve，但 :cr: 不會主動 approve；請由 PMK admin 在此 channel thread @PMK 回覆 \`approve\` 授權（DM 可直接回覆）：${ref.url}`;
+  }
+  return `:mag: 已完成 ${slug}#${ref.number} review（GitHub action: ${status}；${count} 則；未執行 GitHub approve）：${ref.url}`;
+}
+
+/**
+ * Result line for a `:a:` approve. Incomplete first (a REVIEW_INCOMPLETE run posts a
+ * neutral placeholder whose GitHub event reads COMMENT — without this branch it would
+ * fall through to the misleading "請至 PR 確認是否已 approve"). Then three-way on the
+ * mra status: the batch-fallback path (review.sh) posts individual comments and prints
+ * NO `status:` line, so `status` is undefined there — we must NOT claim "發現重大問題 /
+ * 未 approve" then, because GitHub may in fact have recorded an APPROVE. Point the user
+ * to the PR instead of asserting a verdict we can't read.
+ */
+export function approveResultText(slug: string, ref: PrRef, res: ReviewOutcome): string {
+  const cc = res.commentCount ?? 0;
+  if (res.incomplete)
+    return `:warning: 未 approve ${slug}#${ref.number} — review 未完成（mra 回報 REVIEW_INCOMPLETE，可能 max-turns 截斷或 provider 呼叫失敗），未做任何 approve；請重試 :a: 或手動 review：${ref.url}`;
+  if (res.status === "APPROVED")
+    return `:white_check_mark: 已 approve ${slug}#${ref.number}（無重大問題；${cc} 則 minor 建議）：${ref.url}`;
+  if (res.status === "CHANGES_REQUESTED")
+    return `:no_entry: 未 approve ${slug}#${ref.number} — 發現重大問題，已請求修改（${cc} 則）：${ref.url}`;
+  return `:information_source: 已完成 ${slug}#${ref.number} review（GitHub 未回報 approve 狀態，${cc} 則；請至 PR 確認是否已 approve）：${ref.url}`;
+}
+
+/** Last non-empty line of `s`, with ANSI colour escapes stripped and trimmed. */
+function lastNonEmptyLine(s?: string): string | undefined {
+  if (!s) return undefined;
+  const lines = s
+    .split("\n")
+    .map((l) => l.replace(/\x1b\[[0-9;]*m/g, "").trim())
+    .filter(Boolean);
+  return lines[lines.length - 1];
+}
+
+/**
+ * Turn an mra failure into something actionable. Older mra review paths ran
+ * providers under `set -euo pipefail` with `2>/dev/null`, so a non-zero provider
+ * exit can become a silent `mra exited with code=1` with no stderr — `detail`
+ * then falls back to the last stdout phase so the Slack message says WHERE it
+ * died; `logDump` records the full picture for the operator's gateway log.
+ */
+export function describeMraFailure(res: {
+  reason?: string;
+  stderr?: string;
+  stdout?: string;
+}): { detail: string; logDump: string } {
+  const errTail = lastNonEmptyLine(res.stderr);
+  const outTail = lastNonEmptyLine(res.stdout);
+  const detail = errTail
+    ? errTail.slice(0, 200)
+    : outTail
+      ? `最後階段：${outTail.slice(0, 140)}`
+      : "";
+  const logDump = [
+    `reason=${res.reason ?? "unknown"}`,
+    errTail
+      ? `stderr=${errTail}`
+      : "stderr=(empty — mra likely swallowed the provider error via 2>/dev/null)",
+    outTail ? `stdout(last)=${outTail}` : "",
+  ]
+    .filter(Boolean)
+    .join(" | ");
+  return { detail, logDump };
+}

--- a/packages/cli/src/gateway/slack/review-requests.ts
+++ b/packages/cli/src/gateway/slack/review-requests.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure classifiers for the `:cr:` / `:a:` review-request surface. Each takes the
+ * (bot-mention-stripped) message text and decides whether it is a particular
+ * kind of review command. Extracted from review.ts to keep the coordinator lean;
+ * re-exported from there for back-compat.
+ */
+import { parsePrRefs } from "../pr-ref";
+
+/** True when a message is a `:cr:` review request with at least one PR link. */
+export function isReviewRequest(text: string): boolean {
+  return text.includes(":cr:") && parsePrRefs(text).length > 0;
+}
+
+/**
+ * True when a message is an inline `:a:` approve request: it contains the `:a:`
+ * token AND at least one GitHub PR link. `:a:` runs a fast single-agent review
+ * then approves iff no high-severity issue is found.
+ */
+export function isApproveRequest(text: string): boolean {
+  return text.includes(":a:") && parsePrRefs(text).length > 0;
+}
+
+/**
+ * Bare confirmation inside a review thread. This is intentionally narrower than
+ * ordinary chat: `:cr:` may offer approval, but GitHub APPROVE only happens after
+ * an explicit user confirmation.
+ */
+export function isApproveConfirmationRequest(text: string): boolean {
+  const t = text
+    .trim()
+    .toLowerCase()
+    .replace(/[。.!！]+$/g, "")
+    .replace(/\s+/g, " ");
+  return [
+    "approve",
+    "approve pr",
+    "approve this",
+    "confirm approve",
+    "yes approve",
+    "確認 approve",
+    "確認approve",
+    "請 approve",
+    "可以 approve",
+    "進行 approve",
+    "核准",
+  ].includes(t);
+}
+
+/**
+ * True when a message is a bare retry command (`retry` / `重試`), used inside a
+ * review-result thread to re-run that thread's PR review. The bot @-mention is
+ * stripped upstream, so we match the trimmed text exactly to avoid intercepting
+ * ordinary chat that merely mentions "retry".
+ */
+export function isRetryRequest(text: string): boolean {
+  const t = text.trim().toLowerCase();
+  return t === "retry" || t === "重試";
+}
+
+export function isRerunRequest(text: string): boolean {
+  const t = text.trim().toLowerCase();
+  return t === "rerun" || t === "重跑";
+}

--- a/packages/cli/src/gateway/slack/review.ts
+++ b/packages/cli/src/gateway/slack/review.ts
@@ -64,6 +64,30 @@ import {
   ensureReviewWorkspaceMeta as ensureReviewWorkspaceMetaImpl,
   pkbNeedsBuild as pkbNeedsBuildImpl,
 } from "../review-workspace";
+// Pure request classifiers + result-text formatters live in sibling modules.
+// Imported for internal use, and re-exported so slack/index.ts and the review
+// tests keep importing them from "./review" unchanged.
+import { isReviewRequest, isApproveRequest } from "./review-requests";
+export {
+  isReviewRequest,
+  isApproveRequest,
+  isApproveConfirmationRequest,
+  isRetryRequest,
+  isRerunRequest,
+} from "./review-requests";
+import {
+  canConfirmApproveFromReview,
+  reviewResultText,
+  approveResultText,
+  describeMraFailure,
+} from "./review-messages";
+export {
+  type ReviewOutcome,
+  canConfirmApproveFromReview,
+  reviewResultText,
+  approveResultText,
+  describeMraFailure,
+} from "./review-messages";
 
 export interface ReviewGateway {
   resolveProjectByRemote: typeof resolveProjectByRemoteImpl;
@@ -101,160 +125,8 @@ export const realReviewGateway: ReviewGateway = {
   pkbNeedsBuild: pkbNeedsBuildImpl,
 };
 
-/**
- * True when a message is an inline `:cr:` review request: it contains the
- * `:cr:` token AND at least one GitHub PR link. Requiring BOTH avoids
- * false-firing review on a stray PR link in ordinary chat. (option B-lite gate)
- */
-export function isReviewRequest(text: string): boolean {
-  return text.includes(":cr:") && parsePrRefs(text).length > 0;
-}
-
-/**
- * True when a message is an inline `:a:` approve request: it contains the `:a:`
- * token AND at least one GitHub PR link. `:a:` runs a fast single-agent review
- * then approves iff no high-severity issue is found.
- */
-export function isApproveRequest(text: string): boolean {
-  return text.includes(":a:") && parsePrRefs(text).length > 0;
-}
-
-/**
- * Bare confirmation inside a review thread. This is intentionally narrower than
- * ordinary chat: `:cr:` may offer approval, but GitHub APPROVE only happens after
- * an explicit user confirmation.
- */
-export function isApproveConfirmationRequest(text: string): boolean {
-  const t = text
-    .trim()
-    .toLowerCase()
-    .replace(/[。.!！]+$/g, "")
-    .replace(/\s+/g, " ");
-  return [
-    "approve",
-    "approve pr",
-    "approve this",
-    "confirm approve",
-    "yes approve",
-    "確認 approve",
-    "確認approve",
-    "請 approve",
-    "可以 approve",
-    "進行 approve",
-    "核准",
-  ].includes(t);
-}
-
-/** Fields of an mra review result that shape the Slack result line. */
-export interface ReviewOutcome {
-  status?: string;
-  commentCount?: number;
-  blockerCount?: number;
-  /** mra posted a neutral REVIEW_INCOMPLETE placeholder — the review never evaluated the PR. */
-  incomplete?: boolean;
-  protocolVersion?: "1.0";
-  artifactSha256?: string;
-  analyzedHeadSha?: string;
-}
-
-export function canConfirmApproveFromReview(res: ReviewOutcome): boolean {
-  if (res.incomplete === true) return false;
-  return res.protocolVersion === "1.0" && typeof res.artifactSha256 === "string" &&
-    typeof res.analyzedHeadSha === "string" && res.blockerCount === 0 &&
-    (res.status === "COMMENT" || res.status === "COMMENTED");
-}
-
-/** Result line for a plain `:cr:` review. It never claims GitHub approval. */
-export function reviewResultText(slug: string, ref: PrRef, res: ReviewOutcome, approvalEnabled = true): string {
-  if (res.incomplete)
-    return `:warning: ${slug}#${ref.number} review 未完成（mra 回報 REVIEW_INCOMPLETE，未真正評估此 PR — 可能 max-turns 截斷或 provider 呼叫失敗）；已貼中性佔位，claim 已釋放，請重試 :cr:：${ref.url}`;
-  const status = res.status ?? "COMMENT";
-  const count = res.commentCount ?? 0;
-  if (approvalEnabled && canConfirmApproveFromReview(res)) {
-    return `:mag: 已完成 ${slug}#${ref.number} review（GitHub action: ${status}；${count} 則）。這個結果沒有 HIGH/CRITICAL blocker，可進一步 approve，但 :cr: 不會主動 approve；請由 PMK admin 在此 channel thread @PMK 回覆 \`approve\` 授權（DM 可直接回覆）：${ref.url}`;
-  }
-  return `:mag: 已完成 ${slug}#${ref.number} review（GitHub action: ${status}；${count} 則；未執行 GitHub approve）：${ref.url}`;
-}
-
-/**
- * Result line for a `:a:` approve. Incomplete first (a REVIEW_INCOMPLETE run posts a
- * neutral placeholder whose GitHub event reads COMMENT — without this branch it would
- * fall through to the misleading "請至 PR 確認是否已 approve"). Then three-way on the
- * mra status: the batch-fallback path (review.sh) posts individual comments and prints
- * NO `status:` line, so `status` is undefined there — we must NOT claim "發現重大問題 /
- * 未 approve" then, because GitHub may in fact have recorded an APPROVE. Point the user
- * to the PR instead of asserting a verdict we can't read.
- */
-export function approveResultText(slug: string, ref: PrRef, res: ReviewOutcome): string {
-  const cc = res.commentCount ?? 0;
-  if (res.incomplete)
-    return `:warning: 未 approve ${slug}#${ref.number} — review 未完成（mra 回報 REVIEW_INCOMPLETE，可能 max-turns 截斷或 provider 呼叫失敗），未做任何 approve；請重試 :a: 或手動 review：${ref.url}`;
-  if (res.status === "APPROVED")
-    return `:white_check_mark: 已 approve ${slug}#${ref.number}（無重大問題；${cc} 則 minor 建議）：${ref.url}`;
-  if (res.status === "CHANGES_REQUESTED")
-    return `:no_entry: 未 approve ${slug}#${ref.number} — 發現重大問題，已請求修改（${cc} 則）：${ref.url}`;
-  return `:information_source: 已完成 ${slug}#${ref.number} review（GitHub 未回報 approve 狀態，${cc} 則；請至 PR 確認是否已 approve）：${ref.url}`;
-}
-
 /** Backoff before a single transient-failure retry of the mra review call. */
 const MRA_RETRY_BACKOFF_MS = 4000;
-
-/** Last non-empty line of `s`, with ANSI colour escapes stripped and trimmed. */
-function lastNonEmptyLine(s?: string): string | undefined {
-  if (!s) return undefined;
-  const lines = s
-    .split("\n")
-    .map((l) => l.replace(/\[[0-9;]*m/g, "").trim())
-    .filter(Boolean);
-  return lines[lines.length - 1];
-}
-
-/**
- * Turn an mra failure into something actionable. Older mra review paths ran
- * providers under `set -euo pipefail` with `2>/dev/null`, so a non-zero provider
- * exit can become a silent `mra exited with code=1` with no stderr — `detail`
- * then falls back to the last stdout phase so the Slack message says WHERE it
- * died; `logDump` records the full picture for the operator's gateway log.
- */
-export function describeMraFailure(res: {
-  reason?: string;
-  stderr?: string;
-  stdout?: string;
-}): { detail: string; logDump: string } {
-  const errTail = lastNonEmptyLine(res.stderr);
-  const outTail = lastNonEmptyLine(res.stdout);
-  const detail = errTail
-    ? errTail.slice(0, 200)
-    : outTail
-      ? `最後階段：${outTail.slice(0, 140)}`
-      : "";
-  const logDump = [
-    `reason=${res.reason ?? "unknown"}`,
-    errTail
-      ? `stderr=${errTail}`
-      : "stderr=(empty — mra likely swallowed the provider error via 2>/dev/null)",
-    outTail ? `stdout(last)=${outTail}` : "",
-  ]
-    .filter(Boolean)
-    .join(" | ");
-  return { detail, logDump };
-}
-
-/**
- * True when a message is a bare retry command (`retry` / `重試` / `重跑`), used
- * inside a review-result thread to re-run that thread's PR review. The bot
- * @-mention is stripped upstream, so we match the trimmed text exactly to avoid
- * intercepting ordinary chat that merely mentions "retry".
- */
-export function isRetryRequest(text: string): boolean {
-  const t = text.trim().toLowerCase();
-  return t === "retry" || t === "重試";
-}
-
-export function isRerunRequest(text: string): boolean {
-  const t = text.trim().toLowerCase();
-  return t === "rerun" || t === "重跑";
-}
 
 export interface ReviewCoordinatorOptions {
   web: WebClient;


### PR DESCRIPTION
## 動機
`review.ts` 在 codex 整合後膨脹到 1186 行,是 gateway 最大熱點。Phase 1 把**純、已完整測試**的表面抽出,先做零風險的一刀。針對 #76。

## 做法
- `review-requests.ts` — `is{Review,Approve,ApproveConfirmation,Retry,Rerun}Request`(5 個純分類器)
- `review-messages.ts` — `ReviewOutcome`、`canConfirmApproveFromReview`、`review/approveResultText`、`describeMraFailure`(+ `lastNonEmptyLine` helper)
- 兩者從 `review.ts` **re-export**,故 `slack/index.ts` 與 review 測試的 import **完全不用改**
- `review.ts` **1186 → 1058 行**

## 驗證
- 行為保持:**996 cli tests 全綠**,typecheck 乾淨
- 一個坑:ANSI-strip 正則原本帶**字面 ESC 位元組**(複製會遺失),改寫成可見的 `\x1b\[`;已用 describeMraFailure 的 ANSI 測試驗證

## 刻意 defer
`runOne` 的 codex/mra 後端抽取**本次不做**——它在 live `:cr:`/`:a:` 路徑上,且 mra 會吞掉 transient 失敗,值得先在 host live 驗證再動。這是風險/價值考量下的分階。