### PR TITLE
fix: make the approve preflight refusal actionable, treat a 404 ruleset as ungated

### DIFF
--- a/packages/cli/src/adapters/github.ts
+++ b/packages/cli/src/adapters/github.ts
@@ -261,9 +261,28 @@ export function buildGhArgs_getReviewGate(slug: string, branch: string): string[
 }
 
 /**
+ * True only for a literal HTTP 404 from the Rules API, read off the failed
+ * process rather than the Error message: `gh` exits 1 with the API body on
+ * stdout and a summary on stderr. Deliberately narrow — 401/403/5xx and
+ * transport errors must NOT match, because "cannot see the protection" is not
+ * "there is no protection". Never inspects `err.message`, which callers and
+ * tests may set to arbitrary text.
+ */
+function isRulesApiNotFound(err: unknown): boolean {
+  const e = err as { stderr?: unknown; stdout?: unknown };
+  const streams = [e?.stderr, e?.stdout]
+    .filter((s): s is string => typeof s === "string")
+    .join("\n");
+  if (!streams) return false;
+  return /\(HTTP 404\)|"status"\s*:\s*"?404"?/.test(streams);
+}
+
+/**
  * Three-state review-gate probe for the ungated auto-allow path.
  *   true      → gated (some ruleset requires >=1 approving review)
- *   false     → ungated (no pull_request rule, or count 0/absent)
+ *   false     → ungated (no pull_request rule, count 0/absent, or the branch
+ *               has no ruleset at all — which the Rules API reports as 404
+ *               rather than an empty array)
  *   undefined → unknown (no gh, or the Rules API is unreadable)
  * The undefined state is load-bearing: the caller allows ONLY on a literal
  * false, and fails closed on undefined. Classic (admin-only) branch protection
@@ -282,7 +301,11 @@ export async function reviewGateStatus(
     const { stdout } = await exec(gh, buildGhArgs_getReviewGate(args.slug, args.branch), { env, timeoutMs: 15_000 });
     const counts = JSON.parse(stdout) as Array<number | null>;
     return counts.some((c) => typeof c === "number" && c >= 1);
-  } catch {
+  } catch (err) {
+    // A branch with no ruleset 404s instead of returning []. That is the same
+    // "no pull_request rule" fact an empty array expresses, so report it as
+    // ungated. Every other failure stays unknown and the caller fails closed.
+    if (isRulesApiNotFound(err)) return false;
     return undefined;
   }
 }

--- a/packages/cli/src/gateway/slack/review.ts
+++ b/packages/cli/src/gateway/slack/review.ts
@@ -157,6 +157,46 @@ interface InFlightReview {
   projectKey: string;
 }
 
+/**
+ * The refusal shown when approve preflight finds the repo not approval-ready.
+ *
+ * Two very different situations reach this point and the old single sentence
+ * covered both, leaving the reader nothing to act on — one admin retried the
+ * same `approve` seven times over two hours against an underprotected repo.
+ *
+ * `approvalProtectionReady` returning false already establishes that the two
+ * controls are not both on, so that is the default explanation — it holds even
+ * when the gate probe was never consulted (the flag is off). The probe only
+ * adds one distinction: if it ran and came back unknown, the Rules API is
+ * unreadable, which also makes the `false` above untrustworthy. Say that
+ * instead of naming controls we could not actually observe.
+ *
+ * @param gateStatus probe result; meaningful only when `gateProbed` is true
+ * @param gateProbed whether the gate probe was consulted at all
+ */
+export function protectionNotReadyMessage(
+  slug: string,
+  branch: string,
+  gateStatus: boolean | undefined,
+  gateProbed = false,
+): string {
+  if (gateProbed && gateStatus === undefined) {
+    return (
+      `無法確認 ${slug} 的 \`${branch}\` 保護狀態（Rules API 讀取失敗），` +
+      "為安全起見不予核准。請 repo admin 確認 pmk 的 review 身分是否有讀取權限；" +
+      "在確認之前，請直接在 GitHub 上人工核准。"
+    );
+  }
+  return (
+    `${slug} 的 \`${branch}\` 需要 review 核准，但缺少兩項必要保護：` +
+    "`dismiss_stale_reviews_on_push` 與 `require_last_push_approval`（目前皆為 false）。" +
+    "少了它們，核准後推的新 commit 不會讓核准失效，未經審查的變更就能合併。\n" +
+    "請 repo admin 於 ruleset 開啟這兩項；" +
+    "若需在調整前先行放行，請 PMK admin 將此 repo 加入 `review.approval.protectionExemptions`。" +
+    "在此之前，請直接在 GitHub 上人工核准。"
+  );
+}
+
 export class ReviewCoordinator {
   /** Reviews running right now (detached). Drained on shutdown (A). */
   private readonly inFlight = new Set<InFlightReview>();
@@ -657,11 +697,15 @@ export class ReviewCoordinator {
         // unreadable (undefined) — only a positive false may allow; undefined
         // fails closed. Runs at most once, and never on the protected/exempt paths.
         let ungatedAllow = false;
+        let gateStatus: boolean | undefined;
+        let gateProbed = false;
         if (review.approval.allowWhenNoReviewGate && !protectionReady && !exemption) {
-          ungatedAllow = (await gateway.reviewGateStatus({ slug, branch: ref.baseRef, token })) === false;
+          gateProbed = true;
+          gateStatus = await gateway.reviewGateStatus({ slug, branch: ref.baseRef, token });
+          ungatedAllow = gateStatus === false;
         }
         if (!protectionReady && !exemption && !ungatedAllow)
-          throw new Error("repository protection is not approval-ready");
+          throw new Error(protectionNotReadyMessage(slug, ref.baseRef, gateStatus, gateProbed));
         const exemptionInEffect = !protectionReady && !!exemption;
         const approvalBasis: "protected" | "exempt" | "ungated" =
           protectionReady ? "protected" : exemptionInEffect ? "exempt" : "ungated";

--- a/packages/cli/test/github-review-helpers.test.ts
+++ b/packages/cli/test/github-review-helpers.test.ts
@@ -162,6 +162,41 @@ describe("reviewGateStatus (three-state review-gate probe)", () => {
     assert.equal(await reviewGateStatus({ slug: "o/r", branch: "main" }, { findBinary: () => undefined } as never), undefined);
   });
 
+  /** gh exits 1 on a 404; the body lands on stdout and a summary on stderr. */
+  const ghFailure = (stderr: string, stdout = "") => ({
+    exec: async () => {
+      throw Object.assign(new Error("Command failed"), { stderr, stdout });
+    },
+    findBinary: () => "/usr/bin/gh",
+  });
+
+  // A branch with no ruleset 404s instead of returning []. Both express the
+  // same fact — no pull_request rule — so both mean "ungated".
+  it("ungated: the Rules API 404s (branch has no ruleset) → false", async () => {
+    const deps404 = ghFailure(
+      "gh: Not Found (HTTP 404)",
+      '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/rules","status":"404"}',
+    );
+    assert.equal(await reviewGateStatus({ slug: "o/r", branch: "main" }, deps404 as never), false);
+  });
+
+  // Load-bearing: "cannot see the protection" must never read as "there is no
+  // protection". Only a literal 404 may downgrade to ungated.
+  it("unknown: auth/transport failures stay undefined, never false", async () => {
+    for (const stderr of [
+      "gh: Bad credentials (HTTP 401)",
+      "gh: Resource not accessible by integration (HTTP 403)",
+      "gh: Internal Server Error (HTTP 500)",
+      "error connecting to api.github.com",
+    ]) {
+      assert.equal(
+        await reviewGateStatus({ slug: "o/r", branch: "main" }, ghFailure(stderr) as never),
+        undefined,
+        stderr,
+      );
+    }
+  });
+
   it("buildGhArgs_getReviewGate targets the Rules API and extracts the review count", () => {
     const args = buildGhArgs_getReviewGate("o/r", "main");
     assert.deepEqual(args.slice(0, 2), ["api", "repos/o/r/rules/branches/main"]);

--- a/packages/cli/test/review-coordinator.test.ts
+++ b/packages/cli/test/review-coordinator.test.ts
@@ -5,7 +5,7 @@ import * as os from "node:os";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { FakeWebClient } from "./harness/slack-fakes";
-import { ReviewCoordinator, effectiveMraReviewStrategy, isReviewRequest, isRetryRequest, isRerunRequest, isApproveRequest, isApproveConfirmationRequest, canConfirmApproveFromReview, reviewResultText, approveResultText, describeMraFailure, type ReviewGateway } from "../src/gateway/slack/review";
+import { ReviewCoordinator, effectiveMraReviewStrategy, isReviewRequest, isRetryRequest, isRerunRequest, isApproveRequest, isApproveConfirmationRequest, canConfirmApproveFromReview, reviewResultText, approveResultText, describeMraFailure, protectionNotReadyMessage, type ReviewGateway } from "../src/gateway/slack/review";
 import { gatewayConfigPath, resolveReviewConfig, saveGatewayConfig } from "../src/gateway/config";
 
 const ORIG_HOME = process.env.HOME; // gatewayDir() is HOME-based; isolate via HOME (not PMK_HOME)
@@ -846,6 +846,40 @@ describe("ReviewCoordinator.retryInThread", () => {
   });
 });
 
+// roccochen retried `approve` 7 times over 2 hours against superdsp-ui and got
+// the same unactionable "repository protection is not approval-ready" each
+// time. The message must name what is missing and who can change it.
+describe("protectionNotReadyMessage", () => {
+  it("names the two missing ruleset controls when the repo IS gated", () => {
+    const m = protectionNotReadyMessage("onead/superdsp-ui", "main", true);
+    assert.ok(m.includes("onead/superdsp-ui"), "names the repo");
+    assert.ok(/dismiss_stale_reviews_on_push/.test(m), "names the first control");
+    assert.ok(/require_last_push_approval/.test(m), "names the second control");
+    assert.ok(/admin/i.test(m), "says who can fix it");
+  });
+
+  it("says the protection could not be READ when the probe ran and came back unknown", () => {
+    const m = protectionNotReadyMessage("onead/x", "main", undefined, true);
+    assert.ok(/讀取|無法確認/.test(m), "distinguishes unreadable from underprotected");
+    assert.ok(!/dismiss_stale_reviews_on_push/.test(m), "must not claim a specific missing control it never observed");
+  });
+
+  // Flag off → the probe never runs, but approvalProtectionReady already told
+  // us the two controls are not both on. Explain that rather than guessing.
+  it("names the missing controls when the probe was never consulted", () => {
+    const m = protectionNotReadyMessage("onead/x", "main", undefined, false);
+    assert.ok(/缺少兩項必要保護/.test(m));
+    assert.ok(!/無法確認/.test(m), "an unprobed refusal must not claim the API was unreadable");
+  });
+
+  it("never tells the reader to edit host-side settings", () => {
+    for (const [s, p] of [[true, true], [undefined, true], [undefined, false]] as const) {
+      const m = protectionNotReadyMessage("o/r", "main", s, p);
+      assert.ok(!/~\/\.claude|allowedTools|\/permissions/.test(m));
+    }
+  });
+});
+
 describe("ReviewCoordinator.confirmApproveInThread", () => {
   /** Live gateway.json that revokes approval — currentConfig() prefers the file. */
   function revokeApprovalOnDisk() {
@@ -1108,7 +1142,7 @@ describe("ReviewCoordinator.confirmApproveInThread", () => {
 
     assert.equal(approved, 0, "an exemption for another repo must never leak across repos");
     const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
-    assert.ok(allTexts.some((t) => /protection is not approval-ready/.test(t)));
+    assert.ok(allTexts.some((t) => /缺少兩項必要保護/.test(t)), "underprotected repo must name the two missing controls");
   });
 
   it("reports an exempt repo's waiver as obsolete once its branch is genuinely protected", async () => {
@@ -1268,7 +1302,7 @@ describe("ReviewCoordinator.confirmApproveInThread", () => {
 
     assert.equal(approved, 0, "an unreadable gate must never auto-allow");
     const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
-    assert.ok(allTexts.some((t) => /protection is not approval-ready/.test(t)));
+    assert.ok(allTexts.some((t) => /無法確認.*保護狀態/.test(t)), "unreadable probe must not claim a specific missing control");
   });
 
   it("still refuses a gated repo with the flag on (the ungated path must not fire)", async () => {


### PR DESCRIPTION
Reported from a live thread: an admin retried `approve` **seven times over two
hours** against `onead/superdsp-ui`, got the identical sentence every time, and
eventually gave up and asked how to dismiss a request-changes instead.

```
:no_entry: approve preflight 未通過，授權尚未消耗：repository protection is not approval-ready
```

## The refusal was correct — the message was not

Measured against the live Rules API:

| repo | `required_approving_review_count` | `dismiss_stale_reviews_on_push` | `require_last_push_approval` | verdict |
|---|---|---|---|---|
| `super-dsp-2.0` | *(no pull_request rule)* | — | — | ungated → allowed by flag |
| `superdsp-ui` | **1** | **false** | **false** | gated-but-underprotected → refused |
| `oss-ui-v2` | 1 | false | false | same shape, **already waived** |
| `OnePixel` | Rules API **404** | — | — | probe `undefined` → failed closed |

So `superdsp-ui` is gated (the ungated auto-allow legitimately cannot apply) and
underprotected (`approvalProtectionReady` false). Identical to `oss-ui-v2`, which
has had a waiver since v0.33.0. The assumption recorded back then — "only
oss-ui-v2 needs the exemption, everything else uses the flag" — does not hold.

Those two controls being off is a real risk, not a formality: without them an
approval survives a later push, so unreviewed code can merge on the strength of
a bot approval of an earlier sha.

## Changes

**1. The refusal now says what to do.** It names the two missing controls, says a
repo admin owns the ruleset, offers `protectionExemptions` as the interim path,
and points at manual approval meanwhile.

`approvalProtectionReady` returning false already proves the two controls are not
both on, so that explanation holds even when the gate probe never ran (flag off).
Only a probe that **ran and returned unknown** reports "could not read the
protection" — we must not name controls we never observed.

**2. A 404 from the Rules API now means ungated.** A branch with no ruleset 404s
instead of returning `[]`; both express the same "no pull_request rule" fact.

Detection is deliberately narrow: it reads the failed process's `stderr`/`stdout`
(never `err.message`, which tests and callers set freely) and matches only 404.
**401/403/5xx/transport stay `undefined`** so the caller keeps failing closed —
"cannot see the protection" must never read as "there is no protection".

The gate probe is still skipped entirely when `allowWhenNoReviewGate` is off, so
the v0.33.0-parity path gains no API call. That existing contract is covered by a
test which caught an earlier version of this change.

## Also done outside this PR

`onead/superdsp-ui` was added to `protectionExemptions` in the live
`~/.pmk/gateway.json` (config, not code), mirroring the oss-ui-v2 waiver and
labelled as interim pending the ruleset fix. **The durable fix is for a repo
admin to turn both controls on and drop both waivers.**

## Test plan

- [x] **1,070 cli tests pass, 0 fail** + typecheck; llm 13 / shared 32 / rag 13 /
      core 50 / desktop 14 all green; all packages build
- [x] New coverage: 404 → false; 401/403/5xx/transport → undefined; message names
      both controls when gated; says "unreadable" only when the probe ran and
      returned unknown; never emits host-side settings advice
- [x] Live-measured the four repos above through the exact gh query the probe uses
- [ ] CI green
- [ ] Confirm on the next real approve against superdsp-ui that the waiver lets it
      through, and that a refusal elsewhere now reads actionably