### PR TITLE
fix: accept an approve confirmation that carries the PR link

### DIFF
--- a/packages/cli/src/gateway/events.ts
+++ b/packages/cli/src/gateway/events.ts
@@ -163,6 +163,22 @@ export interface MessageCappedEvent {
 }
 
 /**
+ * A model reply was withheld because it read as host-machine instructions
+ * (e.g. "edit ~/.claude/settings.json") rather than an answer to the Slack
+ * user. Records WHICH markers fired and how long the original was, never the
+ * text itself — the point is to keep host detail out of durable surfaces.
+ * A non-zero rate means requests needing host tools are reaching free-chat
+ * instead of a real handler.
+ */
+export interface MessageRedactedEvent {
+  type: "message.redacted";
+  actor: string;
+  reason: "host-guidance";
+  markers: string[];
+  originalChars: number;
+}
+
+/**
  * Per-call token accounting (v0.12.0). Emitted once per model round so
  * audits can attribute spend to the actor and reveal cache effectiveness
  * (cache reads are billed at a fraction of input tokens). The cache
@@ -301,6 +317,7 @@ export type GatewayEvent =
   | ContextExceededEvent
   | ContextForcePrunedEvent
   | MessageCappedEvent
+  | MessageRedactedEvent
   | TokenUsageEvent
   | GithubIssueCreatedEvent
   | GithubIssueFailedEvent

--- a/packages/cli/src/gateway/slack/free-chat-turn.ts
+++ b/packages/cli/src/gateway/slack/free-chat-turn.ts
@@ -72,6 +72,7 @@ import {
   truncateForSlack,
 } from "../formatters";
 import { EscalationCoordinator } from "./escalation";
+import { stripHostOnlyGuidance } from "./host-guidance";
 
 /**
  * Structural shape of any session the free-chat runner can mutate —
@@ -281,6 +282,25 @@ export class FreeChatTurnRunner {
 
     let full = retryResult.full;
     let scissorsPrefix = retryResult.scissorsPrefix;
+
+    // Defence in depth: when the agent hits its own tool-permission guard it
+    // answers by telling "you" to reconfigure the host. That reader is a Slack
+    // user who owns no such file. Replace it before it reaches the channel or
+    // the persisted session — a poisoned history would repeat the advice.
+    // This is a net, not the fix: anything needing host tools should have been
+    // routed to a real handler instead of free-chat.
+    const guarded = stripHostOnlyGuidance(full);
+    if (guarded.redacted) {
+      appendGatewayEvent({
+        type: "message.redacted",
+        actor: userId,
+        reason: "host-guidance",
+        markers: guarded.matched,
+        originalChars: full.length,
+      });
+      full = guarded.text;
+      scissorsPrefix = "";
+    }
 
     // If the model asked us to delegate a deep code-search round to
     // mra, run it and feed the result back for synthesis.

--- a/packages/cli/src/gateway/slack/host-guidance.ts
+++ b/packages/cli/src/gateway/slack/host-guidance.ts
@@ -1,0 +1,57 @@
+/**
+ * Guards against the gateway relaying host-machine instructions to Slack.
+ *
+ * The LLM behind free-chat runs on the operator's machine through the Claude
+ * Agent SDK with `allowedTools: []`. When it decides a request needs a shell
+ * command, the permission guard refuses and the model explains the refusal the
+ * only way it knows how — by telling "you" to run `/permissions` or edit
+ * `~/.claude/settings.json`. Posted verbatim to Slack that reply is both
+ * useless (the reader is not the operator and has no such file) and a small
+ * disclosure of the host's internal layout.
+ *
+ * This is a defence-in-depth net, not the primary fix: a request that needs
+ * host tools should be routed to a real handler, never to free-chat.
+ */
+
+/**
+ * Tokens that only make sense on the machine running the gateway. Any one of
+ * them can appear in a legitimate technical answer — this bot serves an
+ * engineering team — so a single hit is not enough to redact.
+ */
+const HOST_ONLY_MARKERS = [
+  /~\/\.claude/i,
+  /(?:^|\s)\/permissions\b/,
+  /allowedTools/i,
+  /permission guard/i,
+  /settings\.json/i,
+  /dangerously-skip-permissions/i,
+] as const;
+
+/** How many distinct markers must co-occur before a reply reads as host guidance. */
+const REDACT_THRESHOLD = 2;
+
+const REPLACEMENT =
+  ":warning: 這則訊息我沒能完成處理 —— gateway 主機端的工具權限限制擋下了必要的操作。\n" +
+  "這是主機設定問題，請聯繫 PMK admin 處理；你不需要修改自己的任何設定。";
+
+export interface HostGuidanceResult {
+  /** The text safe to post. Unchanged unless `redacted` is true. */
+  text: string;
+  /** True when the original was replaced because it read as host guidance. */
+  redacted: boolean;
+  /** Which markers fired — for operator logs, never for the Slack reply. */
+  matched: string[];
+}
+
+/**
+ * Replace a reply that instructs the reader to reconfigure the host with a
+ * message that points at the operator instead. Pure; safe on empty input.
+ */
+export function stripHostOnlyGuidance(text: string): HostGuidanceResult {
+  if (!text) return { text, redacted: false, matched: [] };
+  const matched = HOST_ONLY_MARKERS.filter((re) => re.test(text)).map((re) => re.source);
+  if (matched.length < REDACT_THRESHOLD) {
+    return { text, redacted: false, matched: [] };
+  }
+  return { text: REPLACEMENT, redacted: true, matched };
+}

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -744,7 +744,7 @@ export class SlackAdapter {
     if (isApproveConfirmationRequest(text)) {
       if (this.review.isEnabled()) {
         await this.review
-          .confirmApproveInThread({ channelId, threadTs: replyThreadTs, userId })
+          .confirmApproveInThread({ channelId, threadTs: replyThreadTs, userId, text })
           .catch((err) =>
             this.onLog(`review: mention approve confirmation failed: ${(err as Error).message}`),
           );
@@ -926,7 +926,7 @@ export class SlackAdapter {
     if (isApproveConfirmationRequest(text)) {
       if (this.review.isEnabled()) {
         await this.review
-          .confirmApproveInThread({ channelId, threadTs, userId })
+          .confirmApproveInThread({ channelId, threadTs, userId, text })
           .catch((err) =>
             this.onLog(`review: DM approve confirmation failed: ${(err as Error).message}`),
           );

--- a/packages/cli/src/gateway/slack/review-requests.ts
+++ b/packages/cli/src/gateway/slack/review-requests.ts
@@ -21,12 +21,29 @@ export function isApproveRequest(text: string): boolean {
 }
 
 /**
+ * A GitHub PR link in either bare or Slack (`<url>` / `<url|label>`) form. The
+ * confirmation matcher strips these before comparing: the bot asks the admin to
+ * reply `approve` in a thread whose root message carries the PR link, so
+ * re-sending that link alongside the word is the natural reply. Stripping the
+ * link keeps the matcher exact — it never widens what counts as a confirmation,
+ * it only ignores the URL.
+ */
+const PR_LINK_RE =
+  /<?https?:\/\/github\.com\/[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+\/pull\/\d+(?:\|[^>]*)?>?/g;
+
+/**
  * Bare confirmation inside a review thread. This is intentionally narrower than
  * ordinary chat: `:cr:` may offer approval, but GitHub APPROVE only happens after
  * an explicit user confirmation.
+ *
+ * A PR link may accompany the confirmation, but it is NOT trusted to select the
+ * PR — the thread's offer does that. The caller must reject a link that names a
+ * different PR (see `confirmApproveInThread`), so a link can never redirect an
+ * approval to somewhere the admin did not review.
  */
 export function isApproveConfirmationRequest(text: string): boolean {
   const t = text
+    .replace(PR_LINK_RE, " ")
     .trim()
     .toLowerCase()
     .replace(/[。.!！]+$/g, "")

--- a/packages/cli/src/gateway/slack/review.ts
+++ b/packages/cli/src/gateway/slack/review.ts
@@ -485,6 +485,12 @@ export class ReviewCoordinator {
     channelId: string;
     threadTs: string;
     userId: string;
+    /**
+     * The confirmation text, when available. A PR link inside it never selects
+     * the PR — the thread's offer does — but a link naming a DIFFERENT PR means
+     * the admin thinks they are approving something else, so we refuse.
+     */
+    text?: string;
   }): Promise<void> {
     const config = this.currentConfig();
     const review = resolveReviewConfig(config.review);
@@ -495,6 +501,11 @@ export class ReviewCoordinator {
     }
     if (!isAdmin(config, args.userId)) {
       await this.reply(args.channelId, args.threadTs, ":no_entry: approve 授權只接受 PMK admin；請 admin 在此 thread 回覆 `approve`。");
+      return;
+    }
+    const mismatch = await this.mismatchedConfirmationPr(args);
+    if (mismatch) {
+      await this.reply(args.channelId, args.threadTs, mismatch);
       return;
     }
     const pending = listPendingApprovalReconciliations(args.channelId, args.threadTs);
@@ -531,6 +542,41 @@ export class ReviewCoordinator {
       return;
     }
     await this.publishApprovalReservation(reservation, args.userId);
+  }
+
+  /**
+   * Guards the intent behind a confirmation that carries a PR link. The thread's
+   * offer selects what gets approved, so a link naming a different PR means the
+   * admin is authorizing something other than what they believe. Returns the
+   * refusal text, or null when there is nothing to object to.
+   *
+   * Runs BEFORE the offer is reserved, so a refused confirmation leaves the
+   * offer intact and the admin can simply reply `approve` again.
+   */
+  private async mismatchedConfirmationPr(args: {
+    channelId: string;
+    threadTs: string;
+    text?: string;
+  }): Promise<string | null> {
+    if (!args.text) return null;
+    const named = parsePrRefs(args.text);
+    if (named.length === 0) return null;
+    const rootText = await this.fetchMessageText(args.channelId, args.threadTs);
+    const threadRefs = rootText ? parsePrRefs(rootText) : [];
+    // No PR in the thread root to compare against — leave the decision to the
+    // offer lookup rather than inventing a mismatch.
+    if (threadRefs.length === 0) return null;
+    const key = (r: PrRef) => `${r.owner}/${r.repo}#${r.number}`;
+    const threadKeys = new Set(threadRefs.map(key));
+    const stray = named.filter((r) => !threadKeys.has(key(r)));
+    if (stray.length === 0) return null;
+    return (
+      `:no_entry: 你附的連結指向不同的 PR（${stray.map(key).join("、")}），` +
+      `與這個 thread 正在處理的 ${[...threadKeys].join("、")} 不符。` +
+      "為避免核准到未 review 的 PR，這次授權不會執行。\n" +
+      "若要核准本 thread 的 PR，直接回覆 `approve`；" +
+      "若要核准另一個 PR，請對它執行 `:cr: <PR 連結>` 後在該 thread 授權。"
+    );
   }
 
   /**

--- a/packages/cli/test/host-guidance.test.ts
+++ b/packages/cli/test/host-guidance.test.ts
@@ -1,0 +1,58 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import { stripHostOnlyGuidance } from "../src/gateway/slack/host-guidance";
+
+// Regression: a `:a:` approve confirmation that carried a PR link fell through
+// to free-chat, where the agent hit its own tool-permission guard and answered
+// with host-machine instructions (`/permissions`, `~/.claude/settings.json`).
+// That reply was posted verbatim to Slack, telling an external user to edit
+// settings they do not have and exposing the host's internal layout.
+const REAL_LEAK = `gh 指令被 Claude Code 的 permission guard 擋下了，需要你在設定中放行。最快的解法：
+
+在 terminal 開一個 Claude Code interactive session，執行：
+
+/permissions
+
+或是直接在 ~/.claude/settings.json 的 allowedTools 加上 Bash(gh *) 這個 pattern，然後回來重跑 \`/review <url>\`。`;
+
+describe("stripHostOnlyGuidance", () => {
+  it("redacts a reply that instructs the user to edit host Claude Code settings", () => {
+    const out = stripHostOnlyGuidance(REAL_LEAK);
+    assert.equal(out.redacted, true);
+    assert.ok(!out.text.includes("~/.claude"), "must not leak the host home path");
+    assert.ok(!out.text.includes("allowedTools"), "must not leak the host setting name");
+    assert.ok(!out.text.includes("/permissions"), "must not leak the host command");
+    assert.ok(/PMK admin/.test(out.text), "should redirect the user to an admin");
+  });
+
+  it("leaves ordinary replies untouched", () => {
+    for (const t of [
+      "這個 PR 看起來沒問題，可以 merge。",
+      "我幫你查了 traceability matrix，有 7 筆通過。",
+      "",
+    ]) {
+      const out = stripHostOnlyGuidance(t);
+      assert.equal(out.redacted, false, `should not redact: '${t}'`);
+      assert.equal(out.text, t);
+    }
+  });
+
+  // A single incidental mention is a legitimate technical answer — this bot
+  // serves an engineering team. Only the combination reads as host guidance.
+  it("does NOT redact a single incidental mention", () => {
+    for (const t of [
+      "allowedTools 是 Claude Agent SDK 用來限制工具的欄位。",
+      "settings.json 通常放在專案根目錄。",
+    ]) {
+      const out = stripHostOnlyGuidance(t);
+      assert.equal(out.redacted, false, `should not redact: '${t}'`);
+    }
+  });
+
+  it("redacts when two or more host-only markers appear together", () => {
+    const out = stripHostOnlyGuidance(
+      "請編輯 ~/.claude/settings.json 並加入 allowedTools。",
+    );
+    assert.equal(out.redacted, true);
+  });
+});

--- a/packages/cli/test/review-coordinator.test.ts
+++ b/packages/cli/test/review-coordinator.test.ts
@@ -775,6 +775,28 @@ describe("isApproveConfirmationRequest", () => {
       assert.equal(isApproveConfirmationRequest(t), false, `should not match: '${t}'`);
     }
   });
+  // The bot asks the admin to "@PMK 回覆 approve" in a thread whose root is a
+  // `:a:`/`:cr:` message carrying the PR link. Re-sending that link alongside
+  // the confirmation is the natural reply, and used to fall through to
+  // free-chat instead of authorizing.
+  it("matches an approve confirmation that also carries a PR link", () => {
+    for (const t of [
+      "approve\nhttps://github.com/onead/super-dsp-2.0/pull/748",
+      "approve https://github.com/o/r/pull/1",
+      "確認 approve https://github.com/o/r/pull/1",
+      "核准 https://github.com/o/r/pull/1",
+    ]) {
+      assert.equal(isApproveConfirmationRequest(t), true, `should match: '${t}'`);
+    }
+  });
+  it("still does NOT match ordinary chat that mentions approve near a PR link", () => {
+    for (const t of [
+      "please approve after deploy https://github.com/o/r/pull/1",
+      "https://github.com/o/r/pull/1 這個 PR 我已經 approve 了",
+    ]) {
+      assert.equal(isApproveConfirmationRequest(t), false, `should not match: '${t}'`);
+    }
+  });
 });
 
 describe("ReviewCoordinator.retryInThread", () => {
@@ -881,6 +903,59 @@ describe("ReviewCoordinator.confirmApproveInThread", () => {
     assert.equal(calls, 1, "second confirmation for the same artifact is idempotent");
     const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
     assert.ok(allTexts.filter((t) => /安全停用|不會執行 approve/.test(t)).length >= 2, "each confirmation must report the revoked policy");
+  });
+
+  // A confirmation may carry a PR link, but the THREAD's offer selects the PR.
+  // A link naming a different PR is an intent mismatch: the admin believes they
+  // are approving what they pasted. Refuse loudly and leave the offer unused.
+  it("refuses a confirmation whose PR link names a different PR than the thread's", async () => {
+    const web = new FakeWebClient();
+    let calls = 0;
+    const gateway = gw({
+      runMraReview: async () => {
+        calls++;
+        return eligibleReviewResult();
+      },
+    } as unknown as Partial<ReviewGateway>);
+    const c = coord(web, gateway);
+    const rootText = ":cr: https://github.com/onead/OnePixel/pull/12";
+    await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: rootText });
+    web.conversationsHistoryResponse = { ok: true, messages: [{ text: rootText }] };
+
+    await c.confirmApproveInThread({
+      channelId: "C1", threadTs: "1.1", userId: "U1",
+      text: "approve https://github.com/onead/OnePixel/pull/999",
+    });
+
+    const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
+    assert.ok(allTexts.some((t) => /不同的 PR|#999/.test(t)), "must name the mismatch");
+    assert.ok(!allTexts.some((t) => /已真實 approve/.test(t)), "must not approve anything");
+    assert.equal(calls, 1, "must not run another review");
+
+    // The offer survives: confirming again without a link still works.
+    await c.confirmApproveInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+    const after = [...web.posted, ...web.updated].map((m) => m.text ?? "");
+    assert.ok(!after.some((t) => /沒有有效、未使用的 approve offer/.test(t)), "mismatch must not consume the offer");
+  });
+
+  it("accepts a confirmation whose PR link matches the thread's PR", async () => {
+    const web = new FakeWebClient();
+    const gateway = gw({
+      runMraReview: async () => eligibleReviewResult(),
+    } as unknown as Partial<ReviewGateway>);
+    const c = coord(web, gateway);
+    const rootText = ":cr: https://github.com/onead/OnePixel/pull/12";
+    await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: rootText });
+    web.conversationsHistoryResponse = { ok: true, messages: [{ text: rootText }] };
+
+    await c.confirmApproveInThread({
+      channelId: "C1", threadTs: "1.1", userId: "U1",
+      text: "approve\nhttps://github.com/onead/OnePixel/pull/12",
+    });
+
+    const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
+    assert.ok(!allTexts.some((t) => /不同的 PR/.test(t)), "matching link must not be treated as a mismatch");
+    assert.ok(!allTexts.some((t) => /沒有有效、未使用的 approve offer/.test(t)), "matching link must reach the offer");
   });
 
   it("publishes a real approval end-to-end when policy allows (#90 veto lifted)", async () => {


### PR DESCRIPTION
Reported from a live `:a:` approve on `onead/super-dsp-2.0#748`.

## What the user saw

The review ran clean (COMMENTED, 0 blockers) and the bot asked the admin to
`@PMK 回覆 approve 授權`. The admin did exactly that, attaching the PR link —
the same shape as their opening `:a:` message. Instead of approving, the bot
replied with instructions to open a Claude Code session, run `/permissions`,
and add `Bash(gh *)` to `~/.claude/settings.json`.

The reader is a Slack user on another machine. That file is not theirs.

## Root cause

The approval logic was never reached. `isApproveConfirmationRequest()` compares
normalized text against an **exact whitelist**, and `"approve https://…"` is not
a member:

```
"@pmk approve\nhttps://github.com/onead/super-dsp-2.0/pull/748"
  → mention-strip + normalize → "approve https://github.com/…"

isApproveConfirmationRequest → false   (whitelist holds bare "approve" only)
isApproveRequest             → false   (needs :a:)
isReviewRequest              → false   (needs :cr:)
  → no early return → free-chat queue (index.ts:770)
  → claude-agent provider, allowedTools: []
  → model hits its own permission guard and explains it to "you"
  → posted verbatim to Slack
```

Verified by running the classifiers on the exact strings: bare `approve` returns
true, the same word with a PR link returns false on all three.

**Not a v0.34.x regression** — the classifier has been this narrow since
`b472a01`. It took a user appending a link to expose it, which is the most
natural way to answer the bot's own prompt.

## Fixes

**1. The matcher tolerates the link.** A GitHub PR link (bare or Slack
`<url|label>` form) is stripped before the whitelist comparison. The matcher
stays exact — deliberately so, per its original comment. Still false:
`"please approve after deploy <link>"`, `"<link> 這個 PR 我已經 approve 了"`,
`":a: <link>"`.

**2. A link never selects the PR.** The thread's offer does. When the
confirmation names a *different* PR, the admin believes they are approving
something they did not review, so `confirmApproveInThread` refuses and names
both PRs. The check runs **before** the offer is reserved, so a refusal leaves
the offer intact and a plain `approve` still works.

**3. Defence in depth — `host-guidance.ts`.** A model reply carrying **two or
more** host-only markers (`~/.claude`, `allowedTools`, `/permissions`,
`settings.json`, `permission guard`, `dangerously-skip-permissions`) is replaced
with a message pointing at the PMK admin. A `message.redacted` event records
which markers fired and the original length — never the text.

The two-marker threshold is deliberate: this bot answers technical questions for
an engineering team, so a single incidental mention of `allowedTools` is a
legitimate answer and is left alone.

This is a net, not the fix. A non-zero redaction rate is a signal that requests
needing host tools are still reaching free-chat, and should be investigated
rather than tuned away.

## Test plan

- [x] **1,074 tests pass, 0 fail** (baseline 1066 + 8 new) + typecheck clean
- [x] `@pmk/cli` builds
- [x] New coverage: confirmation-with-link accepted; mismatched link refused
      without consuming the offer; matching link reaches the offer; the four
      `stripHostOnlyGuidance` cases including the verbatim leaked reply
- [x] CI green — 5/5 checks pass (cli 1m17s, core, rag, shared, desktop)
- [ ] **Live-Slack verify before tagging** — replay the exact failure on a real
      PR: `:a: <link>` → wait for the clean review → reply `approve <same link>`
      and confirm a real GitHub APPROVE lands; then reply `approve <other link>`
      in that thread and confirm the refusal names both PRs and the offer
      survives

## Note on scope

This branch is cut from `main`, independent of #94, so it can ship without
waiting on that refactor.
