### PR TITLE
fix: atom-index staleness robust to fs mtime granularity (#83)

### DIFF
--- a/packages/cli/src/gateway/atom-index.ts
+++ b/packages/cli/src/gateway/atom-index.ts
@@ -57,14 +57,26 @@ function indexFileFor(scope: string | undefined): string {
 }
 
 /**
- * Latest mtime of any approved atom's .md file under the given scope
- * (or all scopes when `scope` is undefined). Used to detect whether
- * the cached index is stale.
+ * Filesystem mtime granularity slack (#83). CI filesystems (ext4/overlayfs)
+ * can truncate mtimes to whole seconds, so an atom written in the same coarse
+ * tick as `builtAt` may compare as NOT newer and the stale cache would be
+ * served. Treat anything within this window of `builtAt` as possibly-newer
+ * and rebuild — rebuilds are cheap (small corpus) and the check converges
+ * once the newest write is older than the window.
  */
-function newestAtomMtime(scope?: string): number {
+const MTIME_TOLERANCE_MS = 2000;
+
+/**
+ * Scan every atom .md file under the given scope (or all scopes when
+ * `scope` is undefined): latest mtime + file count. Both feed staleness
+ * detection — mtime catches edits/additions, the count catches deletions
+ * (removing a file never bumps any surviving file's mtime).
+ */
+function scanAtomFiles(scope?: string): { newestMtime: number; fileCount: number } {
   const root = knowledgeRoot();
-  if (!fs.existsSync(root)) return 0;
+  if (!fs.existsSync(root)) return { newestMtime: 0, fileCount: 0 };
   let newest = 0;
+  let count = 0;
   const scopes = scope
     ? [scope]
     : fs.readdirSync(root).filter((d) => {
@@ -85,12 +97,13 @@ function newestAtomMtime(scope?: string): number {
       try {
         const m = fs.statSync(path.join(dir, f)).mtimeMs;
         if (m > newest) newest = m;
+        count += 1;
       } catch {
         /* skip */
       }
     }
   }
-  return newest;
+  return { newestMtime: newest, fileCount: count };
 }
 
 /**
@@ -159,21 +172,30 @@ export function buildAtomsIndex(opts: { scope?: string } = {}): RagIndex {
     root: knowledgeRoot(),
     chunks,
     idf,
+    fileCount: scanAtomFiles(opts.scope).fileCount,
   };
   saveIndex(index, indexFileFor(opts.scope));
   return index;
 }
 
 /**
- * Load the on-disk index, rebuild if stale (any atom mtime newer
- * than index `builtAt`) or missing. Returns null when there are no
- * atoms to index — caller falls back to keyword search.
+ * Load the on-disk index, rebuild if stale or missing. Staleness (#83):
+ *   - any atom file's mtime within MTIME_TOLERANCE_MS of (or newer than)
+ *     the cached `builtAt` — tolerance absorbs coarse fs mtime granularity;
+ *   - the .md file count changed — catches deletions, which mtime can't;
+ *   - the cached index predates `fileCount` (older version) — rebuild once.
+ * Returns null when there are no atoms to index — caller falls back to
+ * keyword search.
  */
 function getOrBuildIndex(scope: string | undefined): RagIndex | null {
   const file = indexFileFor(scope);
   const cached = loadIndex(file);
-  const newestMtime = newestAtomMtime(scope);
-  if (cached && new Date(cached.builtAt).getTime() >= newestMtime) {
+  const scan = scanAtomFiles(scope);
+  if (
+    cached &&
+    cached.fileCount === scan.fileCount &&
+    new Date(cached.builtAt).getTime() - scan.newestMtime > MTIME_TOLERANCE_MS
+  ) {
     return cached;
   }
   // Stale or missing — rebuild.

--- a/packages/cli/test/gateway.test.ts
+++ b/packages/cli/test/gateway.test.ts
@@ -1847,17 +1847,12 @@ describe("atom-index BM25 (#19)", () => {
     assert.equal(approvedAtomCount("erp"), 2);
   });
 
-  it("index file is rebuilt when atoms change (mtime invalidation)", () => {
+  it("index is rebuilt when an atom is ADDED after build (file-count invalidation, #83)", () => {
     seedThreeApprovedAtoms();
-    const first = buildAtomsIndex({ scope: "erp" });
-    const firstBuiltAt = new Date(first.builtAt).getTime();
-    // Add another atom AFTER the index built; mtime should now be newer
-    // than firstBuiltAt, triggering a rebuild on next searchAtomsRanked.
-    fs.utimesSync(
-      path.join(knowledgeRoot(), "erp"),
-      new Date(),
-      new Date(firstBuiltAt + 60_000), // dir mtime well after index
-    );
+    buildAtomsIndex({ scope: "erp" });
+    // Adding a file changes the scanned file count, which invalidates the
+    // cache deterministically — no mtime granularity dependence (#83: the
+    // old dir-utimes version was flaky on coarse-mtime CI filesystems).
     saveAtom({
       id: generateAtomId("late addition"),
       createdAt: Date.now(),
@@ -1873,6 +1868,49 @@ describe("atom-index BM25 (#19)", () => {
     // Late-added atom is now retrievable.
     assert.ok(hits.length >= 2);
     assert.ok(hits.some((a) => a.question.includes("Late-added")));
+  });
+
+  it("index is rebuilt when an atom is EDITED in place (mtime invalidation, count unchanged)", () => {
+    seedThreeApprovedAtoms();
+    const edited = {
+      id: generateAtomId("editable"),
+      createdAt: Date.now(),
+      scope: "erp",
+      question: "Atom about deployment cadence",
+      answer: "Old answer without the magic keyword.",
+      summary: "Deployment cadence.",
+      tags: ["deploy"],
+      source: { threadKey: "T5", contributorUserId: "U1" },
+      status: "approved" as const,
+    };
+    saveAtom(edited);
+    const first = buildAtomsIndex({ scope: "erp" });
+    const firstBuiltAt = new Date(first.builtAt).getTime();
+    // Overwrite the SAME atom (same id → same file → count unchanged) and pin
+    // its mtime explicitly past builtAt + tolerance, so only the mtime path
+    // can trigger the rebuild — deterministic on any fs granularity.
+    const file = saveAtom({ ...edited, answer: "Rewritten answer mentioning zeppelin scheduling." });
+    fs.utimesSync(file, new Date(), new Date(firstBuiltAt + 60_000));
+    const hits = searchAtomsRanked("zeppelin", { scope: "erp", limit: 5 });
+    assert.ok(hits.some((a) => a.id === edited.id), "edited content must be re-indexed");
+  });
+
+  it("index is rebuilt when an atom is DELETED (mtime can never catch this)", () => {
+    seedThreeApprovedAtoms();
+    buildAtomsIndex({ scope: "erp" });
+    // Find and delete the budget atom's file; no surviving file's mtime
+    // changes, so only the file-count check can invalidate the cache.
+    const budget = loadAtoms({ scope: "erp" }).find((a) => /budget/i.test(a.question));
+    assert.ok(budget);
+    const dir = path.join(knowledgeRoot(), "erp");
+    const victim = fs.readdirSync(dir).find((f) => f.includes(budget.id));
+    assert.ok(victim, "budget atom file must exist");
+    fs.rmSync(path.join(dir, victim));
+    const hits = searchAtomsRanked("budget allocation", { scope: "erp", limit: 5 });
+    assert.ok(
+      hits.every((a) => a.id !== budget.id),
+      "deleted atom must not be returned from a stale cache",
+    );
   });
 });
 

--- a/packages/rag/src/index.ts
+++ b/packages/rag/src/index.ts
@@ -23,6 +23,14 @@ export interface RagIndex {
   root: string;
   chunks: IndexedChunk[];
   idf: Record<string, number>;
+  /**
+   * Number of source files scanned at build time. Consumers that cache the
+   * index compare this against a fresh scan to invalidate on file ADDITIONS
+   * and DELETIONS — deletions never bump any surviving file's mtime, so an
+   * mtime-only check can't catch them. Optional: indexes persisted by older
+   * versions lack it (treat as stale once and rebuild).
+   */
+  fileCount?: number;
 }
 
 const DEFAULT_EXTS = [".md", ".mdx"];


### PR DESCRIPTION
## 問題
快取有效性檢查是 `builtAt >= newest atom mtime` 的精確比較。CI 檔案系統 mtime 粒度較粗,與 builtAt 同 tick 寫入的 atom 比較結果為「不較新」→ 端出過期快取 → #83 的 CI flaky(重跑即過)。原測試又是對**目錄** utimes,而檢查根本不看目錄。Closes #83。

## 修法
**生產側**(atom-index.ts):
- `MTIME_TOLERANCE_MS = 2000`:與 builtAt 距離在窗內一律視為可能較新 → rebuild(語料小、重建便宜,窗過即收斂)
- 索引記錄 `fileCount`(同一次 readdir 順手數)→ 數量變即失效——**抓到刪除**(刪檔不會動任何存活檔案的 mtime,舊邏輯永遠抓不到);舊快取無此欄位 → 一次性重建(`RagIndex.fileCount` optional)

**測試側**:1 個 flaky 換成 3 個 deterministic——ADDED(count 路徑,零 mtime 依賴)、EDITED in place(同 id 同檔,明確未來 mtime 釘死 mtime 路徑)、DELETED(count 路徑;舊邏輯下過期快取會繼續回傳已刪 atom)

## 驗證
cli 1009 → **1011**、rag 13 全綠,typecheck 乾淨。