### PR TITLE
feat: per-repo approve protection exemption

### DIFF
--- a/docs/superpowers/plans/2026-07-17-approve-protection-exemption.md
+++ b/docs/superpowers/plans/2026-07-17-approve-protection-exemption.md
@@ -21,6 +21,7 @@
 - Slack copy is 繁體中文台灣用語; technical identifiers stay in English.
 - Commit message format: `<type>: <description>`. No attribution trailer (disabled globally).
 - Work on branch `feat/approve-protection-exemption` (already created, spec already committed as `5cb360b`).
+- **Line numbers are hints, not addresses.** Every `file.ts:NNN` in this plan was measured against the base commit `a997888` and goes stale the moment you edit above it — Task 1 Step 3 inserts ~18 lines into `config.ts` before Step 4 cites `config.ts:380-384`, and Tasks 3/4/6 each edit `review.ts` above later citations. **Locate every edit by the quoted surrounding code, not by the number.** If a cited line does not contain what the plan says it contains, you are in the right file at the wrong offset — search for the code.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-17-approve-protection-exemption.md
+++ b/docs/superpowers/plans/2026-07-17-approve-protection-exemption.md
@@ -1,0 +1,1077 @@
+# Approve Protection Exemption Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `:a:` approve succeed on repos whose branch ruleset lacks `dismiss_stale_reviews_on_push` + `require_last_push_approval`, via a per-repo, explicitly-reasoned exemption, with honest Slack disclosure and a real audit trail.
+
+**Architecture:** The branch-protection probe (`approvalProtectionReady`) is untouched and keeps running unconditionally — the exemption gates the *throw*, not the *check*. That keeps the probe result available so disclosure asserts only what was actually measured, and so an obsolete exemption is detected for free. Exemptions live in `review.approval.protectionExemptions`, are covered automatically by the existing revision fences (which serialise the whole `review` object), and each carries a mandatory `reason` that flows into Slack, the audit event, and doctor.
+
+**Tech Stack:** TypeScript, Node's built-in test runner (`node --import tsx --test`), `node:assert/strict`.
+
+**Spec:** `docs/superpowers/specs/2026-07-17-approve-protection-exemption-design.md`
+
+## Global Constraints
+
+- Test command (from `packages/cli/`): `npm test` — runs `npm run typecheck:test && node --import tsx --test test/*.test.ts`. Single file: `node --import tsx --test test/<name>.test.ts`. Single test: add `--test-name-pattern "<substring>"`.
+- Never mutate: build new objects/arrays (spread, `map`/`filter`), never modify in place.
+- No `console.log` in production code.
+- `approvalProtectionReady` in `packages/cli/src/adapters/github.ts` must not change. Its five existing tests (`test/github-review-helpers.test.ts:35,56,70,84,95`) must stay green and unmodified.
+- Exact slug matching only. No wildcards, no org-level exemptions.
+- Every dropped/invalid exemption entry must fail **safe**: no exemption means the probe is enforced and the approve is refused.
+- Slack copy is 繁體中文台灣用語; technical identifiers stay in English.
+- Commit message format: `<type>: <description>`. No attribution trailer (disabled globally).
+- Work on branch `feat/approve-protection-exemption` (already created, spec already committed as `5cb360b`).
+
+---
+
+### Task 1: Config shape + `findProtectionExemption`
+
+**Files:**
+- Modify: `packages/cli/src/gateway/config.ts:110-118` (types), `:375-384` (normalise), `:494-497` (resolve)
+- Modify: `packages/cli/src/gateway/review-policy.ts` (add the lookup)
+- Test: `packages/cli/test/review-config.test.ts` (extend), `packages/cli/test/review-protection-exemption.test.ts` (create)
+
+**Interfaces:**
+- Consumes: nothing (foundation task).
+- Produces:
+  - `ProtectionExemption { repo: string; reason: string }` — exported from `config.ts`
+  - `ApprovalConfig { enabled: boolean; protectionExemptions?: ProtectionExemption[] }` — exported from `config.ts`
+  - `ReviewConfig.approval: ApprovalConfig`
+  - `findProtectionExemption(approval: { protectionExemptions?: ProtectionExemption[] }, slug: string): ProtectionExemption | undefined` — exported from `review-policy.ts`
+  - `resolveReviewConfig()` always fills `approval.protectionExemptions` to at least `[]`
+
+**Why `protectionExemptions` is optional in the type:** `RawGatewayConfig.review` is `Partial<ReviewConfig>`, so `approval` must remain satisfiable by `{ enabled }` alone — several existing call sites construct it that way. `resolveReviewConfig` fills the default, mirroring how `repoAllowlist?: string[]` is already handled in this file.
+
+- [ ] **Step 1: Write the failing tests for `findProtectionExemption`**
+
+Create `packages/cli/test/review-protection-exemption.test.ts`:
+
+```ts
+// packages/cli/test/review-protection-exemption.test.ts
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { findProtectionExemption } from "../src/gateway/review-policy";
+
+const approval = {
+  enabled: true,
+  protectionExemptions: [
+    { repo: "onead/oss-ui-v2", reason: "ruleset 8015695 pending" },
+    { repo: "onead/other", reason: "second entry" },
+  ],
+};
+
+describe("findProtectionExemption", () => {
+  it("returns the matching entry with its reason", () => {
+    const found = findProtectionExemption(approval, "onead/oss-ui-v2");
+    assert.equal(found?.repo, "onead/oss-ui-v2");
+    assert.equal(found?.reason, "ruleset 8015695 pending");
+  });
+
+  it("returns undefined for a repo that is not listed", () => {
+    assert.equal(findProtectionExemption(approval, "onead/unlisted"), undefined);
+  });
+
+  it("never matches by wildcard or prefix — the blast radius stays exact", () => {
+    assert.equal(findProtectionExemption(approval, "onead/*"), undefined);
+    assert.equal(findProtectionExemption(approval, "onead/oss-ui-v2-fork"), undefined);
+    assert.equal(findProtectionExemption(approval, "onead"), undefined);
+    const wild = { enabled: true, protectionExemptions: [{ repo: "onead/*", reason: "nope" }] };
+    assert.equal(findProtectionExemption(wild, "onead/oss-ui-v2"), undefined);
+  });
+
+  it("tolerates an approval block with no exemptions at all", () => {
+    assert.equal(findProtectionExemption({ enabled: true }, "onead/oss-ui-v2"), undefined);
+    assert.equal(findProtectionExemption({ enabled: true, protectionExemptions: [] }, "onead/oss-ui-v2"), undefined);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run (from `packages/cli/`): `node --import tsx --test test/review-protection-exemption.test.ts`
+Expected: FAIL — `findProtectionExemption` is not exported from `review-policy.ts`.
+
+- [ ] **Step 3: Add the types to `config.ts`**
+
+Replace the `ReviewConfig` opening at `config.ts:110-112`:
+
+```ts
+/**
+ * A deliberate, reasoned waiver of the branch-protection approve preflight
+ * for one repo. Exact `owner/repo` only — no wildcards, because the whole
+ * point of an exemption is a blast radius someone had to type out in full.
+ */
+export interface ProtectionExemption {
+  repo: string;
+  /** Why the waiver exists. Required; entries without one are dropped at load. */
+  reason: string;
+}
+
+export interface ApprovalConfig {
+  enabled: boolean;
+  /**
+   * Optional on the raw/partial side so `{ enabled }` alone still satisfies
+   * `Partial<ReviewConfig>`; `resolveReviewConfig` always fills it to `[]`.
+   */
+  protectionExemptions?: ProtectionExemption[];
+}
+
+export interface ReviewConfig {
+  enabled: boolean;
+  approval: ApprovalConfig;
+```
+
+Leave `allowPublicRepos` and everything after it exactly as-is.
+
+- [ ] **Step 4: Add the normaliser to `config.ts`**
+
+Insert this helper immediately above `normaliseReviewConfig` (before `config.ts:375`):
+
+```ts
+/**
+ * Keep only well-formed exemptions. A dropped entry fails safe: no exemption
+ * means the branch-protection preflight is enforced and the approve is
+ * refused. `doctor` reports the drop count so a typo is not silent.
+ */
+function asProtectionExemptions(raw: unknown[]): ProtectionExemption[] {
+  return raw
+    .filter((item): item is Record<string, unknown> => !!item && typeof item === "object")
+    .map((e) => ({
+      repo: typeof e.repo === "string" ? e.repo.trim() : "",
+      reason: typeof e.reason === "string" ? e.reason.trim() : "",
+    }))
+    .filter((e) => e.repo !== "" && e.reason !== "");
+}
+```
+
+Then replace `config.ts:380-384` (the `if (o.approval …)` block) with:
+
+```ts
+  if (o.approval && typeof o.approval === "object") {
+    const approval = o.approval as Record<string, unknown>;
+    const normalised: ApprovalConfig = {
+      enabled: typeof approval.enabled === "boolean" ? approval.enabled : false,
+    };
+    if (Array.isArray(approval.protectionExemptions))
+      normalised.protectionExemptions = asProtectionExemptions(approval.protectionExemptions);
+    out.approval = normalised;
+  }
+```
+
+- [ ] **Step 5: Fill the default in `resolveReviewConfig`**
+
+Replace `config.ts:497`:
+
+```ts
+    approval: {
+      enabled: raw?.approval?.enabled ?? false,
+      protectionExemptions: raw?.approval?.protectionExemptions ?? [],
+    },
+```
+
+- [ ] **Step 6: Add `findProtectionExemption` to `review-policy.ts`**
+
+Add to the top of `packages/cli/src/gateway/review-policy.ts` (after the existing `mra` import):
+
+```ts
+import type { ProtectionExemption } from "./config";
+```
+
+And append:
+
+```ts
+/**
+ * The per-repo waiver of the branch-protection preflight, or undefined.
+ *
+ * Returns the entry rather than a boolean so callers get `reason` for the
+ * Slack disclosure and the audit record. Exact slug match only: a stored
+ * `onead/*` is a literal repo name that matches nothing, by design.
+ */
+export function findProtectionExemption(
+  approval: { protectionExemptions?: ProtectionExemption[] },
+  slug: string,
+): ProtectionExemption | undefined {
+  return approval.protectionExemptions?.find((e) => e.repo === slug);
+}
+```
+
+`config.ts` does not import `review-policy.ts`, so this type-only import creates no cycle.
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `node --import tsx --test test/review-protection-exemption.test.ts`
+Expected: PASS — 4 tests.
+
+- [ ] **Step 8: Write the failing config-validation tests**
+
+Append to `packages/cli/test/review-config.test.ts` (inside the existing top-level `describe`; match the file's existing import of `resolveReviewConfig` from `../src/gateway/config`):
+
+```ts
+  it("defaults protectionExemptions to an empty array", () => {
+    assert.deepEqual(resolveReviewConfig({}).approval.protectionExemptions, []);
+    assert.deepEqual(resolveReviewConfig({ approval: { enabled: true } }).approval.protectionExemptions, []);
+  });
+
+  it("keeps well-formed protectionExemptions and trims them", () => {
+    const c = resolveReviewConfig({
+      approval: { enabled: true, protectionExemptions: [{ repo: "  onead/oss-ui-v2 ", reason: " ruleset pending " }] },
+    });
+    assert.deepEqual(c.approval.protectionExemptions, [{ repo: "onead/oss-ui-v2", reason: "ruleset pending" }]);
+  });
+```
+
+- [ ] **Step 9: Write the failing drop-behaviour tests**
+
+Append to the same file. These pin the fail-safe direction:
+
+```ts
+  it("drops exemptions that lack a non-empty reason — the waiver must be justified", () => {
+    const c = resolveReviewConfig({
+      approval: {
+        enabled: true,
+        protectionExemptions: [
+          { repo: "onead/a" } as never,
+          { repo: "onead/b", reason: "" } as never,
+          { repo: "onead/c", reason: "   " } as never,
+          { repo: "onead/d", reason: 42 } as never,
+        ],
+      },
+    });
+    assert.deepEqual(c.approval.protectionExemptions, [], "an unjustified waiver must never take effect");
+  });
+
+  it("drops malformed entries but keeps valid siblings and the surrounding config", () => {
+    const c = resolveReviewConfig({
+      enabled: true,
+      approval: {
+        enabled: true,
+        protectionExemptions: [
+          null as never,
+          "onead/string-form" as never,
+          { reason: "no repo" } as never,
+          { repo: "onead/good", reason: "kept" },
+        ],
+      },
+    });
+    assert.deepEqual(c.approval.protectionExemptions, [{ repo: "onead/good", reason: "kept" }]);
+    assert.equal(c.enabled, true, "one bad exemption must not take the config down");
+    assert.equal(c.approval.enabled, true);
+  });
+```
+
+- [ ] **Step 10: Run the config tests to verify they pass**
+
+Run: `node --import tsx --test test/review-config.test.ts`
+Expected: PASS — the four new tests plus every pre-existing test in the file.
+
+- [ ] **Step 11: Typecheck and run the full suite**
+
+Run: `npm test`
+Expected: PASS. If `normaliseReviewConfig`'s `out.approval` assignment errors, confirm Step 3 declared `protectionExemptions` as **optional** (`?:`) on `ApprovalConfig`.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add packages/cli/src/gateway/config.ts packages/cli/src/gateway/review-policy.ts \
+        packages/cli/test/review-config.test.ts packages/cli/test/review-protection-exemption.test.ts
+git commit -m "feat: add per-repo approve protection exemption config
+
+Exemptions carry a mandatory reason; malformed entries are dropped
+individually and fail safe (no exemption = probe enforced = approve
+refused). findProtectionExemption returns the entry, not a boolean, so
+callers can surface the reason."
+```
+
+---
+
+### Task 2: Fix the admin clobber (regression guard for Task 1)
+
+**Files:**
+- Modify: `packages/cli/src/gateway/slack/admin-review.ts:34`, `:79`, `:84`
+- Test: `packages/cli/test/admin-review.test.ts` (create — confirmed absent; `gateway-admin-doctor.test.ts` covers `handleAdminSlash`, not `adminReview`)
+
+**Interfaces:**
+- Consumes: `ApprovalConfig.protectionExemptions` from Task 1.
+- Produces: nothing new — behavioural fix only.
+
+**Why this task exists:** not in the original design. `admin-review.ts:79` replaces the entire `approval` object, so once exemptions live inside it, any `/pmk admin review approval enable|disable` silently wipes them. The only symptom would be approve failing the probe again with a config file that looks hand-edited. Fix it before anything depends on the exemption surviving.
+
+- [ ] **Step 1: Create the test file**
+
+`admin-review.test.ts` does not exist (only `gateway-admin-doctor.test.ts`, which drives `handleAdminSlash`). Create it:
+
+```ts
+// packages/cli/test/admin-review.test.ts
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import * as os from "node:os";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { adminReview } from "../src/gateway/slack/admin-review";
+import { loadRawGatewayConfig, saveGatewayConfig } from "../src/gateway/config";
+
+const ORIG_HOME = process.env.HOME; // gatewayDir() is HOME-based
+let tmp: string;
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-ar-")); process.env.HOME = tmp; });
+afterEach(() => { if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME; fs.rmSync(tmp, { recursive: true, force: true }); });
+```
+
+- [ ] **Step 2: Write the failing clobber test**
+
+```ts
+describe("adminReview approval toggle", () => {
+  it("preserves protectionExemptions across an enable/disable cycle", () => {
+    saveGatewayConfig({
+      version: 1, admins: ["U1"], blocklist: [], slack: {},
+      review: {
+        enabled: true,
+        approval: {
+          enabled: true,
+          protectionExemptions: [{ repo: "onead/oss-ui-v2", reason: "ruleset 8015695 pending" }],
+        },
+      },
+    } as never);
+
+    adminReview("U1", ["approval", "disable"]);
+    adminReview("U1", ["approval", "enable"]);
+
+    const after = loadRawGatewayConfig();
+    assert.deepEqual(
+      after.review?.approval?.protectionExemptions,
+      [{ repo: "onead/oss-ui-v2", reason: "ruleset 8015695 pending" }],
+      "toggling the approval gate must not silently wipe the exemptions",
+    );
+    assert.equal(after.review?.approval?.enabled, true);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `node --import tsx --test test/admin-review.test.ts --test-name-pattern "preserves protectionExemptions"`
+Expected: FAIL — `protectionExemptions` is `undefined` after the cycle, because `:79` replaced the object.
+
+- [ ] **Step 4: Fix the clobber**
+
+Replace `admin-review.ts:79`:
+
+```ts
+      // Merge, never replace: `approval` also holds protectionExemptions, and
+      // a bare `{ enabled }` would silently wipe them on every toggle.
+      cfg.review = {
+        ...(cfg.review ?? {}),
+        approval: { ...(cfg.review?.approval ?? {}), enabled },
+      };
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `node --import tsx --test test/admin-review.test.ts --test-name-pattern "preserves protectionExemptions"`
+Expected: PASS.
+
+- [ ] **Step 6: Fix the two copy strings that now overstate the guarantee**
+
+Replace `admin-review.ts:34`:
+
+```ts
+    `• automatic approval: \`${review.approval.enabled}\` (PMK admin confirmation required; branch protection required unless the repo is exempt)`,
+    `• protection exemptions: ${review.approval.protectionExemptions?.length ? review.approval.protectionExemptions.map((e) => `\`${e.repo}\``).join(", ") : "`none`"}`,
+```
+
+Replace the `enabled` arm of `admin-review.ts:84`:
+
+```ts
+          ? ":warning: automatic approval enabled; each repo must still pass protocol, identity, head-SHA, and allowlist checks, plus branch-protection readiness unless it is listed in `review.approval.protectionExemptions`"
+```
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `npm test`
+Expected: PASS. If an existing `reviewStatusText` snapshot/substring test breaks on the `:34` change, update that assertion to match the new copy — the copy change is intentional.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/cli/src/gateway/slack/admin-review.ts packages/cli/test/admin-review.test.ts
+git commit -m "fix: stop the admin approval toggle from wiping protectionExemptions
+
+/pmk admin review approval enable|disable replaced the whole approval
+object, so every toggle silently dropped the exemptions. Merge instead,
+and stop claiming branch protection is unconditionally required."
+```
+
+---
+
+### Task 3: Exempt the preflight throw (core behaviour change) + policy comment
+
+**Files:**
+- Modify: `packages/cli/src/gateway/slack/review.ts:573-574` (the preflight), `:609-610` (success reply)
+- Modify: `packages/cli/src/gateway/review-policy.ts:3-10` (comment only)
+- Test: `packages/cli/test/review-coordinator.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `findProtectionExemption` (Task 1), `ReviewConfig.approval.protectionExemptions` (Task 1).
+- Produces: `exemptionInEffect: boolean` and `exemption: ProtectionExemption | undefined` as locals inside `publishApprovalReservation`, consumed by Task 4 (audit event). The success-reply text is finalised here; Task 4 only adds the event.
+
+**The one idea that matters:** the probe still runs on every approve. The exemption gates the `throw`, not the check. Skipping the probe would (a) make §3's disclosure assert a fact never measured, and (b) throw away the obsolete-exemption signal. There is no added cost — today's code already probes unconditionally.
+
+- [ ] **Step 1: Write the failing test — exempt repo approves through an unprotected branch**
+
+Append inside the existing `describe("ReviewCoordinator.confirmApproveInThread", …)` block in `packages/cli/test/review-coordinator.test.ts`. Note `coord()`'s 4th parameter is `reviewOverrides`, merged into `config.review`:
+
+```ts
+  it("approves an exempt repo whose branch protection is not ready", async () => {
+    const web = new FakeWebClient();
+    let approved = 0;
+    const gateway = gw({
+      approvalProtectionReady: async () => false,
+      resolveRepoSlug: async () => "onead/oss-ui-v2",
+      runMraReview: async () => eligibleReviewResult(),
+      createPullRequestApproval: async (a: { commitId: string }) => {
+        approved++;
+        return { reviewId: 99, state: "APPROVED", commitId: a.commitId, actor: "expected-bot" };
+      },
+    } as unknown as Partial<ReviewGateway>);
+    const c = coord(web, gateway, () => {}, {
+      approval: {
+        enabled: true,
+        protectionExemptions: [{ repo: "onead/oss-ui-v2", reason: "ruleset 8015695 pending" }],
+      },
+    });
+    const rootText = ":cr: https://github.com/onead/oss-ui-v2/pull/301";
+    await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: rootText });
+    web.conversationsHistoryResponse = { ok: true, messages: [{ text: rootText }] };
+
+    await c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+
+    assert.equal(approved, 1, "an exempt repo must approve despite an unready probe");
+    const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
+    assert.ok(allTexts.some((t) => /已真實 approve/.test(t)));
+    assert.ok(
+      allTexts.some((t) => /不會讓這個 approval 失效/.test(t)),
+      "the accepted risk must be disclosed at the moment it goes live",
+    );
+    assert.ok(allTexts.some((t) => /ruleset 8015695 pending/.test(t)), "the reason must be surfaced");
+  });
+```
+
+- [ ] **Step 2: Write the failing test — a non-exempt repo still refuses**
+
+```ts
+  it("still refuses a non-exempt repo whose branch protection is not ready", async () => {
+    const web = new FakeWebClient();
+    let approved = 0;
+    const gateway = gw({
+      approvalProtectionReady: async () => false,
+      runMraReview: async () => eligibleReviewResult(),
+      createPullRequestApproval: async () => { approved++; throw new Error("must not be called"); },
+    } as unknown as Partial<ReviewGateway>);
+    const c = coord(web, gateway, () => {}, {
+      approval: {
+        enabled: true,
+        protectionExemptions: [{ repo: "onead/some-other-repo", reason: "unrelated" }],
+      },
+    });
+    const rootText = ":cr: https://github.com/onead/OnePixel/pull/12";
+    await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: rootText });
+    web.conversationsHistoryResponse = { ok: true, messages: [{ text: rootText }] };
+
+    await c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+
+    assert.equal(approved, 0, "an exemption for another repo must never leak across repos");
+    const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
+    assert.ok(allTexts.some((t) => /protection is not approval-ready/.test(t)));
+  });
+```
+
+- [ ] **Step 3: Write the failing test — exempt but actually protected reports the exemption obsolete**
+
+```ts
+  it("reports an exempt repo's waiver as obsolete once its branch is genuinely protected", async () => {
+    const web = new FakeWebClient();
+    let approved = 0;
+    const gateway = gw({
+      approvalProtectionReady: async () => true, // onead fixed the ruleset
+      resolveRepoSlug: async () => "onead/oss-ui-v2",
+      runMraReview: async () => eligibleReviewResult(),
+      createPullRequestApproval: async (a: { commitId: string }) => {
+        approved++;
+        return { reviewId: 99, state: "APPROVED", commitId: a.commitId, actor: "expected-bot" };
+      },
+    } as unknown as Partial<ReviewGateway>);
+    const c = coord(web, gateway, () => {}, {
+      approval: {
+        enabled: true,
+        protectionExemptions: [{ repo: "onead/oss-ui-v2", reason: "ruleset 8015695 pending" }],
+      },
+    });
+    const rootText = ":cr: https://github.com/onead/oss-ui-v2/pull/301";
+    await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: rootText });
+    web.conversationsHistoryResponse = { ok: true, messages: [{ text: rootText }] };
+
+    await c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+
+    assert.equal(approved, 1);
+    const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
+    assert.ok(allTexts.some((t) => /豁免已不再需要/.test(t)), "an obsolete waiver must announce itself");
+    assert.ok(
+      !allTexts.some((t) => /不會讓這個 approval 失效/.test(t)),
+      "a protected branch must never carry the unprotected warning",
+    );
+  });
+```
+
+- [ ] **Step 4: Write the failing test — an exemption cannot be injected mid-approve**
+
+This pins the property the architecture claims for free. Note what is actually being tested: the **authorization lock** refuses any `saveGatewayConfig` that lands inside the critical section, whatever field it touches — the three revision fences are defence-in-depth behind it and cannot be triggered in isolation through the public API. Model this on the existing lock test (`review-coordinator.test.ts:940-978`), which proves the same for `approval.enabled`:
+
+```ts
+  it("refuses a protectionExemptions write that lands inside the approve critical section", async () => {
+    const web = new FakeWebClient();
+    let approved = 0;
+    let writeError: Error | undefined;
+    const gateway = gw({
+      approvalProtectionReady: async () => true,
+      runMraReview: async () => eligibleReviewResult(),
+      // Slow preflight holds the authorization lock long enough for the
+      // concurrent write below to land inside the critical section.
+      getPrHead: async () => {
+        await new Promise((r) => setTimeout(r, 120));
+        return { sha: "headsha", baseRef: "main" };
+      },
+      createPullRequestApproval: async (a: { commitId: string }) => {
+        approved++;
+        return { reviewId: 99, state: "APPROVED", commitId: a.commitId, actor: "expected-bot" };
+      },
+    } as unknown as Partial<ReviewGateway>);
+    const c = coord(web, gateway);
+    const rootText = ":cr: https://github.com/onead/OnePixel/pull/12";
+    await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: rootText });
+    web.conversationsHistoryResponse = { ok: true, messages: [{ text: rootText }] };
+
+    const confirming = c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+    await new Promise((r) => setTimeout(r, 60)); // land inside the held section
+    try {
+      saveGatewayConfig({
+        version: 1, admins: ["U1"], blocklist: [], audience: {}, escalation: {}, slack: {},
+        mraWorkspace: path.join(tmp, "ws"),
+        review: {
+          enabled: true, expectedGhUser: "expected-bot",
+          approval: {
+            enabled: true,
+            protectionExemptions: [{ repo: "onead/OnePixel", reason: "injected mid-approve" }],
+          },
+        },
+      } as never);
+    } catch (err) {
+      writeError = err as Error;
+    }
+    await confirming;
+
+    assert.ok(writeError, "an exemption must not be injectable mid-approve");
+    assert.equal(writeError?.name, "AuthorizationLockBusyError");
+    assert.equal(approved, 1, "the in-flight approve completes under the policy valid at its start");
+  });
+```
+
+- [ ] **Step 5: Run the four tests to verify they fail**
+
+Run: `node --import tsx --test test/review-coordinator.test.ts --test-name-pattern "exempt"`
+Expected: FAIL — the first throws `repository protection is not approval-ready`; the third finds no `豁免已不再需要`. (The Step 4 lock test may already pass: the lock is field-agnostic and pre-existing. That is the point — it documents the property rather than adding it.)
+
+- [ ] **Step 6: Import the lookup in `review.ts`**
+
+Change `review.ts:49`:
+
+```ts
+import { AUTOMATIC_APPROVAL_RELEASE_READY, effectiveMraReviewStrategy, findProtectionExemption } from "../review-policy";
+```
+
+- [ ] **Step 7: Replace the preflight at `review.ts:573-574`**
+
+```ts
+        // The probe still runs on every approve; the exemption gates the THROW,
+        // not the check. Keeping the measurement means the disclosure below
+        // asserts only what we actually observed, and an obsolete waiver
+        // announces itself. approvalProtectionReady never throws (false on
+        // error), so a network blip degrades to "still unprotected".
+        const exemption = findProtectionExemption(review.approval, slug);
+        const protectionReady = await gateway.approvalProtectionReady({ slug, branch: ref.baseRef, token });
+        if (!protectionReady && !exemption)
+          throw new Error("repository protection is not approval-ready");
+        const exemptionInEffect = !protectionReady && !!exemption;
+```
+
+- [ ] **Step 8: Replace the success reply at `review.ts:609-610`**
+
+```ts
+        const approvedLine = `:white_check_mark: 已真實 approve ${slug}#${ref.number}（commit \`${ref.headSha.slice(0, 7)}\`，GitHub review #${posted.reviewId}）。`;
+        const riskLine = exemptionInEffect
+          ? `\n:warning: 此 repo 未啟用 dismiss-stale/require-last-push：後續新 push 不會讓這個 approval 失效，可能被用來 merge 未經 review 的 commit。豁免理由：${exemption!.reason}`
+          : "";
+        const obsoleteLine = protectionReady && exemption
+          ? `\n:information_source: ${slug} 的 protection 豁免已不再需要（branch 現已同時啟用 dismiss-stale 與 require-last-push），可以從 config 移除。`
+          : "";
+        await this.reply(reservation.channelId, reservation.threadTs, `${approvedLine}${riskLine}${obsoleteLine}`);
+```
+
+- [ ] **Step 9: Run the tests to verify they pass**
+
+Run: `node --import tsx --test test/review-coordinator.test.ts`
+Expected: PASS — the three new tests plus every pre-existing test, including "publishes a real approval end-to-end when policy allows (#90 veto lifted)" (its `gw()` default `approvalProtectionReady: async () => true` and empty exemption list keep it on the unchanged path).
+
+- [ ] **Step 10: Amend the policy comment**
+
+Replace `packages/cli/src/gateway/review-policy.ts:7-9` (the tail of the veto comment). The comment must not claim a guarantee the code no longer makes unconditionally:
+
+```ts
+// GitHub APPROVE additionally requires the runtime gate
+// `review.approval.enabled` (admin-togglable, default false) plus the
+// per-approve preflights (identity, head-SHA, protection, revision fences).
+// The protection preflight is waivable per-repo via
+// `review.approval.protectionExemptions` — a deliberate, reasoned risk
+// acceptance for repos whose ruleset lacks dismiss-stale/require-last-push.
+// See docs/superpowers/specs/2026-07-17-approve-protection-exemption-design.md.
+```
+
+- [ ] **Step 11: Run the full suite**
+
+Run: `npm test`
+Expected: PASS.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add packages/cli/src/gateway/slack/review.ts packages/cli/src/gateway/review-policy.ts \
+        packages/cli/test/review-coordinator.test.ts
+git commit -m "feat: waive the approve protection preflight for exempt repos
+
+The probe still runs on every approve -- the exemption gates the throw,
+not the check -- so the Slack disclosure asserts only what was actually
+measured, and a waiver that has outlived its ruleset says so."
+```
+
+---
+
+### Task 4: `review.approved` audit event
+
+**Files:**
+- Modify: `packages/cli/src/gateway/events.ts` (add the interface, extend the union)
+- Modify: `packages/cli/src/gateway/slack/review.ts` (emit inside `publishApprovalReservation`)
+- Test: `packages/cli/test/review-coordinator.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `exemptionInEffect`, `protectionReady`, `exemption`, `posted.reviewId` — all locals established by Task 3 inside `publishApprovalReservation`.
+- Produces: `ReviewApprovedEvent` exported from `events.ts` and added to the `GatewayEvent` union.
+
+**Why this task exists:** `publishApprovalReservation` (`review.ts:537-625`) currently emits **zero** gateway events. Real GitHub approvals leave no trace outside the Slack thread — the log only has `review.triggered`, `review.skipped`, `review.posted`. Approving under a knowingly-accepted risk with no audit record is indefensible, so the risk flag rides on the event.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `describe("ReviewCoordinator.confirmApproveInThread", …)` in `packages/cli/test/review-coordinator.test.ts`. `HOME` is already redirected to `tmp` by the file's `beforeEach`, so events land under the temp dir:
+
+```ts
+  it("records every real approval in the audit log, flagging the accepted risk", async () => {
+    const { readGatewayEvents } = await import("../src/gateway/events");
+    const web = new FakeWebClient();
+    const gateway = gw({
+      approvalProtectionReady: async () => false,
+      resolveRepoSlug: async () => "onead/oss-ui-v2",
+      runMraReview: async () => eligibleReviewResult(),
+      createPullRequestApproval: async (a: { commitId: string }) =>
+        ({ reviewId: 4242, state: "APPROVED", commitId: a.commitId, actor: "expected-bot" }),
+    } as unknown as Partial<ReviewGateway>);
+    const c = coord(web, gateway, () => {}, {
+      approval: {
+        enabled: true,
+        protectionExemptions: [{ repo: "onead/oss-ui-v2", reason: "ruleset 8015695 pending" }],
+      },
+    });
+    const rootText = ":cr: https://github.com/onead/oss-ui-v2/pull/301";
+    await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: rootText });
+    web.conversationsHistoryResponse = { ok: true, messages: [{ text: rootText }] };
+
+    await c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+
+    const approvals = readGatewayEvents().filter((e) => e.type === "review.approved");
+    assert.equal(approvals.length, 1, "a real GitHub approval must never be unaudited");
+    const ev = approvals[0] as never as { actor: string; repo: string; pr: number; reviewId: number; protectionExempt: boolean };
+    assert.equal(ev.actor, "U1");
+    assert.equal(ev.repo, "onead/oss-ui-v2");
+    assert.equal(ev.pr, 301);
+    assert.equal(ev.reviewId, 4242);
+    assert.equal(ev.protectionExempt, true, "the accepted risk must be on the record");
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `node --import tsx --test test/review-coordinator.test.ts --test-name-pattern "audit log"`
+Expected: FAIL — `approvals.length` is `0`.
+
+- [ ] **Step 3: Add the event interface to `events.ts`**
+
+Insert immediately after `ReviewPostedEvent` (`events.ts:228`):
+
+```ts
+/**
+ * A real GitHub APPROVE published by the gateway. Distinct from
+ * `review.posted` (which covers COMMENT/REQUEST_CHANGES review bodies):
+ * this is the mutation that can unblock a merge, so it is audited on its
+ * own. `protectionExempt` records whether the approve rode a per-repo
+ * waiver of the branch-protection preflight — i.e. whether GitHub will
+ * dismiss it when new commits land.
+ */
+export interface ReviewApprovedEvent {
+  type: "review.approved";
+  actor: string;
+  repo: string;      // owner/repo slug
+  pr: number;
+  commit: string;    // the exact head SHA that was approved
+  reviewId: number;
+  protectionExempt: boolean;
+  /** The waiver's recorded justification, when one was in effect. */
+  exemptionReason?: string;
+}
+```
+
+Then add to the `GatewayEvent` union (`events.ts:288`, after `ReviewPostedEvent`):
+
+```ts
+  | ReviewApprovedEvent
+```
+
+- [ ] **Step 4: Emit the event in `review.ts`**
+
+In `publishApprovalReservation`, insert between the post-POST staleness check and the `this.reply(...)` added by Task 3 — i.e. after `if (!after || after.sha !== ref.headSha) throw …` and before `const approvedLine = …`:
+
+```ts
+        appendGatewayEvent({
+          type: "review.approved",
+          actor: actorUserId,
+          repo: slug,
+          pr: ref.number,
+          commit: ref.headSha,
+          reviewId: posted.reviewId,
+          protectionExempt: exemptionInEffect,
+          exemptionReason: exemptionInEffect ? exemption!.reason : undefined,
+        });
+```
+
+`appendGatewayEvent` is already imported at `review.ts:30`.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `node --import tsx --test test/review-coordinator.test.ts --test-name-pattern "audit log"`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `npm test`
+Expected: PASS. A `GatewayEvent` union exhaustiveness error in an audit/reader switch means that consumer needs a `review.approved` arm — add one that counts it alongside `review.posted`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cli/src/gateway/events.ts packages/cli/src/gateway/slack/review.ts \
+        packages/cli/test/review-coordinator.test.ts
+git commit -m "feat: audit real GitHub approvals as review.approved
+
+publishApprovalReservation emitted no events at all, so approves existed
+only in the Slack thread. The event carries protectionExempt, putting the
+accepted risk on the record rather than in a chat scrollback."
+```
+
+---
+
+### Task 5: Doctor reports exemptions and dropped entries
+
+**Files:**
+- Modify: `packages/cli/src/gateway/doctor-checks/review.ts`
+- Test: `packages/cli/test/gateway-doctor.test.ts` (extend — the review checks already live there at `:679-687`; there is no `doctor-review.test.ts`)
+
+**Interfaces:**
+- Consumes: `ReviewConfig.approval.protectionExemptions` (Task 1), `DoctorContext.configPath`.
+- Produces: nothing consumed downstream — reporting only.
+
+**Design constraint (do not violate):** this check documents itself as "Presence/config only — no live gh call (kept fast like github-token)", and `doctor.ts:6` states "checks themselves stay testable without network access" (network is injected via `DoctorRunners`). Doctor must **not** probe branch protection. Stale-exemption detection already lives on the approve path (Task 3), which probes anyway.
+
+**Why the raw re-read:** `normaliseReviewConfig` discards malformed entries without a trace, so the resolved config cannot reveal a drop. Doctor re-reads the on-disk JSON and compares counts. Without this, a typo in `repo` silently degrades to "no exemption" and the only symptom is an approve that keeps failing the probe.
+
+- [ ] **Step 1: Write the failing tests**
+
+The tests live in `packages/cli/test/gateway-doctor.test.ts` — there is no `doctor-review.test.ts`. The existing harness (`:679-687`) just casts a bare object, so build the `DoctorContext` the same way. Append after the `describe("doctor — review readiness check", …)` block. Ensure `fs`, `os`, `path` are imported at the top of the file; add them if not.
+
+**Do not assert `severity`.** With `review.enabled: true` the check calls the real `findMraBinary()` / `findGhBinary()`, so severity is `fail` wherever `mra`/`gh` are off PATH. Assert on `message`, which is deterministic.
+
+```ts
+describe("doctor — review protection exemptions", () => {
+  it("lists protection exemptions so a standing waiver stays visible", async () => {
+    const { reviewDoctorCheck } = await import("../src/gateway/doctor-checks/review");
+    const res = await reviewDoctorCheck({
+      configPath: "/nonexistent/gateway.json", // droppedExemptionCount must tolerate this
+      config: {
+        review: {
+          enabled: true,
+          approval: {
+            enabled: true,
+            protectionExemptions: [{ repo: "onead/oss-ui-v2", reason: "ruleset 8015695 pending" }],
+          },
+        },
+      },
+    } as never);
+    assert.match(res.message, /protection exemptions active/i);
+    assert.match(res.message, /onead\/oss-ui-v2/);
+    assert.match(res.message, /ruleset 8015695 pending/, "the recorded justification must be visible");
+    assert.match(res.message, /exemptions=1/);
+  });
+
+  it("reports a malformed exemption that normalisation silently dropped", async () => {
+    const { reviewDoctorCheck } = await import("../src/gateway/doctor-checks/review");
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-doc-"));
+    const configPath = path.join(dir, "gateway.json");
+    // Two entries on disk; the second lacks `reason` and is dropped at load.
+    fs.writeFileSync(configPath, JSON.stringify({
+      review: {
+        approval: {
+          protectionExemptions: [
+            { repo: "onead/oss-ui-v2", reason: "kept" },
+            { repo: "onead/typo" },
+          ],
+        },
+      },
+    }));
+    try {
+      const res = await reviewDoctorCheck({
+        configPath,
+        config: {
+          review: {
+            enabled: true,
+            approval: { enabled: true, protectionExemptions: [{ repo: "onead/oss-ui-v2", reason: "kept" }] },
+          },
+        },
+      } as never);
+      assert.match(res.message, /1 protectionExemption entry dropped/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports no exemptions and no drops for a config that has none", async () => {
+    const { reviewDoctorCheck } = await import("../src/gateway/doctor-checks/review");
+    const res = await reviewDoctorCheck({
+      configPath: "/nonexistent/gateway.json",
+      config: { review: { enabled: true, approval: { enabled: true } } },
+    } as never);
+    assert.match(res.message, /exemptions=0/);
+    assert.ok(!/dropped/.test(res.message));
+    assert.ok(!/protection exemptions active/i.test(res.message));
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `node --import tsx --test test/gateway-doctor.test.ts --test-name-pattern "exemption"`
+Expected: FAIL — the message has no exemption text.
+
+- [ ] **Step 3: Add the raw drop-count helper to `doctor-checks/review.ts`**
+
+```ts
+/**
+ * Count exemption entries that normalisation threw away. The resolved
+ * config keeps no record of a drop, so the raw file is the only source —
+ * and a silently-dropped waiver presents as "approve keeps failing the
+ * probe" with a config that looks correct to the eye.
+ */
+function droppedExemptionCount(configPath: string, keptCount: number): number {
+  try {
+    const raw = JSON.parse(fs.readFileSync(configPath, "utf8")) as
+      { review?: { approval?: { protectionExemptions?: unknown } } };
+    const listed = raw.review?.approval?.protectionExemptions;
+    if (!Array.isArray(listed)) return 0;
+    return Math.max(0, listed.length - keptCount);
+  } catch {
+    return 0; // unreadable/absent config is another check's problem
+  }
+}
+```
+
+Add `import * as fs from "node:fs";` at the top of the file.
+
+- [ ] **Step 4: Wire it into the check**
+
+After the existing `warnings` block and before `detail` is built:
+
+```ts
+  const exemptions = review.approval.protectionExemptions ?? [];
+  if (exemptions.length) {
+    warnings.push(
+      `protection exemptions active: ${exemptions.map((e) => `${e.repo} (${e.reason})`).join("; ")} — approve on these repos skips branch-protection readiness`,
+    );
+  }
+  const dropped = droppedExemptionCount(ctx.configPath, exemptions.length);
+  if (dropped > 0) {
+    warnings.push(
+      `${dropped} protectionExemption entr${dropped === 1 ? "y" : "ies"} dropped (each needs a non-empty repo and reason)`,
+    );
+  }
+```
+
+Then extend `detail` (`review.ts:43`) by appending:
+
+```ts
+`; exemptions=${exemptions.length}`
+```
+
+- [ ] **Step 5: Run to verify they pass**
+
+Run: `node --import tsx --test test/gateway-doctor.test.ts --test-name-pattern "exemption"`
+Expected: PASS — 3 tests.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `npm test`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cli/src/gateway/doctor-checks/review.ts packages/cli/test/gateway-doctor.test.ts
+git commit -m "feat: surface protection exemptions and dropped entries in doctor
+
+Config-only, honouring the check's no-live-gh-call constraint. Drop
+counting needs the raw file: normalisation discards malformed entries
+without a trace, so a typo would otherwise be invisible."
+```
+
+---
+
+### Task 6: Offer-message note (spec §3, offer half)
+
+**Files:**
+- Modify: `packages/cli/src/gateway/slack/review-messages.ts:28-37`
+- Modify: `packages/cli/src/gateway/slack/review.ts:1006` (pass the new argument)
+- Test: `packages/cli/test/review-coordinator.test.ts` (extend — `reviewResultText` is re-exported from `review.ts` and already imported there at `:8`)
+
+**Interfaces:**
+- Consumes: `findProtectionExemption` (Task 1).
+- Produces: `reviewResultText(slug, ref, res, approvalEnabled?, protectionExempted?)` — a fifth optional parameter, defaulting `false`.
+
+**The honesty rule this task exists to obey:** the offer line is emitted on the `:cr:` path, which **never probes**. So it must state the *config* fact ("this repo is on the exemption list") and never the *branch* fact ("this branch is unprotected") — the latter is unmeasured there. Only the approve path (Task 3), which probes, may assert the branch fact. Do not add a probe here: that would put a network call on every review just to decorate a message.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside the existing `describe("review/approve result text (pure)", …)` block at `packages/cli/test/review-coordinator.test.ts:1169`. It already declares a shared `ref` fixture and imports `reviewResultText` and `eligibleReviewResult` — reuse all three rather than redeclaring. `slug` is a separate parameter from `ref`, so the shared fixture works for any repo name:
+
+```ts
+  it("reviewResultText notes the exemption as a config fact, never a branch claim", () => {
+    const t = reviewResultText("onead/oss-ui-v2", ref, eligibleReviewResult() as never, true, true);
+    assert.match(t, /已列入 protection 豁免清單/);
+    assert.doesNotMatch(
+      t,
+      /未啟用 dismiss-stale/,
+      ":cr: never probes, so the offer line has no standing to describe the branch",
+    );
+  });
+
+  it("reviewResultText leaves the offer line untouched for a non-exempt repo", () => {
+    const t = reviewResultText("onead/OnePixel", ref, eligibleReviewResult() as never, true, false);
+    assert.doesNotMatch(t, /豁免/);
+    assert.match(t, /可進一步 approve/);
+  });
+
+  it("reviewResultText never mentions the exemption when approval is disabled", () => {
+    const t = reviewResultText("onead/oss-ui-v2", ref, eligibleReviewResult() as never, false, true);
+    assert.doesNotMatch(t, /豁免/, "the no-approve line must not advertise a waiver it cannot use");
+    assert.match(t, /未執行 GitHub approve/);
+  });
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `node --import tsx --test test/review-coordinator.test.ts --test-name-pattern "reviewResultText"`
+Expected: FAIL — no `已列入 protection 豁免清單` in the output.
+
+- [ ] **Step 3: Add the parameter in `review-messages.ts`**
+
+Replace `reviewResultText` (`review-messages.ts:27-37`):
+
+```ts
+/**
+ * Result line for a plain `:cr:` review. It never claims GitHub approval.
+ *
+ * `protectionExempted` is a CONFIG fact (the repo is on the exemption list),
+ * not a branch fact. The `:cr:` path never probes branch protection, so this
+ * line must not assert anything about dismiss-stale / require-last-push —
+ * only the approve path, which probes, may do that.
+ */
+export function reviewResultText(
+  slug: string,
+  ref: PrRef,
+  res: ReviewOutcome,
+  approvalEnabled = true,
+  protectionExempted = false,
+): string {
+  if (res.incomplete)
+    return `:warning: ${slug}#${ref.number} review 未完成（mra 回報 REVIEW_INCOMPLETE，未真正評估此 PR — 可能 max-turns 截斷或 provider 呼叫失敗）；已貼中性佔位，claim 已釋放，請重試 :cr:：${ref.url}`;
+  const status = res.status ?? "COMMENT";
+  const count = res.commentCount ?? 0;
+  if (approvalEnabled && canConfirmApproveFromReview(res)) {
+    const exemptNote = protectionExempted
+      ? "（此 repo 已列入 protection 豁免清單，approve 時會略過 branch-protection 檢查）"
+      : "";
+    return `:mag: 已完成 ${slug}#${ref.number} review（GitHub action: ${status}；${count} 則）。這個結果沒有 HIGH/CRITICAL blocker，可進一步 approve，但 :cr: 不會主動 approve；請由 PMK admin 在此 channel thread @PMK 回覆 \`approve\` 授權（DM 可直接回覆）${exemptNote}：${ref.url}`;
+  }
+  return `:mag: 已完成 ${slug}#${ref.number} review（GitHub action: ${status}；${count} 則；未執行 GitHub approve）：${ref.url}`;
+}
+```
+
+- [ ] **Step 4: Pass it at the call site**
+
+Replace `review.ts:1004-1006`:
+
+```ts
+      const resultText = isApprove
+        ? approveResultText(slug, ref, res)
+        : reviewResultText(slug, ref, res, ctx.review.approval.enabled,
+            !!findProtectionExemption(ctx.review.approval, slug));
+```
+
+`findProtectionExemption` is already imported into `review.ts` by Task 3 Step 6.
+
+- [ ] **Step 5: Run to verify they pass**
+
+Run: `node --import tsx --test test/review-coordinator.test.ts`
+Expected: PASS — the two new tests plus every pre-existing `reviewResultText` test (the new parameter defaults to `false`, so the old three- and four-argument calls are unaffected).
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `npm test`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cli/src/gateway/slack/review-messages.ts packages/cli/src/gateway/slack/review.ts \
+        packages/cli/test/review-coordinator.test.ts
+git commit -m "feat: note the protection exemption on the :cr: offer line
+
+Stated as a config fact, not a branch claim: :cr: never probes, so it has
+no standing to say whether dismiss-stale is on. Only the approve path,
+which probes, asserts that."
+```
+
+---
+
+## Rollout (do NOT fold into the tasks above)
+
+Only after every task is green and the branch is merged. This is a deliberate, separate act — it is the moment the risk goes live.
+
+1. Edit `~/.pmk/gateway.json`: set `review.approval.enabled` to `true` and add the `onead/oss-ui-v2` exemption with its reason.
+2. Restart: `launchctl kickstart -k gui/$(id -u)/com.pmk.gateway`
+3. `pmk gateway doctor` — expect the review check to `warn` and name `onead/oss-ui-v2`.
+4. Live-verify on an **open** PR in `onead/oss-ui-v2`. `#299` is closed and cannot serve.
+   Expect: `:cr:` → offer → thread `approve` → real APPROVE + the `:warning:` disclosure.
+5. Confirm the audit record: `pmk gateway audit` (or read `~/.pmk/events-2026-07.log`) shows
+   `review.approved` with `protectionExempt: true`.

--- a/docs/superpowers/specs/2026-07-17-approve-protection-exemption-design.md
+++ b/docs/superpowers/specs/2026-07-17-approve-protection-exemption-design.md
@@ -1,0 +1,220 @@
+# Approve protection exemption (per-repo)
+
+**Date:** 2026-07-17
+**Status:** Approved, pending implementation
+**Amends:** `2026-07-03-review-approve-progress-design.md` (#90 approve), `packages/cli/src/gateway/review-policy.ts:3-10`
+
+## Problem
+
+`:a:` approve shipped in v0.32.0 and was live-verified against a real GitHub approve. It
+does not work on the repo it was built for. On `onead/oss-ui-v2` — the real workload — every
+`:cr:` review ends with:
+
+```
+:mag: 已完成 onead/oss-ui-v2#299 review（GitHub action: COMMENTED；0 則；未執行 GitHub approve）
+```
+
+That line is not a review verdict. It is `review-messages.ts:36`, the fallback branch, taken
+unconditionally because `~/.pmk/gateway.json` has `review.approval.enabled: false`. A perfect
+zero-blocker review prints the same string.
+
+Turning the flag on is not sufficient. The approve preflight at `review.ts:573` calls
+`approvalProtectionReady`, which requires the target branch to have **both**
+`dismiss_stale_reviews_on_push` and `require_last_push_approval` enabled. Verified state of
+`onead/oss-ui-v2` `main` (ruleset `8015695`) on 2026-07-17:
+
+| Setting | Actual | Probe requires |
+| --- | --- | --- |
+| `dismiss_stale_reviews_on_push` | `false` | `true` |
+| `require_last_push_approval` | `false` | `true` |
+| `required_approving_review_count` | `1` | — |
+
+The pinned review identity `HanfourHuangOneAD` has `push: true` but `admin: false` on that
+repo, so it cannot change the ruleset. With the flag on, `:a:` → thread `approve` would fail
+at the probe with `:no_entry: approve preflight 未通過…repository protection is not approval-ready`.
+
+The blocker is org-side policy, not gateway code.
+
+## Decision
+
+Add a **per-repo, explicitly-reasoned exemption** to the branch-protection preflight, paired
+with honest disclosure in Slack and a real audit trail. The `:cr:`/`:a:` two-step UX does not
+change.
+
+### Rejected alternatives
+
+- **Ask onead admin to enable the two controls.** Correct and safest; the probe would pass
+  legitimately with zero code change. Rejected as the *primary* path because it is outside the
+  owner's control (`admin: false`), has an unknown timeline, and changes the whole team's
+  workflow (every push would dismiss existing approvals). Still the right long-term end state.
+- **Gateway self-enforces dismiss-stale semantics.** After approving, watch the PR head and
+  auto-dismiss its own approval when a push lands. Closes the hole without org action, but
+  reimplements branch protection in userspace: gateway downtime or a missed poll is an open
+  window, and the failure mode is silent.
+- **Auto-approve on zero blockers, or collapse `:a:` to one step.** Considered and declined.
+  The two-step exists so that the admin authorizes *after* seeing the review result. Keeping it
+  means the exemption changes the safety envelope only, not who decides.
+
+## Risk accepted
+
+Stated plainly, because this weakens one of the four preflights that `review-policy.ts:3-10`
+cites as justification for lifting the release veto:
+
+> On an exempt repo, PMK's approval satisfies `required_approving_review_count: 1`. Because
+> `dismiss_stale_reviews_on_push` is `false`, a push landing **after** the approval does not
+> invalidate it. Code that PMK never reviewed can therefore be merged on the strength of PMK's
+> approval of an earlier commit.
+
+This is not a race. It is a durable hole, and it is a realistic accident (author pushes "one
+more fix" after approval, then merges), not only an insider attack.
+
+**Context that makes it acceptable:** the identical hole already applies to every *human*
+approval on that repo, because `dismiss_stale_reviews_on_push: false` is repo-wide. The probe
+was holding PMK to a stricter standard than the repo holds its own engineers. The exemption
+removes that asymmetry; it does not introduce a new class of risk.
+
+**What still bounds the approve, unchanged:**
+
+- `review.approval.enabled` runtime gate, admin-only, default `false`
+- Admin identity check, blocklist, `repoAllowlist`
+- A prior `:cr:` review producing a zero-blocker offer with a protocol-v1 artifact
+- An explicit `approve` reply in-thread by an admin
+- GitHub identity pinned to `expectedGhUser`
+- Head SHA + baseRef pinned before the POST and re-verified after it
+- Three revision fences and the cross-process authorization lock
+
+The gateway will still never approve a commit that moved *during* the operation. The residual
+hole is strictly what happens *after* a successful approve.
+
+**What does not bound it:** nothing prevents a later push from riding the approval. That is the
+accepted hole, and the reason disclosure and audit logging are part of this design rather than
+nice-to-haves.
+
+## Design
+
+### 1. Config shape
+
+```json
+"review": {
+  "approval": {
+    "enabled": true,
+    "protectionExemptions": [
+      { "repo": "onead/oss-ui-v2",
+        "reason": "ruleset 8015695 未開 dismiss_stale/require_last_push；admin 調整前的過渡豁免" }
+    ]
+  }
+}
+```
+
+An array of objects rather than `string[]`, with **`reason` required**. The requirement is the
+mechanism, not ceremony: it forces whoever adds a repo to record why, and the string is carried
+into the Slack disclosure, the audit event, and `doctor`.
+
+**Invalid-entry handling (explicit):** an entry that is not an object, or lacks a non-empty
+string `repo`, or lacks a non-empty string `reason`, is **dropped individually**. The rest of
+the config loads normally; the gateway does not refuse to start. Dropping is the fail-safe
+direction — a dropped exemption means the probe is enforced and the approve is refused, which is
+the current behaviour. It also matches the existing permissive pattern at `config.ts:380-383`.
+Because a typo would otherwise present as a silent "why isn't approve working", `doctor` reports
+dropped entries (see §5).
+
+Touch points: type at `config.ts:112`, validation at `config.ts:380-383`, resolution at
+`config.ts:497` (default `[]`).
+
+### 2. Exemption applies at the call site, not inside the probe
+
+`approvalProtectionReady` (`github.ts:221`) is **unchanged**. It continues to answer truthfully
+whether the branch is protected. The exemption is policy layered on top of that fact:
+
+```ts
+const exempt = isProtectionExempt(review.approval, slug);
+if (!exempt && !await gateway.approvalProtectionReady({ slug, branch: ref.baseRef, token }))
+  throw new Error("repository protection is not approval-ready");
+```
+
+Two consequences worth naming:
+
+- The probe's existing tests stay meaningful and untouched — the five that exercise
+  `approvalProtectionReady` directly (`github-review-helpers.test.ts:35,56,70,84,95`) still
+  assert real protection behaviour, including the `#90` Rules-API-first ordering.
+- `policyRevision` (`review.ts:559`) already serialises the whole `review` object, so
+  `protectionExemptions` is **automatically covered by the three revision fences** — an
+  exemption cannot be introduced mid-approve. This falls out of the existing design for free.
+
+`isProtectionExempt` is a pure function: exact slug match, no wildcards.
+
+### 3. Disclosure
+
+Two places. The offer message (`review-messages.ts:34`) gains a note. The load-bearing one is
+the approve success message (`review.ts:610`), because that is the moment the risk goes live:
+
+```
+:white_check_mark: 已真實 approve onead/oss-ui-v2#301（commit `9236381`，GitHub review #12345）。
+:warning: 此 repo 未啟用 dismiss-stale/require-last-push：後續新 push 不會讓這個 approval 失效，
+   可能被用來 merge 未經 review 的 commit。豁免理由：ruleset 8015695 未開…
+```
+
+### 4. Audit event (new — closes an existing gap)
+
+`publishApprovalReservation` (`review.ts:537-625`) currently emits **no** gateway events at all.
+Real GitHub approvals leave no trace outside the Slack thread; the event log only has
+`review.triggered`, `review.skipped`, `review.posted`. Approving under an accepted risk without
+an audit record is not defensible, so:
+
+```ts
+appendGatewayEvent({
+  type: "review.approved",
+  actor: actorUserId, repo: slug, pr: ref.number,
+  commit: ref.headSha, reviewId: posted.reviewId,
+  protectionExempt: exempt,
+});
+```
+
+### 5. Doctor
+
+`doctor-checks/review.ts` already reports approval state. Extend it to:
+
+- List exempt repos with their reasons.
+- **Probe each exempt repo live.** If the branch now satisfies both controls, report that the
+  exemption is no longer needed and can be removed. This prevents an exemption from silently
+  outliving its justification — the main way a transitional risk acceptance becomes permanent.
+- **Report dropped entries** (§1). Without this, a typo in `repo` or a missing `reason` silently
+  degrades to "no exemption", and the only symptom is an approve that keeps failing the probe.
+
+### 6. Policy comment
+
+`review-policy.ts:3-10` lists `protection` among the preflights justifying the lifted veto.
+Amend it to say the protection preflight is exemptible per-repo and point here. The code comment
+must not overstate the guarantee.
+
+## Testing
+
+`github-review-helpers.test.ts` is untouched (12 tests, five of which exercise the probe
+directly). New coverage:
+
+- `isProtectionExempt`: exact slug match; non-listed repo not exempt; no wildcard behaviour
+  (`onead/*` and `onead/oss-ui-v2-fork` must not match an `onead/oss-ui-v2` entry)
+- Config validation: entry with missing/empty/whitespace `reason` dropped; entry with missing
+  `repo` dropped; non-object entry dropped; a valid entry alongside an invalid one survives;
+  the surrounding config still loads; default `[]`
+- Coordinator: exempt repo approves even with `approvalProtectionReady: async () => false`;
+  non-exempt repo still throws `repository protection is not approval-ready`
+- Fence: an exemption added mid-approve is rejected by the revision fence
+- Disclosure: offer and success text include the warning and reason when exempt; unchanged when not
+- Event: `review.approved` emitted with correct `protectionExempt` on both exempt and non-exempt paths
+
+## Out of scope
+
+- Wildcard or org-level exemptions (`onead/*`) — precisely the blast radius a risk exemption
+  must not have
+- Any change to `approvalProtectionReady`'s own logic
+- Auto-approve on zero blockers; collapsing the `:a:` two-step
+- Pursuing the onead ruleset change (worth doing, tracked separately; the doctor hint in §5 is
+  the cheap detector for when it lands)
+
+## Rollout
+
+Code first, tests green. Then the ops step, as a separate deliberate action: flip
+`review.approval.enabled` to `true` in `~/.pmk/gateway.json` and add the `onead/oss-ui-v2`
+exemption. Note `#299` is already closed and cannot serve as a live test; live verification
+needs an open PR on that repo.

--- a/docs/superpowers/specs/2026-07-17-approve-protection-exemption-design.md
+++ b/docs/superpowers/specs/2026-07-17-approve-protection-exemption-design.md
@@ -124,13 +124,35 @@ Touch points: type at `config.ts:112`, validation at `config.ts:380-383`, resolu
 ### 2. Exemption applies at the call site, not inside the probe
 
 `approvalProtectionReady` (`github.ts:221`) is **unchanged**. It continues to answer truthfully
-whether the branch is protected. The exemption is policy layered on top of that fact:
+whether the branch is protected. The exemption is policy layered on top of that fact.
+
+The probe runs **unconditionally** — the exemption gates the *throw*, not the *check*:
 
 ```ts
-const exempt = isProtectionExempt(review.approval, slug);
-if (!exempt && !await gateway.approvalProtectionReady({ slug, branch: ref.baseRef, token }))
+const exemption = findProtectionExemption(review.approval, slug);
+const protectionReady = await gateway.approvalProtectionReady({ slug, branch: ref.baseRef, token });
+if (!protectionReady && !exemption)
   throw new Error("repository protection is not approval-ready");
+// The exemption is only *in effect* when the branch really is unprotected.
+const exemptionInEffect = !protectionReady && !!exemption;
 ```
+
+Probing even when exempt is not optional, for two reasons:
+
+- **The disclosure would otherwise be a lie.** §3's warning asserts the branch lacks the two
+  controls. Skipping the probe means asserting a fact we never checked; once onead fixes the
+  ruleset the gateway would keep printing a false warning forever.
+- **It is the stale-exemption detector.** `protectionReady && exemption` means the exemption is
+  obsolete and can be deleted — reported in Slack at the one moment anyone cares (see §5).
+
+There is no added cost: today's code already probes on every approve, so the probe count is
+unchanged. `approvalProtectionReady` returns `false` on error and never throws, so a network
+failure degrades to "still unprotected" rather than breaking the approve.
+
+`findProtectionExemption(approval, slug): ProtectionExemption | undefined` is a pure function —
+exact slug match, no wildcards. It returns the entry rather than a boolean so callers get
+`reason` for the disclosure and audit record. (The spec's earlier `isProtectionExempt` name is
+retired: a boolean cannot carry the reason.)
 
 Two consequences worth naming:
 
@@ -145,8 +167,21 @@ Two consequences worth naming:
 
 ### 3. Disclosure
 
-Two places. The offer message (`review-messages.ts:34`) gains a note. The load-bearing one is
-the approve success message (`review.ts:610`), because that is the moment the risk goes live:
+Each message asserts only what its own code path actually knows. This distinction is
+load-bearing, not pedantry — it is the difference between a warning that stays true and one that
+rots into a lie the day onead fixes the ruleset.
+
+**Offer message** (`review-messages.ts:34`, emitted on the `:cr:` path, which never probes):
+states the *config* fact only, because that is all it has measured. No probe is added — that
+would put a network call on every review to serve a message.
+
+```
+（此 repo 已列入 protection 豁免清單，approve 時會略過 branch-protection 檢查）
+```
+
+**Approve success message** (`review.ts:610`): states the *branch* fact, gated on
+`exemptionInEffect` from §2, which is derived from a real probe. This is the load-bearing one —
+it is the moment the risk goes live:
 
 ```
 :white_check_mark: 已真實 approve onead/oss-ui-v2#301（commit `9236381`，GitHub review #12345）。
@@ -172,16 +207,51 @@ appendGatewayEvent({
 
 ### 5. Doctor
 
-`doctor-checks/review.ts` already reports approval state. Extend it to:
+`doctor-checks/review.ts` documents itself as "Presence/config only — no live gh call (kept fast
+like github-token)", and network access in doctor is injected via `DoctorRunners` precisely so
+"checks themselves stay testable without network access" (`doctor.ts:6`). An earlier draft of
+this spec had doctor probe each exempt repo live; that would have broken both constraints and
+required new runner plumbing. It is **dropped**. Doctor stays config-only:
 
 - List exempt repos with their reasons.
-- **Probe each exempt repo live.** If the branch now satisfies both controls, report that the
-  exemption is no longer needed and can be removed. This prevents an exemption from silently
-  outliving its justification — the main way a transitional risk acceptance becomes permanent.
 - **Report dropped entries** (§1). Without this, a typo in `repo` or a missing `reason` silently
   degrades to "no exemption", and the only symptom is an approve that keeps failing the probe.
+  Doctor detects drops by re-reading the raw `gateway.json` and comparing the entry count with
+  the resolved config's, since normalisation discards malformed entries without a trace.
 
-### 6. Policy comment
+**Stale-exemption detection moves to the approve path** (§2), which already probes. When
+`protectionReady && exemption`, the approve replies:
+
+```
+:information_source: onead/oss-ui-v2 的 protection 豁免已不再需要
+   （branch 現已同時啟用 dismiss-stale 與 require-last-push），可以從 config 移除。
+```
+
+This fires at the one moment anyone cares about the exemption, needs no new doctor surface, and
+costs nothing extra.
+
+### 6. Admin clobber bug (found during planning — not in the original design)
+
+`admin-review.ts:79` currently does:
+
+```ts
+cfg.review = { ...(cfg.review ?? {}), approval: { enabled } };
+```
+
+This **replaces the whole `approval` object**. Once `protectionExemptions` lives inside it, any
+`/pmk admin review approval enable|disable` silently wipes every exemption — and the only
+symptom is approve mysteriously failing the probe again, with the config file looking like
+someone deleted the exemptions by hand. It must become a merge:
+
+```ts
+cfg.review = { ...(cfg.review ?? {}), approval: { ...(cfg.review?.approval ?? {}), enabled } };
+```
+
+Two copy strings in the same file also overstate the guarantee once exemptions exist and must be
+amended: `:34` ("PMK admin confirmation + protected repo required") and `:84` ("each repo must
+still pass … branch-protection readiness checks").
+
+### 7. Policy comment
 
 `review-policy.ts:3-10` lists `protection` among the preflights justifying the lifted veto.
 Amend it to say the protection preflight is exemptible per-repo and point here. The code comment
@@ -192,16 +262,26 @@ must not overstate the guarantee.
 `github-review-helpers.test.ts` is untouched (12 tests, five of which exercise the probe
 directly). New coverage:
 
-- `isProtectionExempt`: exact slug match; non-listed repo not exempt; no wildcard behaviour
-  (`onead/*` and `onead/oss-ui-v2-fork` must not match an `onead/oss-ui-v2` entry)
+- `findProtectionExemption`: exact slug match returns the entry with its `reason`; non-listed
+  repo returns `undefined`; no wildcard behaviour (`onead/*` and `onead/oss-ui-v2-fork` must not
+  match an `onead/oss-ui-v2` entry); tolerates an absent `protectionExemptions`
 - Config validation: entry with missing/empty/whitespace `reason` dropped; entry with missing
   `repo` dropped; non-object entry dropped; a valid entry alongside an invalid one survives;
   the surrounding config still loads; default `[]`
-- Coordinator: exempt repo approves even with `approvalProtectionReady: async () => false`;
-  non-exempt repo still throws `repository protection is not approval-ready`
-- Fence: an exemption added mid-approve is rejected by the revision fence
-- Disclosure: offer and success text include the warning and reason when exempt; unchanged when not
-- Event: `review.approved` emitted with correct `protectionExempt` on both exempt and non-exempt paths
+- Coordinator: exempt repo approves when `approvalProtectionReady: async () => false`;
+  non-exempt repo still throws `repository protection is not approval-ready`; an exempt repo
+  whose probe returns `true` approves **without** the warning and reports the exemption obsolete
+- Lock: a `protectionExemptions` write landing inside the approve critical section is refused
+  (`AuthorizationLockBusyError`), so a waiver cannot be injected mid-approve. Note what this
+  does and does not prove: the **authorization lock** is the mechanism, and it is field-agnostic.
+  The three revision fences sit behind it as defence-in-depth and cannot be triggered in
+  isolation through the public API — an earlier draft of this spec claimed a "fence rejects the
+  exemption" test that is not actually writable.
+- Disclosure: offer and success text carry the warning and reason only when `exemptionInEffect`
+- Event: `review.approved` emitted with correct `protectionExempt` on exempt, non-exempt, and
+  exempt-but-protected paths
+- Admin (§6): `/pmk admin review approval enable` then `disable` preserves `protectionExemptions`
+  — the regression test for the clobber
 
 ## Out of scope
 

--- a/packages/cli/src/gateway/config.ts
+++ b/packages/cli/src/gateway/config.ts
@@ -390,8 +390,16 @@ function normaliseRawConfig(raw: unknown): RawGatewayConfig {
  * Keep only well-formed exemptions. A dropped entry fails safe: no exemption
  * means the branch-protection preflight is enforced and the approve is
  * refused. `doctor` reports the drop count so a typo is not silent.
+ *
+ * `raw` is `unknown`, not `unknown[]`: this is the single choke point for
+ * BOTH element- and container-level sanitising. A non-array truthy value
+ * (a bare string, a plain object, a number) must fail safe to `[]` here
+ * rather than throwing — pushing that guard onto callers means every call
+ * site has to remember it, and resolve is a public entry point whose
+ * sanitising must not depend on which path built the input.
  */
-function asProtectionExemptions(raw: unknown[]): ProtectionExemption[] {
+function asProtectionExemptions(raw: unknown): ProtectionExemption[] {
+  if (!Array.isArray(raw)) return [];
   return raw
     .filter((item): item is Record<string, unknown> => !!item && typeof item === "object")
     .map((e) => ({
@@ -538,9 +546,10 @@ export function resolveReviewConfig(raw?: Partial<ReviewConfig>): ReviewConfig {
       // Re-sanitize even though normaliseReviewConfig already did: resolve
       // is a public entry point callers can reach directly (as these tests
       // do), and an unjustified waiver must never take effect regardless of
-      // which path constructed `raw`. asProtectionExemptions is idempotent,
-      // so this is a no-op for the already-clean load-from-disk path.
-      protectionExemptions: asProtectionExemptions(raw?.approval?.protectionExemptions ?? []),
+      // which path constructed `raw`. asProtectionExemptions now guards its
+      // own container (non-array → []), so this is a no-op for the
+      // already-clean load-from-disk path and safe for any raw input.
+      protectionExemptions: asProtectionExemptions(raw?.approval?.protectionExemptions),
     },
     allowPublicRepos: raw?.allowPublicRepos ?? false,
     repoAllowlist: raw?.repoAllowlist,

--- a/packages/cli/src/gateway/config.ts
+++ b/packages/cli/src/gateway/config.ts
@@ -107,9 +107,29 @@ export interface ResolvedAudioConfig {
   globalMonthlyMinutes?: number;
 }
 
+/**
+ * A deliberate, reasoned waiver of the branch-protection approve preflight
+ * for one repo. Exact `owner/repo` only — no wildcards, because the whole
+ * point of an exemption is a blast radius someone had to type out in full.
+ */
+export interface ProtectionExemption {
+  repo: string;
+  /** Why the waiver exists. Required; entries without one are dropped at load. */
+  reason: string;
+}
+
+export interface ApprovalConfig {
+  enabled: boolean;
+  /**
+   * Optional on the raw/partial side so `{ enabled }` alone still satisfies
+   * `Partial<ReviewConfig>`; `resolveReviewConfig` always fills it to `[]`.
+   */
+  protectionExemptions?: ProtectionExemption[];
+}
+
 export interface ReviewConfig {
   enabled: boolean;
-  approval: { enabled: boolean };
+  approval: ApprovalConfig;
   allowPublicRepos: boolean;
   repoAllowlist?: string[];          // e.g. ["onead/OnePixel"]; undefined = any private repo in workspace
   maxPrsPerTrigger: number;
@@ -367,6 +387,21 @@ function normaliseRawConfig(raw: unknown): RawGatewayConfig {
 }
 
 /**
+ * Keep only well-formed exemptions. A dropped entry fails safe: no exemption
+ * means the branch-protection preflight is enforced and the approve is
+ * refused. `doctor` reports the drop count so a typo is not silent.
+ */
+function asProtectionExemptions(raw: unknown[]): ProtectionExemption[] {
+  return raw
+    .filter((item): item is Record<string, unknown> => !!item && typeof item === "object")
+    .map((e) => ({
+      repo: typeof e.repo === "string" ? e.repo.trim() : "",
+      reason: typeof e.reason === "string" ? e.reason.trim() : "",
+    }))
+    .filter((e) => e.repo !== "" && e.reason !== "");
+}
+
+/**
  * Extract the known fields of a raw `review` config block into a typed
  * Partial<ReviewConfig>. Returns undefined when absent/not-an-object.
  * Lenient on value sanity (resolveReviewConfig clamps/guards downstream);
@@ -379,8 +414,12 @@ function normaliseReviewConfig(raw: unknown): Partial<ReviewConfig> | undefined 
   if (typeof o.enabled === "boolean") out.enabled = o.enabled;
   if (o.approval && typeof o.approval === "object") {
     const approval = o.approval as Record<string, unknown>;
-    if (typeof approval.enabled === "boolean")
-      out.approval = { enabled: approval.enabled };
+    const normalised: ApprovalConfig = {
+      enabled: typeof approval.enabled === "boolean" ? approval.enabled : false,
+    };
+    if (Array.isArray(approval.protectionExemptions))
+      normalised.protectionExemptions = asProtectionExemptions(approval.protectionExemptions);
+    out.approval = normalised;
   }
   if (typeof o.allowPublicRepos === "boolean")
     out.allowPublicRepos = o.allowPublicRepos;
@@ -494,7 +533,15 @@ export function resolveGithubToken(
 export function resolveReviewConfig(raw?: Partial<ReviewConfig>): ReviewConfig {
   return {
     enabled: raw?.enabled ?? false,
-    approval: { enabled: raw?.approval?.enabled ?? false },
+    approval: {
+      enabled: raw?.approval?.enabled ?? false,
+      // Re-sanitize even though normaliseReviewConfig already did: resolve
+      // is a public entry point callers can reach directly (as these tests
+      // do), and an unjustified waiver must never take effect regardless of
+      // which path constructed `raw`. asProtectionExemptions is idempotent,
+      // so this is a no-op for the already-clean load-from-disk path.
+      protectionExemptions: asProtectionExemptions(raw?.approval?.protectionExemptions ?? []),
+    },
     allowPublicRepos: raw?.allowPublicRepos ?? false,
     repoAllowlist: raw?.repoAllowlist,
     maxPrsPerTrigger: Math.max(1, raw?.maxPrsPerTrigger ?? 5),

--- a/packages/cli/src/gateway/doctor-checks/review.ts
+++ b/packages/cli/src/gateway/doctor-checks/review.ts
@@ -1,7 +1,27 @@
+import * as fs from "node:fs";
+
 import type { DoctorCheck, DoctorCheckResult } from "../doctor";
 import { resolveReviewConfig } from "../config";
 import { findMraBinary, mraIntegrationCapabilities, mraSupportsReviewProvider } from "../../adapters/mra";
 import { findGhBinary } from "../../adapters/github";
+
+/**
+ * Count exemption entries that normalisation threw away. The resolved
+ * config keeps no record of a drop, so the raw file is the only source —
+ * and a silently-dropped waiver presents as "approve keeps failing the
+ * probe" with a config that looks correct to the eye.
+ */
+function droppedExemptionCount(configPath: string, keptCount: number): number {
+  try {
+    const raw = JSON.parse(fs.readFileSync(configPath, "utf8")) as
+      { review?: { approval?: { protectionExemptions?: unknown } } };
+    const listed = raw.review?.approval?.protectionExemptions;
+    if (!Array.isArray(listed)) return 0;
+    return Math.max(0, listed.length - keptCount);
+  } catch {
+    return 0; // unreadable/absent config is another check's problem
+  }
+}
 
 /**
  * review check for the :cr: PR-review flow. PASS when review is disabled
@@ -40,7 +60,20 @@ export const reviewDoctorCheck: DoctorCheck = async (
   }
   if (!protocol) warnings.push("legacy MRA bridge is review-only; structured completion and approval are unavailable");
 
-  const detail = `mra=${mraPresent ? "found" : "missing"}; protocol=${protocol ? "v1" : "legacy/unavailable"}; gh=${ghPresent ? "found" : "missing"}; provider=${review.providerMode}; strategy=${review.strategy}; approval=${review.approval.enabled ? "enabled" : "disabled"}`;
+  const exemptions = review.approval.protectionExemptions ?? [];
+  if (exemptions.length) {
+    warnings.push(
+      `protection exemptions active: ${exemptions.map((e) => `${e.repo} (${e.reason})`).join("; ")} — approve on these repos skips branch-protection readiness`,
+    );
+  }
+  const dropped = droppedExemptionCount(ctx.configPath, exemptions.length);
+  if (dropped > 0) {
+    warnings.push(
+      `${dropped} protectionExemption entr${dropped === 1 ? "y" : "ies"} dropped (each needs a non-empty repo and reason)`,
+    );
+  }
+
+  const detail = `mra=${mraPresent ? "found" : "missing"}; protocol=${protocol ? "v1" : "legacy/unavailable"}; gh=${ghPresent ? "found" : "missing"}; provider=${review.providerMode}; strategy=${review.strategy}; approval=${review.approval.enabled ? "enabled" : "disabled"}; exemptions=${exemptions.length}`;
   const severity = problems.length ? "fail" : warnings.length ? "warn" : "pass";
   const message = problems.length
     ? `${detail} — ${problems.join("; ")}`

--- a/packages/cli/src/gateway/doctor-checks/review.ts
+++ b/packages/cli/src/gateway/doctor-checks/review.ts
@@ -75,11 +75,14 @@ export const reviewDoctorCheck: DoctorCheck = async (
 
   const detail = `mra=${mraPresent ? "found" : "missing"}; protocol=${protocol ? "v1" : "legacy/unavailable"}; gh=${ghPresent ? "found" : "missing"}; provider=${review.providerMode}; strategy=${review.strategy}; approval=${review.approval.enabled ? "enabled" : "disabled"}; exemptions=${exemptions.length}`;
   const severity = problems.length ? "fail" : warnings.length ? "warn" : "pass";
-  const message = problems.length
-    ? `${detail} — ${problems.join("; ")}`
-    : warnings.length
-      ? `${detail}; ${warnings.join("; ")}`
-      : detail;
+  // Problems and warnings both render. A standing protection exemption (or a
+  // dropped entry) is a warning, and it must stay visible even when the check
+  // is already failing for another reason — e.g. mra/gh off PATH in CI —
+  // rather than being swallowed by the problems branch.
+  const message =
+    detail +
+    (problems.length ? ` — ${problems.join("; ")}` : "") +
+    (warnings.length ? `; ${warnings.join("; ")}` : "");
 
   return { name: "review", severity, message };
 };

--- a/packages/cli/src/gateway/events.ts
+++ b/packages/cli/src/gateway/events.ts
@@ -227,6 +227,26 @@ export interface ReviewPostedEvent {
   durationMs: number;
 }
 
+/**
+ * A real GitHub APPROVE published by the gateway. Distinct from
+ * `review.posted` (which covers COMMENT/REQUEST_CHANGES review bodies):
+ * this is the mutation that can unblock a merge, so it is audited on its
+ * own. `protectionExempt` records whether the approve rode a per-repo
+ * waiver of the branch-protection preflight — i.e. whether GitHub will
+ * dismiss it when new commits land.
+ */
+export interface ReviewApprovedEvent {
+  type: "review.approved";
+  actor: string;
+  repo: string;      // owner/repo slug
+  pr: number;
+  commit: string;    // the exact head SHA that was approved
+  reviewId: number;
+  protectionExempt: boolean;
+  /** The waiver's recorded justification, when one was in effect. */
+  exemptionReason?: string;
+}
+
 export interface ReviewSkippedEvent {
   type: "review.skipped";
   actor: string;
@@ -286,6 +306,7 @@ export type GatewayEvent =
   | GithubIssueFailedEvent
   | ReviewTriggeredEvent
   | ReviewPostedEvent
+  | ReviewApprovedEvent
   | ReviewSkippedEvent
   | AudioTranscribedEvent
   | AudioSummarizedEvent
@@ -309,6 +330,7 @@ const VALID_TYPES: ReadonlySet<string> = new Set([
   "github.issue.failed",
   "review.triggered",
   "review.posted",
+  "review.approved",
   "review.skipped",
   "audio.transcribed",
   "audio.summarized",

--- a/packages/cli/src/gateway/review-policy.ts
+++ b/packages/cli/src/gateway/review-policy.ts
@@ -8,6 +8,10 @@ import type { ProtectionExemption } from "./config";
 // against. GitHub APPROVE additionally requires the runtime gate
 // `review.approval.enabled` (admin-togglable, default false) plus the
 // per-approve preflights (identity, head-SHA, protection, revision fences).
+// The protection preflight is waivable per-repo via
+// `review.approval.protectionExemptions` — a deliberate, reasoned risk
+// acceptance for repos whose ruleset lacks dismiss-stale/require-last-push.
+// See docs/superpowers/specs/2026-07-17-approve-protection-exemption-design.md.
 export const AUTOMATIC_APPROVAL_RELEASE_READY = true;
 
 export function effectiveMraReviewStrategy(

--- a/packages/cli/src/gateway/review-policy.ts
+++ b/packages/cli/src/gateway/review-policy.ts
@@ -1,4 +1,5 @@
 import type { ReviewProviderMode, ReviewStrategy } from "../adapters/mra";
+import type { ProtectionExemption } from "./config";
 
 // Release veto — LIFTED (#90, 2026-07-17): config writers
 // (saveGatewayConfig) and the approve POST critical section
@@ -26,4 +27,18 @@ export function reviewStrategySummary(
   const cr = effectiveMraReviewStrategy(configured, providerMode, false);
   const approve = effectiveMraReviewStrategy(configured, providerMode, true);
   return `strategy configured \`${configured}\` · effective :cr: \`${cr}\` · :a: \`${approve}\``;
+}
+
+/**
+ * The per-repo waiver of the branch-protection preflight, or undefined.
+ *
+ * Returns the entry rather than a boolean so callers get `reason` for the
+ * Slack disclosure and the audit record. Exact slug match only: a stored
+ * `onead/*` is a literal repo name that matches nothing, by design.
+ */
+export function findProtectionExemption(
+  approval: { protectionExemptions?: ProtectionExemption[] },
+  slug: string,
+): ProtectionExemption | undefined {
+  return approval.protectionExemptions?.find((e) => e.repo === slug);
 }

--- a/packages/cli/src/gateway/slack/admin-review.ts
+++ b/packages/cli/src/gateway/slack/admin-review.ts
@@ -31,7 +31,8 @@ export function reviewStatusText(cfg: RawGatewayConfig): string {
     `• enabled: \`${review.enabled}\``,
     `• provider: \`${review.providerMode}\``,
     `• ${reviewStrategySummary(review.strategy, review.providerMode)}`,
-    `• automatic approval: \`${review.approval.enabled}\` (PMK admin confirmation + protected repo required)`,
+    `• automatic approval: \`${review.approval.enabled}\` (PMK admin confirmation required; branch protection required unless the repo is exempt)`,
+    `• protection exemptions: ${review.approval.protectionExemptions?.length ? review.approval.protectionExemptions.map((e) => `\`${e.repo}\``).join(", ") : "`none`"}`,
     `• concurrency: global \`${review.maxConcurrent}\` · per user \`${review.maxConcurrentPerUser}\``,
     `• allow public repos: \`${review.allowPublicRepos}\``,
   ].join("\n");
@@ -76,12 +77,17 @@ export function adminReview(actor: string, tokens: string[]): AdminSlashResult {
         logAdmin(actor, "review.approval.enable", false, undefined, "release veto active");
         return { text: ":lock: automatic approval 尚未 release；`:cr:` review 可正常使用，但目前不能開啟 GitHub APPROVE。" };
       }
-      cfg.review = { ...(cfg.review ?? {}), approval: { enabled } };
+      // Merge, never replace: `approval` also holds protectionExemptions, and
+      // a bare `{ enabled }` would silently wipe them on every toggle.
+      cfg.review = {
+        ...(cfg.review ?? {}),
+        approval: { ...(cfg.review?.approval ?? {}), enabled },
+      };
       saveGatewayConfig(cfg);
       logAdmin(actor, `review.approval.${value}`, true);
       return {
         text: enabled
-          ? ":warning: automatic approval enabled; each repo must still pass protocol, identity, head-SHA, allowlist, and branch-protection readiness checks"
+          ? ":warning: automatic approval enabled; each repo must still pass protocol, identity, head-SHA, and allowlist checks, plus branch-protection readiness unless it is listed in `review.approval.protectionExemptions`"
           : ":white_check_mark: automatic approval disabled; `:cr:` review remains available",
       };
     }

--- a/packages/cli/src/gateway/slack/review-messages.ts
+++ b/packages/cli/src/gateway/slack/review-messages.ts
@@ -24,14 +24,30 @@ export function canConfirmApproveFromReview(res: ReviewOutcome): boolean {
     (res.status === "COMMENT" || res.status === "COMMENTED");
 }
 
-/** Result line for a plain `:cr:` review. It never claims GitHub approval. */
-export function reviewResultText(slug: string, ref: PrRef, res: ReviewOutcome, approvalEnabled = true): string {
+/**
+ * Result line for a plain `:cr:` review. It never claims GitHub approval.
+ *
+ * `protectionExempted` is a CONFIG fact (the repo is on the exemption list),
+ * not a branch fact. The `:cr:` path never probes branch protection, so this
+ * line must not assert anything about dismiss-stale / require-last-push —
+ * only the approve path, which probes, may do that.
+ */
+export function reviewResultText(
+  slug: string,
+  ref: PrRef,
+  res: ReviewOutcome,
+  approvalEnabled = true,
+  protectionExempted = false,
+): string {
   if (res.incomplete)
     return `:warning: ${slug}#${ref.number} review 未完成（mra 回報 REVIEW_INCOMPLETE，未真正評估此 PR — 可能 max-turns 截斷或 provider 呼叫失敗）；已貼中性佔位，claim 已釋放，請重試 :cr:：${ref.url}`;
   const status = res.status ?? "COMMENT";
   const count = res.commentCount ?? 0;
   if (approvalEnabled && canConfirmApproveFromReview(res)) {
-    return `:mag: 已完成 ${slug}#${ref.number} review（GitHub action: ${status}；${count} 則）。這個結果沒有 HIGH/CRITICAL blocker，可進一步 approve，但 :cr: 不會主動 approve；請由 PMK admin 在此 channel thread @PMK 回覆 \`approve\` 授權（DM 可直接回覆）：${ref.url}`;
+    const exemptNote = protectionExempted
+      ? "（此 repo 已列入 protection 豁免清單，approve 時會略過 branch-protection 檢查）"
+      : "";
+    return `:mag: 已完成 ${slug}#${ref.number} review（GitHub action: ${status}；${count} 則）。這個結果沒有 HIGH/CRITICAL blocker，可進一步 approve，但 :cr: 不會主動 approve；請由 PMK admin 在此 channel thread @PMK 回覆 \`approve\` 授權（DM 可直接回覆）${exemptNote}：${ref.url}`;
   }
   return `:mag: 已完成 ${slug}#${ref.number} review（GitHub action: ${status}；${count} 則；未執行 GitHub approve）：${ref.url}`;
 }

--- a/packages/cli/src/gateway/slack/review.ts
+++ b/packages/cli/src/gateway/slack/review.ts
@@ -46,7 +46,7 @@ import {
   runMraReview as runMraReviewImpl,
   runMraAnalyze as runMraAnalyzeImpl,
 } from "../../adapters/mra";
-import { AUTOMATIC_APPROVAL_RELEASE_READY, effectiveMraReviewStrategy } from "../review-policy";
+import { AUTOMATIC_APPROVAL_RELEASE_READY, effectiveMraReviewStrategy, findProtectionExemption } from "../review-policy";
 export { effectiveMraReviewStrategy } from "../review-policy";
 import { withAuthorizationLock } from "../authorization-lock";
 import {
@@ -570,8 +570,16 @@ export class ReviewCoordinator {
         const before = await gateway.getPrHead({ slug, pr: ref.number, token });
         if (!before || before.sha !== ref.headSha || before.baseRef !== ref.baseRef)
           throw new Error("PR head, base, or review context changed after review");
-        if (!await gateway.approvalProtectionReady({ slug, branch: ref.baseRef, token }))
+        // The probe still runs on every approve; the exemption gates the THROW,
+        // not the check. Keeping the measurement means the disclosure below
+        // asserts only what we actually observed, and an obsolete waiver
+        // announces itself. approvalProtectionReady never throws (false on
+        // error), so a network blip degrades to "still unprotected".
+        const exemption = findProtectionExemption(review.approval, slug);
+        const protectionReady = await gateway.approvalProtectionReady({ slug, branch: ref.baseRef, token });
+        if (!protectionReady && !exemption)
           throw new Error("repository protection is not approval-ready");
+        const exemptionInEffect = !protectionReady && !!exemption;
         const finalLive = this.currentConfig();
         const finalReview = resolveReviewConfig(finalLive.review);
         const finalToken = resolveReviewGhToken(finalLive.review) ?? resolveGithubToken(finalLive.github);
@@ -606,8 +614,14 @@ export class ReviewCoordinator {
         const after = await gateway.getPrHead({ slug, pr: ref.number, token });
         if (!after || after.sha !== ref.headSha)
           throw new Error(`approval ${posted.reviewId} became stale during publication`);
-        await this.reply(reservation.channelId, reservation.threadTs,
-          `:white_check_mark: 已真實 approve ${slug}#${ref.number}（commit \`${ref.headSha.slice(0, 7)}\`，GitHub review #${posted.reviewId}）。`);
+        const approvedLine = `:white_check_mark: 已真實 approve ${slug}#${ref.number}（commit \`${ref.headSha.slice(0, 7)}\`，GitHub review #${posted.reviewId}）。`;
+        const riskLine = exemptionInEffect
+          ? `\n:warning: 此 repo 未啟用 dismiss-stale/require-last-push：後續新 push 不會讓這個 approval 失效，可能被用來 merge 未經 review 的 commit。豁免理由：${exemption!.reason}`
+          : "";
+        const obsoleteLine = protectionReady && exemption
+          ? `\n:information_source: ${slug} 的 protection 豁免已不再需要（branch 現已同時啟用 dismiss-stale 與 require-last-push），可以從 config 移除。`
+          : "";
+        await this.reply(reservation.channelId, reservation.threadTs, `${approvedLine}${riskLine}${obsoleteLine}`);
       }
       });
       consumeApprovalReservation(reservation);

--- a/packages/cli/src/gateway/slack/review.ts
+++ b/packages/cli/src/gateway/slack/review.ts
@@ -1027,7 +1027,8 @@ export class ReviewCoordinator {
       });
       const resultText = isApprove
         ? approveResultText(slug, ref, res)
-        : reviewResultText(slug, ref, res, ctx.review.approval.enabled);
+        : reviewResultText(slug, ref, res, ctx.review.approval.enabled,
+            !!findProtectionExemption(ctx.review.approval, slug));
       if (progress) await progress.finish(resultText);
       else await this.reply(ctx.channelId, ctx.threadTs, resultText);
     } catch (err) {

--- a/packages/cli/src/gateway/slack/review.ts
+++ b/packages/cli/src/gateway/slack/review.ts
@@ -614,6 +614,16 @@ export class ReviewCoordinator {
         const after = await gateway.getPrHead({ slug, pr: ref.number, token });
         if (!after || after.sha !== ref.headSha)
           throw new Error(`approval ${posted.reviewId} became stale during publication`);
+        appendGatewayEvent({
+          type: "review.approved",
+          actor: actorUserId,
+          repo: slug,
+          pr: ref.number,
+          commit: ref.headSha,
+          reviewId: posted.reviewId,
+          protectionExempt: exemptionInEffect,
+          exemptionReason: exemptionInEffect ? exemption!.reason : undefined,
+        });
         const approvedLine = `:white_check_mark: 已真實 approve ${slug}#${ref.number}（commit \`${ref.headSha.slice(0, 7)}\`，GitHub review #${posted.reviewId}）。`;
         const riskLine = exemptionInEffect
           ? `\n:warning: 此 repo 未啟用 dismiss-stale/require-last-push：後續新 push 不會讓這個 approval 失效，可能被用來 merge 未經 review 的 commit。豁免理由：${exemption!.reason}`

--- a/packages/cli/test/admin-review.test.ts
+++ b/packages/cli/test/admin-review.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import * as os from "node:os";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { adminReview } from "../src/gateway/slack/admin-review";
+import { loadRawGatewayConfig, saveGatewayConfig } from "../src/gateway/config";
+
+const ORIG_HOME = process.env.HOME; // gatewayDir() is HOME-based
+let tmp: string;
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-ar-")); process.env.HOME = tmp; });
+afterEach(() => { if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME; fs.rmSync(tmp, { recursive: true, force: true }); });
+
+describe("adminReview approval toggle", () => {
+  it("preserves protectionExemptions across an enable/disable cycle", () => {
+    saveGatewayConfig({
+      version: 1, admins: ["U1"], blocklist: [], slack: {},
+      review: {
+        enabled: true,
+        approval: {
+          enabled: true,
+          protectionExemptions: [{ repo: "onead/oss-ui-v2", reason: "ruleset 8015695 pending" }],
+        },
+      },
+    } as never);
+
+    adminReview("U1", ["approval", "disable"]);
+    adminReview("U1", ["approval", "enable"]);
+
+    const after = loadRawGatewayConfig();
+    assert.deepEqual(
+      after.review?.approval?.protectionExemptions,
+      [{ repo: "onead/oss-ui-v2", reason: "ruleset 8015695 pending" }],
+      "toggling the approval gate must not silently wipe the exemptions",
+    );
+    assert.equal(after.review?.approval?.enabled, true);
+  });
+});

--- a/packages/cli/test/gateway-doctor.test.ts
+++ b/packages/cli/test/gateway-doctor.test.ts
@@ -686,6 +686,70 @@ describe("doctor — review readiness check", () => {
   });
 });
 
+describe("doctor — review protection exemptions", () => {
+  it("lists protection exemptions so a standing waiver stays visible", async () => {
+    const { reviewDoctorCheck } = await import("../src/gateway/doctor-checks/review");
+    const res = await reviewDoctorCheck({
+      configPath: "/nonexistent/gateway.json", // droppedExemptionCount must tolerate this
+      config: {
+        review: {
+          enabled: true,
+          approval: {
+            enabled: true,
+            protectionExemptions: [{ repo: "onead/oss-ui-v2", reason: "ruleset 8015695 pending" }],
+          },
+        },
+      },
+    } as never);
+    assert.match(res.message, /protection exemptions active/i);
+    assert.match(res.message, /onead\/oss-ui-v2/);
+    assert.match(res.message, /ruleset 8015695 pending/, "the recorded justification must be visible");
+    assert.match(res.message, /exemptions=1/);
+  });
+
+  it("reports a malformed exemption that normalisation silently dropped", async () => {
+    const { reviewDoctorCheck } = await import("../src/gateway/doctor-checks/review");
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-doc-"));
+    const configPath = path.join(dir, "gateway.json");
+    // Two entries on disk; the second lacks `reason` and is dropped at load.
+    fs.writeFileSync(configPath, JSON.stringify({
+      review: {
+        approval: {
+          protectionExemptions: [
+            { repo: "onead/oss-ui-v2", reason: "kept" },
+            { repo: "onead/typo" },
+          ],
+        },
+      },
+    }));
+    try {
+      const res = await reviewDoctorCheck({
+        configPath,
+        config: {
+          review: {
+            enabled: true,
+            approval: { enabled: true, protectionExemptions: [{ repo: "onead/oss-ui-v2", reason: "kept" }] },
+          },
+        },
+      } as never);
+      assert.match(res.message, /1 protectionExemption entry dropped/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports no exemptions and no drops for a config that has none", async () => {
+    const { reviewDoctorCheck } = await import("../src/gateway/doctor-checks/review");
+    const res = await reviewDoctorCheck({
+      configPath: "/nonexistent/gateway.json",
+      config: { review: { enabled: true, approval: { enabled: true } } },
+    } as never);
+    assert.match(res.message, /exemptions=0/);
+    assert.ok(!/dropped/.test(res.message));
+    assert.ok(!/protection exemptions active/i.test(res.message));
+  });
+});
+
 describe("doctor — DEFAULT_CHECKS shape", () => {
   it("exports exactly 12 checks (FR2 + secret-sources + github-token + review + audio)", () => {
     assert.equal(DEFAULT_CHECKS.length, 12);

--- a/packages/cli/test/gateway-doctor.test.ts
+++ b/packages/cli/test/gateway-doctor.test.ts
@@ -748,6 +748,39 @@ describe("doctor — review protection exemptions", () => {
     assert.ok(!/dropped/.test(res.message));
     assert.ok(!/protection exemptions active/i.test(res.message));
   });
+
+  it("keeps the exemption warning visible even when the check is already failing (mra/gh off PATH — the CI case)", async () => {
+    // Force both binary probes to miss, so the check has PROBLEMS (fail) — the
+    // exact state CI runs in. The exemption line lives in `warnings`, which the
+    // old message builder dropped whenever problems existed, so it vanished in
+    // CI while passing locally. This pins that warnings render alongside problems.
+    const priorMra = process.env.PMK_SKIP_MRA_PROBE;
+    const priorGh = process.env.PMK_SKIP_GH_PROBE;
+    process.env.PMK_SKIP_MRA_PROBE = "1";
+    process.env.PMK_SKIP_GH_PROBE = "1";
+    try {
+      const { reviewDoctorCheck } = await import("../src/gateway/doctor-checks/review");
+      const res = await reviewDoctorCheck({
+        configPath: "/nonexistent/gateway.json",
+        config: {
+          review: {
+            enabled: true,
+            approval: {
+              enabled: true,
+              protectionExemptions: [{ repo: "onead/oss-ui-v2", reason: "ruleset 8015695 pending" }],
+            },
+          },
+        },
+      } as never);
+      assert.equal(res.severity, "fail", "mra+gh missing must still fail the check");
+      assert.match(res.message, /mra not on PATH/, "the problem must be reported");
+      assert.match(res.message, /protection exemptions active/i, "the standing waiver must NOT be swallowed by the problem branch");
+      assert.match(res.message, /onead\/oss-ui-v2/);
+    } finally {
+      if (priorMra === undefined) delete process.env.PMK_SKIP_MRA_PROBE; else process.env.PMK_SKIP_MRA_PROBE = priorMra;
+      if (priorGh === undefined) delete process.env.PMK_SKIP_GH_PROBE; else process.env.PMK_SKIP_GH_PROBE = priorGh;
+    }
+  });
 });
 
 describe("doctor — DEFAULT_CHECKS shape", () => {

--- a/packages/cli/test/review-config.test.ts
+++ b/packages/cli/test/review-config.test.ts
@@ -38,4 +38,49 @@ describe("resolveReviewConfig", () => {
     assert.equal(resolveReviewConfig({ providerMode: "fallback" }).providerMode, "fallback");
     assert.equal(resolveReviewConfig({ providerMode: "dual" }).providerMode, "dual");
   });
+
+  it("defaults protectionExemptions to an empty array", () => {
+    assert.deepEqual(resolveReviewConfig({}).approval.protectionExemptions, []);
+    assert.deepEqual(resolveReviewConfig({ approval: { enabled: true } }).approval.protectionExemptions, []);
+  });
+
+  it("keeps well-formed protectionExemptions and trims them", () => {
+    const c = resolveReviewConfig({
+      approval: { enabled: true, protectionExemptions: [{ repo: "  onead/oss-ui-v2 ", reason: " ruleset pending " }] },
+    });
+    assert.deepEqual(c.approval.protectionExemptions, [{ repo: "onead/oss-ui-v2", reason: "ruleset pending" }]);
+  });
+
+  it("drops exemptions that lack a non-empty reason — the waiver must be justified", () => {
+    const c = resolveReviewConfig({
+      approval: {
+        enabled: true,
+        protectionExemptions: [
+          { repo: "onead/a" } as never,
+          { repo: "onead/b", reason: "" } as never,
+          { repo: "onead/c", reason: "   " } as never,
+          { repo: "onead/d", reason: 42 } as never,
+        ],
+      },
+    });
+    assert.deepEqual(c.approval.protectionExemptions, [], "an unjustified waiver must never take effect");
+  });
+
+  it("drops malformed entries but keeps valid siblings and the surrounding config", () => {
+    const c = resolveReviewConfig({
+      enabled: true,
+      approval: {
+        enabled: true,
+        protectionExemptions: [
+          null as never,
+          "onead/string-form" as never,
+          { reason: "no repo" } as never,
+          { repo: "onead/good", reason: "kept" },
+        ],
+      },
+    });
+    assert.deepEqual(c.approval.protectionExemptions, [{ repo: "onead/good", reason: "kept" }]);
+    assert.equal(c.enabled, true, "one bad exemption must not take the config down");
+    assert.equal(c.approval.enabled, true);
+  });
 });

--- a/packages/cli/test/review-config.test.ts
+++ b/packages/cli/test/review-config.test.ts
@@ -66,6 +66,19 @@ describe("resolveReviewConfig", () => {
     assert.deepEqual(c.approval.protectionExemptions, [], "an unjustified waiver must never take effect");
   });
 
+  it("fails safe to [] when protectionExemptions itself is not an array, instead of throwing", () => {
+    for (const nonArray of ["onead/x", {}, 42]) {
+      const c = resolveReviewConfig({
+        approval: { enabled: true, protectionExemptions: nonArray as never },
+      });
+      assert.deepEqual(
+        c.approval.protectionExemptions,
+        [],
+        `container ${JSON.stringify(nonArray)} must fail safe, not throw`,
+      );
+    }
+  });
+
   it("drops malformed entries but keeps valid siblings and the surrounding config", () => {
     const c = resolveReviewConfig({
       enabled: true,

--- a/packages/cli/test/review-coordinator.test.ts
+++ b/packages/cli/test/review-coordinator.test.ts
@@ -1375,6 +1375,25 @@ describe("review/approve result text (pure)", () => {
     const t = reviewResultText("onead/OnePixel", ref, { status: "COMMENT", commentCount: 0, incomplete: true } as never);
     assert.match(t, /未完成|REVIEW_INCOMPLETE/);
   });
+  it("reviewResultText notes the exemption as a config fact, never a branch claim", () => {
+    const t = reviewResultText("onead/oss-ui-v2", ref, eligibleReviewResult() as never, true, true);
+    assert.match(t, /已列入 protection 豁免清單/);
+    assert.doesNotMatch(
+      t,
+      /未啟用 dismiss-stale/,
+      ":cr: never probes, so the offer line has no standing to describe the branch",
+    );
+  });
+  it("reviewResultText leaves the offer line untouched for a non-exempt repo", () => {
+    const t = reviewResultText("onead/OnePixel", ref, eligibleReviewResult() as never, true, false);
+    assert.doesNotMatch(t, /豁免/);
+    assert.match(t, /可進一步 approve/);
+  });
+  it("reviewResultText never mentions the exemption when approval is disabled", () => {
+    const t = reviewResultText("onead/oss-ui-v2", ref, eligibleReviewResult() as never, false, true);
+    assert.doesNotMatch(t, /豁免/, "the no-approve line must not advertise a waiver it cannot use");
+    assert.match(t, /未執行 GitHub approve/);
+  });
 });
 
 describe("describeMraFailure (pure)", () => {

--- a/packages/cli/test/review-coordinator.test.ts
+++ b/packages/cli/test/review-coordinator.test.ts
@@ -1114,6 +1114,38 @@ describe("ReviewCoordinator.confirmApproveInThread", () => {
     assert.equal(writeError?.name, "AuthorizationLockBusyError");
     assert.equal(approved, 1, "the in-flight approve completes under the policy valid at its start");
   });
+
+  it("records every real approval in the audit log, flagging the accepted risk", async () => {
+    const { readGatewayEvents } = await import("../src/gateway/events");
+    const web = new FakeWebClient();
+    const gateway = gw({
+      approvalProtectionReady: async () => false,
+      resolveRepoSlug: async () => "onead/oss-ui-v2",
+      runMraReview: async () => eligibleReviewResult(),
+      createPullRequestApproval: async (a: { commitId: string }) =>
+        ({ reviewId: 4242, state: "APPROVED", commitId: a.commitId, actor: "expected-bot" }),
+    } as unknown as Partial<ReviewGateway>);
+    const c = coord(web, gateway, () => {}, {
+      approval: {
+        enabled: true,
+        protectionExemptions: [{ repo: "onead/oss-ui-v2", reason: "ruleset 8015695 pending" }],
+      },
+    });
+    const rootText = ":cr: https://github.com/onead/oss-ui-v2/pull/301";
+    await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: rootText });
+    web.conversationsHistoryResponse = { ok: true, messages: [{ text: rootText }] };
+
+    await c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+
+    const approvals = readGatewayEvents().filter((e) => e.type === "review.approved");
+    assert.equal(approvals.length, 1, "a real GitHub approval must never be unaudited");
+    const ev = approvals[0] as never as { actor: string; repo: string; pr: number; reviewId: number; protectionExempt: boolean };
+    assert.equal(ev.actor, "U1");
+    assert.equal(ev.repo, "onead/oss-ui-v2");
+    assert.equal(ev.pr, 301);
+    assert.equal(ev.reviewId, 4242);
+    assert.equal(ev.protectionExempt, true, "the accepted risk must be on the record");
+  });
 });
 
 describe("ReviewCoordinator.fromApproveMessage (:a: approve flow)", () => {

--- a/packages/cli/test/review-coordinator.test.ts
+++ b/packages/cli/test/review-coordinator.test.ts
@@ -975,6 +975,145 @@ describe("ReviewCoordinator.confirmApproveInThread", () => {
     assert.equal(writeError?.name, "AuthorizationLockBusyError");
     assert.equal(approved, 1, "the in-flight approve completes under the policy valid at its start");
   });
+
+  it("approves an exempt repo whose branch protection is not ready", async () => {
+    const web = new FakeWebClient();
+    let approved = 0;
+    const gateway = gw({
+      approvalProtectionReady: async () => false,
+      resolveRepoSlug: async () => "onead/oss-ui-v2",
+      runMraReview: async () => eligibleReviewResult(),
+      createPullRequestApproval: async (a: { commitId: string }) => {
+        approved++;
+        return { reviewId: 99, state: "APPROVED", commitId: a.commitId, actor: "expected-bot" };
+      },
+    } as unknown as Partial<ReviewGateway>);
+    const c = coord(web, gateway, () => {}, {
+      approval: {
+        enabled: true,
+        protectionExemptions: [{ repo: "onead/oss-ui-v2", reason: "ruleset 8015695 pending" }],
+      },
+    });
+    const rootText = ":cr: https://github.com/onead/oss-ui-v2/pull/301";
+    await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: rootText });
+    web.conversationsHistoryResponse = { ok: true, messages: [{ text: rootText }] };
+
+    await c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+
+    assert.equal(approved, 1, "an exempt repo must approve despite an unready probe");
+    const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
+    assert.ok(allTexts.some((t) => /已真實 approve/.test(t)));
+    assert.ok(
+      allTexts.some((t) => /不會讓這個 approval 失效/.test(t)),
+      "the accepted risk must be disclosed at the moment it goes live",
+    );
+    assert.ok(allTexts.some((t) => /ruleset 8015695 pending/.test(t)), "the reason must be surfaced");
+  });
+
+  it("still refuses a non-exempt repo whose branch protection is not ready", async () => {
+    const web = new FakeWebClient();
+    let approved = 0;
+    const gateway = gw({
+      approvalProtectionReady: async () => false,
+      runMraReview: async () => eligibleReviewResult(),
+      createPullRequestApproval: async () => { approved++; throw new Error("must not be called"); },
+    } as unknown as Partial<ReviewGateway>);
+    const c = coord(web, gateway, () => {}, {
+      approval: {
+        enabled: true,
+        protectionExemptions: [{ repo: "onead/some-other-repo", reason: "unrelated" }],
+      },
+    });
+    const rootText = ":cr: https://github.com/onead/OnePixel/pull/12";
+    await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: rootText });
+    web.conversationsHistoryResponse = { ok: true, messages: [{ text: rootText }] };
+
+    await c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+
+    assert.equal(approved, 0, "an exemption for another repo must never leak across repos");
+    const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
+    assert.ok(allTexts.some((t) => /protection is not approval-ready/.test(t)));
+  });
+
+  it("reports an exempt repo's waiver as obsolete once its branch is genuinely protected", async () => {
+    const web = new FakeWebClient();
+    let approved = 0;
+    const gateway = gw({
+      approvalProtectionReady: async () => true, // onead fixed the ruleset
+      resolveRepoSlug: async () => "onead/oss-ui-v2",
+      runMraReview: async () => eligibleReviewResult(),
+      createPullRequestApproval: async (a: { commitId: string }) => {
+        approved++;
+        return { reviewId: 99, state: "APPROVED", commitId: a.commitId, actor: "expected-bot" };
+      },
+    } as unknown as Partial<ReviewGateway>);
+    const c = coord(web, gateway, () => {}, {
+      approval: {
+        enabled: true,
+        protectionExemptions: [{ repo: "onead/oss-ui-v2", reason: "ruleset 8015695 pending" }],
+      },
+    });
+    const rootText = ":cr: https://github.com/onead/oss-ui-v2/pull/301";
+    await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: rootText });
+    web.conversationsHistoryResponse = { ok: true, messages: [{ text: rootText }] };
+
+    await c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+
+    assert.equal(approved, 1);
+    const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
+    assert.ok(allTexts.some((t) => /豁免已不再需要/.test(t)), "an obsolete waiver must announce itself");
+    assert.ok(
+      !allTexts.some((t) => /不會讓這個 approval 失效/.test(t)),
+      "a protected branch must never carry the unprotected warning",
+    );
+  });
+
+  it("refuses a protectionExemptions write that lands inside the approve critical section", async () => {
+    const web = new FakeWebClient();
+    let approved = 0;
+    let writeError: Error | undefined;
+    const gateway = gw({
+      approvalProtectionReady: async () => true,
+      runMraReview: async () => eligibleReviewResult(),
+      // Slow preflight holds the authorization lock long enough for the
+      // concurrent write below to land inside the critical section.
+      getPrHead: async () => {
+        await new Promise((r) => setTimeout(r, 120));
+        return { sha: "headsha", baseRef: "main" };
+      },
+      createPullRequestApproval: async (a: { commitId: string }) => {
+        approved++;
+        return { reviewId: 99, state: "APPROVED", commitId: a.commitId, actor: "expected-bot" };
+      },
+    } as unknown as Partial<ReviewGateway>);
+    const c = coord(web, gateway);
+    const rootText = ":cr: https://github.com/onead/OnePixel/pull/12";
+    await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: rootText });
+    web.conversationsHistoryResponse = { ok: true, messages: [{ text: rootText }] };
+
+    const confirming = c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+    await new Promise((r) => setTimeout(r, 60)); // land inside the held section
+    try {
+      saveGatewayConfig({
+        version: 1, admins: ["U1"], blocklist: [], audience: {}, escalation: {}, slack: {},
+        mraWorkspace: path.join(tmp, "ws"),
+        review: {
+          enabled: true, expectedGhUser: "expected-bot",
+          approval: {
+            enabled: true,
+            protectionExemptions: [{ repo: "onead/OnePixel", reason: "injected mid-approve" }],
+          },
+        },
+      } as never);
+    } catch (err) {
+      writeError = err as Error;
+    }
+    await confirming;
+
+    assert.ok(writeError, "an exemption must not be injectable mid-approve");
+    assert.equal(writeError?.name, "AuthorizationLockBusyError");
+    assert.equal(approved, 1, "the in-flight approve completes under the policy valid at its start");
+  });
 });
 
 describe("ReviewCoordinator.fromApproveMessage (:a: approve flow)", () => {

--- a/packages/cli/test/review-protection-exemption.test.ts
+++ b/packages/cli/test/review-protection-exemption.test.ts
@@ -2,7 +2,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { findProtectionExemption } from "../src/gateway/review-policy";
-import type { ProtectionExemption } from "../src/gateway/config";
+import type { ApprovalConfig } from "../src/gateway/config";
 
 const approval = {
   enabled: true,
@@ -29,14 +29,31 @@ describe("findProtectionExemption", () => {
     assert.equal(findProtectionExemption(approval, "onead"), undefined);
     const wild = { enabled: true, protectionExemptions: [{ repo: "onead/*", reason: "nope" }] };
     assert.equal(findProtectionExemption(wild, "onead/oss-ui-v2"), undefined);
+
+    // Exact match is case-sensitive. GitHub repo slugs ARE case-insensitive,
+    // so someone will eventually propose relaxing this to a case-fold
+    // compare — pin it here so the tests are the thing that stops them.
+    // (Also consistent with the sibling `repoAllowlist`, which is checked
+    // via plain `Array.includes`.)
+    assert.equal(findProtectionExemption(approval, "ONEAD/OSS-UI-V2"), undefined);
+    assert.equal(findProtectionExemption(approval, "onead/OSS-UI-V2"), undefined);
+
+    // Exact match does not unicode-normalise either: an NFD-decomposed
+    // slug (base letter + combining accent as separate code points) must
+    // not match a stored NFC (precomposed) repo name, even though the two
+    // render identically and `String.normalize()` would consider them equal.
+    const nfcRepo = "onead/caf\u00e9"; // "café", NFC — precomposed é (U+00E9)
+    const nfdSlug = "onead/cafe\u0301"; // "café", NFD — e + combining acute (U+0301)
+    const unicode = { enabled: true, protectionExemptions: [{ repo: nfcRepo, reason: "unicode pin" }] };
+    assert.equal(findProtectionExemption(unicode, nfdSlug), undefined);
   });
 
   it("tolerates an approval block with no exemptions at all", () => {
-    // Cast, not a fresh literal call arg: TS's weak-type check would
-    // otherwise reject `{ enabled: true }` outright since it shares no
-    // property with the (all-optional) parameter type — the cast asserts
-    // this is deliberately an approval block missing the field entirely.
-    const noExemptionsField = { enabled: true } as { protectionExemptions?: ProtectionExemption[] };
+    // Type annotation, not a cast: `{ enabled: true }` already satisfies
+    // ApprovalConfig with no cast needed (protectionExemptions is optional).
+    // An annotation also catches a future required-field change on
+    // ApprovalConfig — a cast would silently paper over that instead.
+    const noExemptionsField: ApprovalConfig = { enabled: true };
     const emptyExemptions = { enabled: true, protectionExemptions: [] };
     assert.equal(findProtectionExemption(noExemptionsField, "onead/oss-ui-v2"), undefined);
     assert.equal(findProtectionExemption(emptyExemptions, "onead/oss-ui-v2"), undefined);

--- a/packages/cli/test/review-protection-exemption.test.ts
+++ b/packages/cli/test/review-protection-exemption.test.ts
@@ -1,0 +1,44 @@
+// packages/cli/test/review-protection-exemption.test.ts
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { findProtectionExemption } from "../src/gateway/review-policy";
+import type { ProtectionExemption } from "../src/gateway/config";
+
+const approval = {
+  enabled: true,
+  protectionExemptions: [
+    { repo: "onead/oss-ui-v2", reason: "ruleset 8015695 pending" },
+    { repo: "onead/other", reason: "second entry" },
+  ],
+};
+
+describe("findProtectionExemption", () => {
+  it("returns the matching entry with its reason", () => {
+    const found = findProtectionExemption(approval, "onead/oss-ui-v2");
+    assert.equal(found?.repo, "onead/oss-ui-v2");
+    assert.equal(found?.reason, "ruleset 8015695 pending");
+  });
+
+  it("returns undefined for a repo that is not listed", () => {
+    assert.equal(findProtectionExemption(approval, "onead/unlisted"), undefined);
+  });
+
+  it("never matches by wildcard or prefix — the blast radius stays exact", () => {
+    assert.equal(findProtectionExemption(approval, "onead/*"), undefined);
+    assert.equal(findProtectionExemption(approval, "onead/oss-ui-v2-fork"), undefined);
+    assert.equal(findProtectionExemption(approval, "onead"), undefined);
+    const wild = { enabled: true, protectionExemptions: [{ repo: "onead/*", reason: "nope" }] };
+    assert.equal(findProtectionExemption(wild, "onead/oss-ui-v2"), undefined);
+  });
+
+  it("tolerates an approval block with no exemptions at all", () => {
+    // Cast, not a fresh literal call arg: TS's weak-type check would
+    // otherwise reject `{ enabled: true }` outright since it shares no
+    // property with the (all-optional) parameter type — the cast asserts
+    // this is deliberately an approval block missing the field entirely.
+    const noExemptionsField = { enabled: true } as { protectionExemptions?: ProtectionExemption[] };
+    const emptyExemptions = { enabled: true, protectionExemptions: [] };
+    assert.equal(findProtectionExemption(noExemptionsField, "onead/oss-ui-v2"), undefined);
+    assert.equal(findProtectionExemption(emptyExemptions, "onead/oss-ui-v2"), undefined);
+  });
+});


### PR DESCRIPTION
## 為什麼

`:a:` approve（v0.32.0 上線、live-verified）在它為之打造的那個 repo 上根本不能用。`onead/oss-ui-v2` 的每一次 `:cr:` review 都以 `未執行 GitHub approve` 收尾——不是 review 判決，而是 `review.approval.enabled: false` 造成的 fallback。就算把開關打開，approve preflight（`review.ts` 的 `approvalProtectionReady`）也會擋下：它要求 target branch 同時啟用 `dismiss_stale_reviews_on_push` + `require_last_push_approval`，而該 repo 的 main ruleset（`8015695`）兩者皆 `false`，且 gateway 的 pinned 身分 `HanfourHuangOneAD` 對該 repo 有 push 但非 admin，改不了 ruleset。**卡點在 org 端政策，不在 gateway 程式碼。**

## 做了什麼

新增 **per-repo、必附理由的豁免**，鬆動這一個 preflight，並配上誠實揭露與真實稽核。`:cr:`/`:a:` 兩段式 UX 不變。

- **Config**（`config.ts` / `review-policy.ts`）：`review.approval.protectionExemptions: [{repo, reason}]`。`reason` 必填；格式錯誤的項目個別丟棄且 fail-safe（無豁免 = probe 生效 = approve 被拒）。純函式 `findProtectionExemption` 精確 slug 比對，無 wildcard。
- **核心行為**（`review.ts`）：**probe 照樣每次執行——豁免只擋 `throw`，不擋 check**。因此揭露只斷言實際量測到的事，且過期豁免會自報。豁免被既有的三道 revision fence 免費涵蓋（`policyRevision` 序列化整個 `review` 物件）。
- **誠實揭露**：approve 成功訊息在「豁免且實測未受保護」時附風險警告、在「豁免但實測已受保護」時提示可移除豁免；`:cr:` offer line 只講 config 事實（`:cr:` 不 probe，無權斷言 branch 狀態）。
- **稽核**（`events.ts`）：新增 `review.approved` event 帶 `protectionExempt` 旗標——`publishApprovalReservation` 原本零 event，真實 approve 過去只存在於 Slack thread。
- **Doctor**：列出豁免中的 repo + 理由，並回報被丟棄的項目（config-only，不做 live gh call）。
- **順帶修 bug**：`admin-review.ts` 的 approval 開關原本整個換掉 `approval` 物件，會無聲清空豁免——改為 merge。

## 明確接受的風險

豁免 repo 上，PMK approve commit X 之後若有人 push Y，approval 不會失效，Y 可能靠 X 的 approval 被 merge。這是持久的洞，但**該 repo 對人類 reviewer 早就開著**（`dismiss_stale` 是 repo-wide），probe 等於拿比同事更嚴的標準要求 PMK。設計文件 `docs/superpowers/specs/2026-07-17-approve-protection-exemption-design.md` 有完整論述與仍生效的其餘所有 gate。

## 測試

1047/1047 綠（1026 基線 + 21 新測），typecheck 通過。每個 task 經 mutation 驗證測試會咬；最終 whole-branch review（opus）= ready-to-merge，0 must-fix。

## Rollout（本 PR 合併後、獨立進行）

程式碼合併不會啟用任何東西。上線是刻意分開的一步：`~/.pmk/gateway.json` 翻 `approval.enabled: true` + 加 `onead/oss-ui-v2` 豁免 → 重啟 gateway → **在該 repo 一個開著的 PR 上 live-verify**（`#299` 已 closed，不能當測試）→ 讀原始 `~/.pmk/events-*.log` 確認 `review.approved`（注意 `pmk gateway audit` 目前不統計 `review.*`，見下方 follow-up）。

## 非阻擋 follow-up

- 教 `buildAuditReport` + ops recent-activity 統計 `review.approved`，讓 `pmk gateway audit` 也能看到接受風險的 approve。
- 選擇性：`asProtectionExemptions` 在檢查空 `reason` 前先剝除 zero-width/control 字元。