### PR TITLE
feat: re-enable :a: GitHub approve behind a cross-process authorization lock (#90)

### DIFF
--- a/apps/docs/docs/changelog.md
+++ b/apps/docs/docs/changelog.md
@@ -8,6 +8,13 @@ All notable changes to **pm-workspace-kit** are documented here.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each release also has a longer narrative on [GitHub Releases](https://github.com/hanfour/pm-workspace-kit/releases) with rationale, dogfood notes, and test plans.
 
+## [Unreleased]
+
+### Added
+
+- **`:a:` GitHub approve re-enabled behind the cross-process authorization lock** ([#90](https://github.com/hanfour/pm-workspace-kit/issues/90)) — implements the precondition PR #70's release veto documented: config writers (`saveGatewayConfig`) and the approve POST critical section (`publishApprovalReservation`) now share one mkdir-based cross-process lock (`gateway/authorization-lock.ts`, dead-pid + stale-hold takeover via atomic rename-to-tombstone), closing the TOCTOU where a policy revocation could land between the last revision-fence read and the GitHub mutation. Same-process writers fail fast with an honest ":hourglass: approve 進行中" reply instead of starving the event loop; foreign-process writers block briefly. `AUTOMATIC_APPROVAL_RELEASE_READY` flipped to `true` — the runtime gate is now `review.approval.enabled` (admin-togglable via `/pmk admin review approval enable`, default **false**). The three-phase revision fences stay as defense-in-depth. +9 tests (7 lock, 2 acceptance: end-to-end gated approve; write-refused-inside-critical-section), 1,020 cli tests green.
+- ⚠️ Not yet live-verified: a real end-to-end `:a:` approve on GitHub requires admin-enabling approval + a sacrificial PR — do this before the next tag.
+
 ## [v0.31.0] — 2026-07-16 — Codex review provider, CI test harness, security hardening & hotspot decomposition
 
 [GitHub release](https://github.com/hanfour/pm-workspace-kit/releases/tag/v0.31.0)

--- a/packages/cli/src/gateway/authorization-lock.ts
+++ b/packages/cli/src/gateway/authorization-lock.ts
@@ -1,0 +1,212 @@
+/**
+ * The single cross-process authorization lock shared by gateway-config
+ * writers and the GitHub-approve POST path (#90 — the #70 release-veto
+ * precondition).
+ *
+ * Why it exists: `publishApprovalReservation` re-validates live policy with
+ * a three-phase revision fence before POSTing, but fences are reads — they
+ * cannot exclude a writer landing between the last read and the POST. This
+ * lock makes them mutually exclusive: while the approve critical section
+ * holds it, `saveGatewayConfig` blocks (bounded), so every config write is
+ * serialized either wholly before the section's policy reads (the fences
+ * then reject) or wholly after the POST completes.
+ *
+ * Mechanics: an mkdir-based lock (atomic on POSIX) at
+ * `~/.pmk/gateway/authorization.lock/`, same family as the approval-offer
+ * lock. The owner file records `{ pid, acquiredAt }`; takeover happens when
+ * the owner pid is dead or the hold exceeds `staleMs` (the approve section
+ * spans several GitHub calls, so holds are seconds — a stale hold means a
+ * crashed/hung holder). Takeover is an atomic RENAME to a tombstone, never
+ * an rm of the live path, so two contenders cannot delete each other's
+ * freshly acquired lock.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { gatewayDir } from "./config";
+
+export class AuthorizationLockBusyError extends Error {
+  constructor(heldByPid?: number) {
+    super(
+      `authorization lock is busy${heldByPid ? ` (held by pid ${heldByPid})` : ""} — ` +
+        "a GitHub approve may be in flight; retry shortly",
+    );
+    this.name = "AuthorizationLockBusyError";
+  }
+}
+
+export interface AuthorizationLockOptions {
+  /** Give up acquiring after this long. Default 15s. */
+  acquireTimeoutMs?: number;
+  /** A hold older than this is presumed crashed/hung and taken over. Default 120s. */
+  staleMs?: number;
+  /** Retry cadence while waiting. Default 50ms. */
+  pollMs?: number;
+}
+
+const DEFAULTS = { acquireTimeoutMs: 15_000, staleMs: 120_000, pollMs: 50 };
+
+export function authorizationLockPath(): string {
+  return path.join(gatewayDir(), "authorization.lock");
+}
+
+interface Owner {
+  pid: number;
+  acquiredAt: number;
+}
+
+function readOwner(lock: string): Owner | undefined {
+  try {
+    const raw = JSON.parse(fs.readFileSync(path.join(lock, "owner"), "utf8")) as Owner;
+    if (typeof raw.pid === "number" && typeof raw.acquiredAt === "number") return raw;
+  } catch {
+    /* unreadable/missing — treat as unknown */
+  }
+  return undefined;
+}
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Atomic takeover: rename the stale lock to a tombstone, then clean it up. */
+function tombstone(lock: string): void {
+  const grave = `${lock}.stale.${Date.now()}.${process.pid}`;
+  try {
+    fs.renameSync(lock, grave);
+    fs.rmSync(grave, { recursive: true, force: true });
+  } catch {
+    /* someone else already took it over — loop and retry */
+  }
+}
+
+type Attempt = { lock: string } | { heldBy: "self" } | { heldBy: "other"; pid?: number };
+
+/**
+ * One acquisition attempt. Success returns the lock path; otherwise reports
+ * who holds it. A live, fresh hold by THIS process is surfaced distinctly:
+ * a synchronous waiter on the same event loop can never outlive it (waiting
+ * would starve the async holder), so callers fail fast instead of spinning.
+ */
+function tryAcquire(staleMs: number): Attempt {
+  const lock = authorizationLockPath();
+  fs.mkdirSync(path.dirname(lock), { recursive: true });
+  try {
+    fs.mkdirSync(lock, { mode: 0o700 });
+    fs.writeFileSync(
+      path.join(lock, "owner"),
+      JSON.stringify({ pid: process.pid, acquiredAt: Date.now() } satisfies Owner),
+      { mode: 0o600 },
+    );
+    return { lock };
+  } catch {
+    const owner = readOwner(lock);
+    // Unknown owner (mid-acquisition or corrupt): only reap if it stays
+    // ownerless past the stale bound — mtime of the dir is the tiebreaker.
+    if (!owner) {
+      try {
+        const st = fs.statSync(lock);
+        if (Date.now() - st.mtimeMs > staleMs) tombstone(lock);
+      } catch {
+        /* vanished between attempts — retry on next poll */
+      }
+      return { heldBy: "other" };
+    }
+    if (!pidAlive(owner.pid) || Date.now() - owner.acquiredAt > staleMs) {
+      tombstone(lock);
+      return { heldBy: "other", pid: owner.pid }; // freshly reaped — next poll acquires
+    }
+    if (owner.pid === process.pid) return { heldBy: "self" };
+    return { heldBy: "other", pid: owner.pid };
+  }
+}
+
+function syncSleep(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Synchronous acquire for the (sync) config-write path.
+ *
+ * - Held by ANOTHER process: block-spin up to `acquireTimeoutMs` (a foreign
+ *   event loop keeps running; the hold is seconds).
+ * - Held by THIS process (an in-flight approve section on the same event
+ *   loop): throw {@link AuthorizationLockBusyError} IMMEDIATELY — spinning
+ *   here would starve the very section we are waiting on. The admin surface
+ *   reports it honestly ("approve in flight; retry shortly") instead of
+ *   writing around the lock.
+ */
+export function acquireAuthorizationLockSync(opts: AuthorizationLockOptions = {}): string {
+  const { acquireTimeoutMs, staleMs, pollMs } = { ...DEFAULTS, ...opts };
+  const deadline = Date.now() + acquireTimeoutMs;
+  for (;;) {
+    const attempt = tryAcquire(staleMs);
+    if ("lock" in attempt) return attempt.lock;
+    if (attempt.heldBy === "self") throw new AuthorizationLockBusyError(process.pid);
+    if (Date.now() >= deadline) {
+      throw new AuthorizationLockBusyError(attempt.pid);
+    }
+    syncSleep(pollMs);
+  }
+}
+
+export function releaseAuthorizationLock(lock: string): void {
+  try {
+    fs.rmSync(lock, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * In-process FIFO chain: two async sections in the SAME process serialize
+ * here first (fair, no fs polling against ourselves), then take the file
+ * lock to exclude OTHER processes.
+ */
+let inProcessChain: Promise<unknown> = Promise.resolve();
+
+/**
+ * Run `fn` while holding the authorization lock (async acquire). Used by the
+ * approve POST critical section: policy reads, preflights, and the POST all
+ * happen under the same hold, excluding concurrent config writes.
+ */
+export function withAuthorizationLock<T>(
+  fn: () => Promise<T> | T,
+  opts: AuthorizationLockOptions = {},
+): Promise<T> {
+  const { acquireTimeoutMs, staleMs, pollMs } = { ...DEFAULTS, ...opts };
+  const run = async (): Promise<T> => {
+    const deadline = Date.now() + acquireTimeoutMs;
+    let lock: string | undefined;
+    for (;;) {
+      const attempt = tryAcquire(staleMs);
+      if ("lock" in attempt) {
+        lock = attempt.lock;
+        break;
+      }
+      // heldBy "self" can only mean a sync holder or a leaked release on this
+      // pid — the chain already serialized async sections. Treat it like any
+      // contended hold: poll until free or stale.
+      if (Date.now() >= deadline) {
+        throw new AuthorizationLockBusyError(
+          attempt.heldBy === "other" ? attempt.pid : process.pid,
+        );
+      }
+      await new Promise<void>((r) => setTimeout(r, pollMs));
+    }
+    try {
+      return await fn();
+    } finally {
+      releaseAuthorizationLock(lock);
+    }
+  };
+  // Chain regardless of the predecessor's outcome (its errors surface to its
+  // own caller; the chain link swallows them so the queue never jams).
+  const next = inProcessChain.then(run, run);
+  inProcessChain = next.catch(() => undefined);
+  return next;
+}

--- a/packages/cli/src/gateway/config.ts
+++ b/packages/cli/src/gateway/config.ts
@@ -11,6 +11,10 @@ import {
   validateSecretSource,
   resolveSecret,
 } from "./secret-source";
+import {
+  acquireAuthorizationLockSync,
+  releaseAuthorizationLock,
+} from "./authorization-lock";
 
 /**
  * Gateway config — what the host configures once, before
@@ -615,17 +619,28 @@ export function isAdmin(cfg: GatewayConfig, userId: string): boolean {
 }
 
 export function saveGatewayConfig(cfg: RawGatewayConfig): string {
-  const file = gatewayConfigPath();
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, JSON.stringify(cfg, null, 2), { mode: 0o600 });
-  // Tighten existing-file permissions in case the file was created with
-  // the umask default.
+  // #90: every config write serializes with the GitHub-approve POST critical
+  // section via the shared authorization lock. While an approve is in flight
+  // this throws AuthorizationLockBusyError instead of writing around it —
+  // callers surface "approve 進行中，請稍後重試" honestly. (The config ↔
+  // authorization-lock import cycle is safe: both sides only touch the other
+  // at call time, never at module init.)
+  const lock = acquireAuthorizationLockSync();
   try {
-    fs.chmodSync(file, 0o600);
-  } catch {
-    /* non-POSIX or permission issue — best-effort */
+    const file = gatewayConfigPath();
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify(cfg, null, 2), { mode: 0o600 });
+    // Tighten existing-file permissions in case the file was created with
+    // the umask default.
+    try {
+      fs.chmodSync(file, 0o600);
+    } catch {
+      /* non-POSIX or permission issue — best-effort */
+    }
+    return file;
+  } finally {
+    releaseAuthorizationLock(lock);
   }
-  return file;
 }
 
 export function isGatewayConfigured(cfg: GatewayConfig): boolean {

--- a/packages/cli/src/gateway/review-policy.ts
+++ b/packages/cli/src/gateway/review-policy.ts
@@ -1,9 +1,13 @@
 import type { ReviewProviderMode, ReviewStrategy } from "../adapters/mra";
 
-// Release veto: the analysis/review integration is production-ready, but a
-// GitHub APPROVE mutation remains disabled until config writers and the POST
-// path share one cross-process authorization lock.
-export const AUTOMATIC_APPROVAL_RELEASE_READY = false;
+// Release veto — LIFTED (#90, 2026-07-17): config writers
+// (saveGatewayConfig) and the approve POST critical section
+// (publishApprovalReservation) now share the cross-process authorization
+// lock (gateway/authorization-lock.ts), closing the TOCTOU the veto guarded
+// against. GitHub APPROVE additionally requires the runtime gate
+// `review.approval.enabled` (admin-togglable, default false) plus the
+// per-approve preflights (identity, head-SHA, protection, revision fences).
+export const AUTOMATIC_APPROVAL_RELEASE_READY = true;
 
 export function effectiveMraReviewStrategy(
   configured: ReviewStrategy,

--- a/packages/cli/src/gateway/slack/admin.ts
+++ b/packages/cli/src/gateway/slack/admin.ts
@@ -68,6 +68,23 @@ const SLACK_USER_ID_RE = /^[UW][A-Z0-9]{2,}$/;
 export async function handleAdminSlash(
   args: AdminSlashArgs,
 ): Promise<AdminSlashResult> {
+  try {
+    return await dispatchAdminSlash(args);
+  } catch (err) {
+    // #90: config writes serialize with the approve POST critical section.
+    // While an approve is in flight the write is refused — tell the admin
+    // honestly instead of surfacing a stack trace (or worse, silently
+    // writing around the lock).
+    if ((err as Error).name === "AuthorizationLockBusyError") {
+      return { text: ":hourglass: 有一筆 GitHub approve 正在進行，設定暫時鎖定；請幾秒後重試這個指令。" };
+    }
+    throw err;
+  }
+}
+
+async function dispatchAdminSlash(
+  args: AdminSlashArgs,
+): Promise<AdminSlashResult> {
   const [head, ...rest] = args.tokens;
   switch (head) {
     case undefined:

--- a/packages/cli/src/gateway/slack/review.ts
+++ b/packages/cli/src/gateway/slack/review.ts
@@ -48,6 +48,7 @@ import {
 } from "../../adapters/mra";
 import { AUTOMATIC_APPROVAL_RELEASE_READY, effectiveMraReviewStrategy } from "../review-policy";
 export { effectiveMraReviewStrategy } from "../review-policy";
+import { withAuthorizationLock } from "../authorization-lock";
 import {
   resolveRepoSlug as resolveRepoSlugImpl,
   repoVisibility as repoVisibilityImpl,
@@ -539,6 +540,12 @@ export class ReviewCoordinator {
     try {
       if (reservation.refs.length !== 1)
         throw new Error("multi-PR approval must be confirmed in separate review threads");
+      // #90: the whole authorize→preflight→POST section runs under the shared
+      // authorization lock, so no config write can land between the policy
+      // reads (the revision fences below, kept as defense-in-depth) and the
+      // actual GitHub mutation. A concurrent writer either commits before the
+      // first read (fences reject) or blocks until the POST completes.
+      await withAuthorizationLock(async () => {
       for (const ref of reservation.refs) {
         const live = this.currentConfig();
         const review = resolveReviewConfig(live.review);
@@ -598,6 +605,7 @@ export class ReviewCoordinator {
         await this.reply(reservation.channelId, reservation.threadTs,
           `:white_check_mark: 已真實 approve ${slug}#${ref.number}（commit \`${ref.headSha.slice(0, 7)}\`，GitHub review #${posted.reviewId}）。`);
       }
+      });
       consumeApprovalReservation(reservation);
     } catch (err) {
       if (mutationStarted) {

--- a/packages/cli/test/authorization-lock.test.ts
+++ b/packages/cli/test/authorization-lock.test.ts
@@ -1,0 +1,116 @@
+// packages/cli/test/authorization-lock.test.ts
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import * as os from "node:os";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  withAuthorizationLock,
+  acquireAuthorizationLockSync,
+  releaseAuthorizationLock,
+  authorizationLockPath,
+  AuthorizationLockBusyError,
+} from "../src/gateway/authorization-lock";
+
+const ORIG_HOME = process.env.HOME; // gatewayDir() is HOME-based
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-authlock-"));
+  process.env.HOME = tmp;
+});
+afterEach(() => {
+  if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+describe("authorization-lock (#90)", () => {
+  it("withAuthorizationLock runs the section and releases the lock", async () => {
+    let ran = false;
+    const out = await withAuthorizationLock(async () => {
+      ran = true;
+      assert.ok(fs.existsSync(authorizationLockPath()), "lock dir held during section");
+      return 42;
+    });
+    assert.equal(out, 42);
+    assert.equal(ran, true);
+    assert.equal(fs.existsSync(authorizationLockPath()), false, "released after section");
+  });
+
+  it("releases the lock when the section throws", async () => {
+    await assert.rejects(
+      () => withAuthorizationLock(async () => { throw new Error("boom"); }),
+      /boom/,
+    );
+    assert.equal(fs.existsSync(authorizationLockPath()), false);
+  });
+
+  it("serializes two concurrent async sections (mutual exclusion)", async () => {
+    const events: string[] = [];
+    const a = withAuthorizationLock(async () => {
+      events.push("a-start");
+      await sleep(120);
+      events.push("a-end");
+    });
+    await sleep(20); // let A acquire first
+    const b = withAuthorizationLock(async () => {
+      events.push("b-start");
+      await sleep(10);
+      events.push("b-end");
+    });
+    await Promise.all([a, b]);
+    assert.deepEqual(events, ["a-start", "a-end", "b-start", "b-end"]);
+  });
+
+  it("sync acquire during a SAME-PROCESS async hold fails fast (no event-loop starvation)", async () => {
+    const holder = withAuthorizationLock(async () => { await sleep(300); });
+    await sleep(20);
+    // Spinning here would starve the async holder on our own event loop —
+    // the design mandates an immediate, honest Busy error instead.
+    const t0 = Date.now();
+    assert.throws(
+      () => acquireAuthorizationLockSync({ acquireTimeoutMs: 5_000 }),
+      AuthorizationLockBusyError,
+    );
+    assert.ok(Date.now() - t0 < 200, "must fail fast, not wait out the timeout");
+    await holder;
+  });
+
+  it("sync acquire spins for a FOREIGN live holder and throws after the timeout", () => {
+    // Forge a fresh lock owned by another live process (our parent shell).
+    const lock = authorizationLockPath();
+    fs.mkdirSync(path.dirname(lock), { recursive: true });
+    fs.mkdirSync(lock, { mode: 0o700 });
+    fs.writeFileSync(path.join(lock, "owner"), JSON.stringify({ pid: process.ppid, acquiredAt: Date.now() }), { mode: 0o600 });
+    const t0 = Date.now();
+    assert.throws(
+      () => acquireAuthorizationLockSync({ acquireTimeoutMs: 150, pollMs: 25 }),
+      AuthorizationLockBusyError,
+    );
+    assert.ok(Date.now() - t0 >= 140, "must have spun until the deadline");
+    fs.rmSync(lock, { recursive: true, force: true });
+  });
+
+  it("takes over a lock whose owner pid is dead", async () => {
+    // Forge a lock owned by a dead pid.
+    const lock = authorizationLockPath();
+    fs.mkdirSync(path.dirname(lock), { recursive: true });
+    fs.mkdirSync(lock, { mode: 0o700 });
+    fs.writeFileSync(path.join(lock, "owner"), JSON.stringify({ pid: 999999999, acquiredAt: Date.now() }), { mode: 0o600 });
+    let ran = false;
+    await withAuthorizationLock(async () => { ran = true; }, { acquireTimeoutMs: 2_000 });
+    assert.equal(ran, true, "dead-owner lock must be taken over");
+  });
+
+  it("takes over a lock held beyond the staleness bound even if the pid is alive", async () => {
+    const lock = authorizationLockPath();
+    fs.mkdirSync(path.dirname(lock), { recursive: true });
+    fs.mkdirSync(lock, { mode: 0o700 });
+    // Owned by THIS live process but acquired far in the past.
+    fs.writeFileSync(path.join(lock, "owner"), JSON.stringify({ pid: process.pid, acquiredAt: Date.now() - 10 * 60_000 }), { mode: 0o600 });
+    let ran = false;
+    await withAuthorizationLock(async () => { ran = true; }, { acquireTimeoutMs: 2_000, staleMs: 60_000 });
+    assert.equal(ran, true, "stale-held lock must be taken over");
+  });
+});

--- a/packages/cli/test/review-coordinator.test.ts
+++ b/packages/cli/test/review-coordinator.test.ts
@@ -824,7 +824,16 @@ describe("ReviewCoordinator.retryInThread", () => {
 });
 
 describe("ReviewCoordinator.confirmApproveInThread", () => {
-  it("keeps an eligible protocol artifact review-only while the approval release veto is active", async () => {
+  /** Live gateway.json that revokes approval — currentConfig() prefers the file. */
+  function revokeApprovalOnDisk() {
+    saveGatewayConfig({
+      version: 1, admins: ["U1"], blocklist: [], audience: {}, escalation: {}, slack: {},
+      mraWorkspace: path.join(tmp, "ws"),
+      review: { enabled: true, approval: { enabled: false }, expectedGhUser: "expected-bot" },
+    } as never);
+  }
+
+  it("keeps an eligible protocol artifact review-only when approval was config-revoked after the offer (#90)", async () => {
     const web = new FakeWebClient();
     const calls: Array<Record<string, unknown>> = [];
     const gateway = gw({
@@ -838,17 +847,19 @@ describe("ReviewCoordinator.confirmApproveInThread", () => {
     await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: rootText });
     web.conversationsHistoryResponse = { ok: true, messages: [{ text: rootText }] };
 
+    // Admin revokes approval BETWEEN the offer and the confirmation.
+    revokeApprovalOnDisk();
     await c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
 
     assert.equal(calls.length, 1, "confirmation must reuse the SHA-bound artifact");
     assert.equal(calls[0]?.["allowApprove"], undefined, ":cr: remains analysis-only");
     const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
     assert.ok(allTexts.some((t) => /回覆 `approve`|授權 GitHub approve/.test(t)), ":cr: result should ask for explicit authorization");
-    assert.ok(allTexts.some((t) => /安全停用|不會執行 approve/.test(t)), "release veto must block the GitHub mutation");
+    assert.ok(allTexts.some((t) => /安全停用|不會執行 approve/.test(t)), "config-revoked approval must block the GitHub mutation");
     assert.ok(!allTexts.some((t) => /已真實 approve/.test(t)));
   });
 
-  it("does not consume the review artifact while approval is release-vetoed", async () => {
+  it("does not consume the review artifact while approval is config-revoked", async () => {
     const web = new FakeWebClient();
     let calls = 0;
     const gateway = gw({
@@ -861,13 +872,80 @@ describe("ReviewCoordinator.confirmApproveInThread", () => {
     const rootText = ":cr: https://github.com/onead/OnePixel/pull/12";
     await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: rootText });
     web.conversationsHistoryResponse = { ok: true, messages: [{ text: rootText }] };
+    revokeApprovalOnDisk();
     await c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
     assert.equal(calls, 1, "first confirmation reuses the earlier artifact");
 
     await c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
     assert.equal(calls, 1, "second confirmation for the same artifact is idempotent");
     const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
-    assert.ok(allTexts.filter((t) => /安全停用|不會執行 approve/.test(t)).length >= 2, "each confirmation must report the release veto");
+    assert.ok(allTexts.filter((t) => /安全停用|不會執行 approve/.test(t)).length >= 2, "each confirmation must report the revoked policy");
+  });
+
+  it("publishes a real approval end-to-end when policy allows (#90 veto lifted)", async () => {
+    const web = new FakeWebClient();
+    let approved = 0;
+    const gateway = gw({
+      runMraReview: async () => eligibleReviewResult(),
+      createPullRequestApproval: async (a: { commitId: string }) => {
+        approved++;
+        return { reviewId: 99, state: "APPROVED", commitId: a.commitId, actor: "expected-bot" };
+      },
+    } as unknown as Partial<ReviewGateway>);
+    const c = coord(web, gateway);
+    const rootText = ":cr: https://github.com/onead/OnePixel/pull/12";
+    await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: rootText });
+    web.conversationsHistoryResponse = { ok: true, messages: [{ text: rootText }] };
+
+    await c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+
+    assert.equal(approved, 1, "the gated confirmation must publish exactly one GitHub approval");
+    const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
+    assert.ok(allTexts.some((t) => /已真實 approve/.test(t)));
+
+    // The consumed offer must not be publishable twice.
+    await c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+    assert.equal(approved, 1, "a consumed offer must never approve again");
+  });
+
+  it("a config write during the approve critical section is refused, never interleaved (#90)", async () => {
+    const web = new FakeWebClient();
+    let approved = 0;
+    let writeError: Error | undefined;
+    const gateway = gw({
+      runMraReview: async () => eligibleReviewResult(),
+      // Slow preflight keeps the authorization lock held long enough for the
+      // concurrent write attempt below to land INSIDE the critical section.
+      getPrHead: async () => {
+        await new Promise((r) => setTimeout(r, 120));
+        return { sha: "headsha", baseRef: "main" };
+      },
+      createPullRequestApproval: async (a: { commitId: string }) => {
+        approved++;
+        return { reviewId: 99, state: "APPROVED", commitId: a.commitId, actor: "expected-bot" };
+      },
+    } as unknown as Partial<ReviewGateway>);
+    const c = coord(web, gateway);
+    const rootText = ":cr: https://github.com/onead/OnePixel/pull/12";
+    await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: rootText });
+    web.conversationsHistoryResponse = { ok: true, messages: [{ text: rootText }] };
+
+    const confirming = c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+    await new Promise((r) => setTimeout(r, 60)); // land inside the held section
+    try {
+      saveGatewayConfig({
+        version: 1, admins: ["U1"], blocklist: [], audience: {}, escalation: {}, slack: {},
+        mraWorkspace: path.join(tmp, "ws"),
+        review: { enabled: true, approval: { enabled: false }, expectedGhUser: "expected-bot" },
+      } as never);
+    } catch (err) {
+      writeError = err as Error;
+    }
+    await confirming;
+
+    assert.ok(writeError, "the write inside the critical section must be refused");
+    assert.equal(writeError?.name, "AuthorizationLockBusyError");
+    assert.equal(approved, 1, "the in-flight approve completes under the policy valid at its start");
   });
 });
 
@@ -957,19 +1035,22 @@ describe("ReviewCoordinator.fromApproveMessage (:a: approve flow)", () => {
 });
 
 describe("ReviewCoordinator exact-head approval offer", () => {
-  it("release veto takes precedence over exact-head approval preflight", async () => {
+  it("exact-head preflight rejects a stale offer without any GitHub mutation (#90 veto lifted)", async () => {
     const web = new FakeWebClient();
     let head = "head-1";
     let calls = 0;
+    let approved = 0;
     const c = coord(web, gw({
       getPrHead: async () => ({ sha: head, baseRef: "main" }),
       runMraReview: async () => { calls++; return eligibleReviewResult(head); },
+      createPullRequestApproval: async () => { approved++; return { reviewId: 99, state: "APPROVED", commitId: head, actor: "expected-bot" }; },
     } as unknown as Partial<ReviewGateway>));
     await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: ":cr: https://github.com/onead/OnePixel/pull/12" });
-    head = "head-2";
+    head = "head-2"; // PR moved after the review — the offer is now stale
     await c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
     assert.equal(calls, 1, "changed head must not reach the approval model pass");
-    assert.ok(web.posted.some((p) => /安全停用|不會執行 approve/.test(p.text ?? "")));
+    assert.equal(approved, 0, "a stale offer must never produce a GitHub approval");
+    assert.ok(web.posted.some((p) => /preflight 未通過|changed after review/.test(p.text ?? "")), "the rejection must be reported honestly");
   });
 });
 


### PR DESCRIPTION
## 動機
實作 PR #70 release veto 明文要求的前置:**config 寫入者與 approve POST 路徑共享一把跨進程授權鎖**,封死「最後一次 revision-fence 讀取與 GitHub mutation 之間」的 TOCTOU 殘窗。針對 #90(判準 1-3、5 完成;第 4 項 live 驗證留在 issue 追蹤,tag 前完成)。

## 做法
- **`gateway/authorization-lock.ts`** — mkdir-lock(與 approval-offer lock 同族):owner `{pid, acquiredAt}`、dead-pid + stale-hold takeover 用 **atomic rename-to-tombstone**(兩個競爭者不可能互刪對方剛建的新鎖);async 取鎖走進程內 FIFO chain;**sync 取鎖遇同進程 holder 立即 fail-fast**(自旋會餓死自己 event loop 上的 async holder),外部進程則短暫自旋等待
- **`saveGatewayConfig`** 每次寫入持鎖;`handleAdminSlash` 把 `AuthorizationLockBusyError` 轉成誠實的「:hourglass: approve 進行中,請稍後重試」
- **`publishApprovalReservation`** 的 authorize→preflight→POST 全程持鎖;三段 revision fence 保留作縱深
- **`AUTOMATIC_APPROVAL_RELEASE_READY` → `true`**;runtime gate = `review.approval.enabled`(預設 **false**,`/pmk admin review approval enable` 可開)

## 驗證
- **+9 測試,cli 1,020 全綠**,typecheck 乾淨:
  - 7 個 lock 測試:互斥、sync 同進程 fail-fast vs 外部自旋逾時、dead-pid / stale takeover、throw 時釋放
  - 3 個原 veto 測試改寫為 **config-revocation 語意**(offer 後撤銷 → 不 mutation、artifact 不消耗)
  - **2 個 #90 驗收測試**:端到端 gated approve(fake GitHub 收到恰好一次 approval、consumed offer 不能二次使用);**臨界區內的 config 寫入被拒**(AuthorizationLockBusyError)而 approve 完整完成
- 現有 exact-head preflight 測試升級:stale offer 在 veto 解除後真實驗證「零 GitHub mutation + 誠實回報」

## ⚠️ 尚未 live 驗證(#90 判準第 4 項)
真實端到端 `:a:` approve 需要:admin `approval enable` + 一個犧牲用 PR。**建議合併後、下次 tag 前完成**;在那之前 production 的 `review.approval.enabled` 保持 false,行為與現狀完全相同(:lock: 通知)。
