### PR TITLE
fix(gateway): stop re-reviewing the same commit, and stop free-chat answering commands

### DIFF
--- a/packages/cli/src/gateway/review-claim.ts
+++ b/packages/cli/src/gateway/review-claim.ts
@@ -15,6 +15,10 @@ export interface ReviewRef {
   pr: number;
   headSha: string;
   intent?: "review" | "approve";
+  /**
+   * The PR's `updated_at` at trigger time. Carried for callers that record it,
+   * but DELIBERATELY NOT part of the claim key — see {@link reviewClaimKey}.
+   */
   contextVersion?: string;
 }
 
@@ -34,11 +38,26 @@ function sanitize(s: string): string {
   return s.replace(/[^A-Za-z0-9._-]/g, "_");
 }
 
+/**
+ * The identity of one review: (owner, repo, pr, headSha) plus intent.
+ *
+ * `contextVersion` (the PR's `updated_at`) is deliberately EXCLUDED. Including
+ * it silently defeated the whole mechanism: the gateway's own review post bumps
+ * `updated_at`, as does any teammate comment, so the next trigger computed a
+ * different key, the `wx` create succeeded, and the same commit was reviewed
+ * again. Seen live 9 times, with the verdict flipping between
+ * CHANGES_REQUESTED and 0-blocker on byte-identical code — and since a
+ * 0-blocker result is what opens the approve offer, a blocked PR could become
+ * approvable without a single line changing.
+ *
+ * The approve path reached the same conclusion independently (see the
+ * freshness-pin comment in slack/review.ts: pin headSha + baseRef, never
+ * updatedAt); the claim key simply never followed.
+ */
 export function reviewClaimKey(r: ReviewRef): string {
   const base = [sanitize(r.owner), sanitize(r.repo), String(r.pr), sanitize(r.headSha)];
   const intent = r.intent ?? "review";
-  const withIntent = intent === "review" ? base : [...base, sanitize(intent)];
-  return (r.contextVersion ? [...withIntent, sanitize(r.contextVersion)] : withIntent).join("__");
+  return (intent === "review" ? base : [...base, sanitize(intent)]).join("__");
 }
 
 function reviewsDir(): string {
@@ -51,8 +70,51 @@ function claimPath(r: ReviewRef): string {
   return path.join(reviewsDir(), `${reviewClaimKey(r)}.json`);
 }
 
+/**
+ * A sanitized ISO instant, i.e. the shape a legacy `contextVersion` segment
+ * takes on disk (`2026-07-13T08_42_44Z`). Matching the SHAPE rather than any
+ * `key__…` suffix matters: the approve key is the review key plus `__approve`,
+ * so a loose prefix match would let an approve claim block a review claim.
+ */
+const LEGACY_CONTEXT_SUFFIX = /^\d{4}-\d{2}-\d{2}T[\d_]+Z$/;
+
+/**
+ * True when a pre-upgrade claim for this same review was already finalized.
+ *
+ * Claims written while `contextVersion` was part of the key carry it as a
+ * trailing segment. Dropping it from the key would otherwise orphan every one
+ * of them, so the first trigger after upgrading would re-review an
+ * already-reviewed commit — reproducing, once per PR, the very bug the change
+ * removes. Recognised on read; nothing on disk is rewritten.
+ */
+function hasFinalizedLegacyClaim(key: string): boolean {
+  let names: string[];
+  try {
+    names = fs.readdirSync(reviewsDir());
+  } catch {
+    return false;
+  }
+  for (const name of names) {
+    if (!name.endsWith(".json") || !name.startsWith(`${key}__`)) continue;
+    const suffix = name.slice(key.length + 2, -".json".length);
+    if (!LEGACY_CONTEXT_SUFFIX.test(suffix)) continue;
+    try {
+      const rec = JSON.parse(
+        fs.readFileSync(path.join(reviewsDir(), name), "utf8"),
+      ) as ClaimRecord;
+      // Only a FINALIZED legacy claim counts. An unfinalized one is an orphan
+      // from a crashed run, which recoverReviewClaims would have released.
+      if (rec.done === true) return true;
+    } catch {
+      /* unreadable — treat as absent rather than blocking a fresh review */
+    }
+  }
+  return false;
+}
+
 export function claimReview(r: ReviewRef): boolean {
   const key = reviewClaimKey(r);
+  if (hasFinalizedLegacyClaim(key)) return false;
   const ownerId = randomUUID();
   const rec: ClaimRecord = { key, claimedAt: nowIso(), ownerPid: process.pid, ownerId };
   try {

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -55,7 +55,7 @@ import {
   runMraAsk as runMraAskImpl,
 } from "../../adapters/mra";
 import { IssueCoordinator, realGithubGateway, type GithubGateway } from "./issue";
-import { ReviewCoordinator, realReviewGateway, isReviewRequest, isRetryRequest, isRerunRequest, isApproveRequest, isApproveConfirmationRequest } from "./review";
+import { ReviewCoordinator, realReviewGateway, isReviewRequest, isRetryRequest, isRerunRequest, isApproveRequest, isApproveConfirmationRequest, isReviewCommandMissingPr, reviewCommandUsageText } from "./review";
 import { AudioCoordinator, isAudioMessage } from "../audio/coordinator";
 import { needsConsentNotice } from "../audio/consent";
 import { pickAudience } from "../config";
@@ -705,6 +705,17 @@ export class SlackAdapter {
       return;
     }
 
+    // A command token with no PR: answer with usage rather than letting the
+    // message fall through to free-chat, where the model improvises a product
+    // surface (it once told a user to use "/code-review", a Claude Code
+    // command that does not exist here).
+    if (isReviewCommandMissingPr(text) && this.review.isEnabled()) {
+      await this.web.chat
+        .postMessage({ channel: channelId, thread_ts: replyThreadTs, text: reviewCommandUsageText() })
+        .catch(() => {});
+      return;
+    }
+
     // `retry` command: audio-first so audio threads are never intercepted by
     // review. audio.retryInThread returns false (and posts nothing) for
     // non-audio threads; the caller then falls through to review. Nothing is
@@ -884,6 +895,17 @@ export class SlackAdapter {
         .catch((err) =>
           this.onLog(`review: detached DM review failed: ${(err as Error).message}`),
         );
+      return;
+    }
+
+    // A command token with no PR: answer with usage rather than letting the
+    // message fall through to free-chat, where the model improvises a product
+    // surface (it once told a user to use "/code-review", a Claude Code
+    // command that does not exist here).
+    if (isReviewCommandMissingPr(text) && this.review.isEnabled()) {
+      await this.web.chat
+        .postMessage({ channel: channelId, thread_ts: threadTs, text: reviewCommandUsageText() })
+        .catch(() => {});
       return;
     }
 

--- a/packages/cli/src/gateway/slack/review-messages.ts
+++ b/packages/cli/src/gateway/slack/review-messages.ts
@@ -38,6 +38,13 @@ export function reviewResultText(
   res: ReviewOutcome,
   approvalEnabled = true,
   protectionExempted = false,
+  /**
+   * Which command the user actually typed. An `:a:` with no offer yet runs a
+   * review FIRST and delegates here, so without this the reply lectured the
+   * user about `:cr:` not auto-approving when they had typed `:a:` — advice
+   * about a command they did not use.
+   */
+  origin: "cr" | "a" = "cr",
 ): string {
   if (res.incomplete)
     return `:warning: ${slug}#${ref.number} review 未完成（mra 回報 REVIEW_INCOMPLETE，未真正評估此 PR — 可能 max-turns 截斷或 provider 呼叫失敗）；已貼中性佔位，claim 已釋放，請重試 :cr:：${ref.url}`;
@@ -47,7 +54,7 @@ export function reviewResultText(
     const exemptNote = protectionExempted
       ? "（此 repo 已列入 protection 豁免清單，approve 時會略過 branch-protection 檢查）"
       : "";
-    return `:mag: 已完成 ${slug}#${ref.number} review（GitHub action: ${status}；${count} 則）。這個結果沒有 HIGH/CRITICAL blocker，可進一步 approve，但 :cr: 不會主動 approve；請由 PMK admin 在此 channel thread @PMK 回覆 \`approve\` 授權（DM 可直接回覆）${exemptNote}：${ref.url}`;
+    return `:mag: 已完成 ${slug}#${ref.number} review（GitHub action: ${status}；${count} 則）。這個結果沒有 HIGH/CRITICAL blocker，可進一步 approve，但 \`:${origin}:\` 不會主動 approve；請由 PMK admin 在此 channel thread @PMK 回覆 \`approve\` 授權（DM 可直接回覆）${exemptNote}：${ref.url}`;
   }
   return `:mag: 已完成 ${slug}#${ref.number} review（GitHub action: ${status}；${count} 則；未執行 GitHub approve）：${ref.url}`;
 }

--- a/packages/cli/src/gateway/slack/review-requests.ts
+++ b/packages/cli/src/gateway/slack/review-requests.ts
@@ -21,6 +21,36 @@ export function isApproveRequest(text: string): boolean {
 }
 
 /**
+ * True when a message OPENS with a review command token but carries no PR
+ * reference — `:cr:` on its own, `:a: 4914`, and so on.
+ *
+ * Without this, both typed classifiers return false and the message falls
+ * through to free-chat, where the LLM answers a command from its own
+ * vocabulary. Live on 2026-08-03 that produced "/code-review 需要指定一個 PR
+ * 才能啟動" — `/code-review` is a Claude Code command, not a pmk surface, so the
+ * gap leaked internal tooling into a user-facing answer. A classifier that
+ * falls through is not silent; it hands the wheel to the model.
+ *
+ * Anchored at the start on purpose. A message that merely MENTIONS the token
+ * ("我剛用 :cr: 審過了") is ordinary chat and belongs in free-chat — answering
+ * that with usage help would be its own kind of hijack.
+ */
+export function isReviewCommandMissingPr(text: string): boolean {
+  if (!/^:(cr|a):/.test(text.trim())) return false;
+  return parsePrRefs(text).length === 0;
+}
+
+/** What to say instead of letting the model improvise. */
+export function reviewCommandUsageText(): string {
+  return (
+    ":information_source: 這個指令需要一個 PR 才能執行。\n" +
+    "• `:cr: <PR 連結>` — 執行 code review\n" +
+    "• `:a: <PR 連結>` — 先 review，通過後再由 admin 於 thread 回覆 `approve` 授權\n" +
+    "例如：`:cr: https://github.com/onead/erp/pull/4914`"
+  );
+}
+
+/**
  * A GitHub PR link in either bare or Slack (`<url>` / `<url|label>`) form. The
  * confirmation matcher strips these before comparing: the bot asks the admin to
  * reply `approve` in a thread whose root message carries the PR link, so

--- a/packages/cli/src/gateway/slack/review.ts
+++ b/packages/cli/src/gateway/slack/review.ts
@@ -74,6 +74,8 @@ export {
   isReviewRequest,
   isApproveRequest,
   isApproveConfirmationRequest,
+  isReviewCommandMissingPr,
+  reviewCommandUsageText,
   isRetryRequest,
   isRerunRequest,
 } from "./review-requests";
@@ -386,11 +388,26 @@ export class ReviewCoordinator {
     }
     if (!args.offeredRefs) {
       await this.reply(channelId, threadTs, ":mag: `:a:` 會先執行安全 review；完成且沒有 blocker 後，我會再請你於 thread 明確回覆 `approve`，不會直接核准。");
+      // Record the APPROVE intent before delegating. The delegated run audits
+      // itself as a review (that is what runs), so without this line an
+      // `:a:`-initiated run is indistinguishable from a plain `:cr:` after
+      // the fact — the audit could not answer "who asked to approve what".
+      appendGatewayEvent({
+        type: "review.triggered",
+        actor: actorUserId,
+        channelId,
+        prCount: parsePrRefs(text, { cap: review.maxPrsPerTrigger }).length,
+        intent: "approve",
+        providerMode: review.providerMode,
+        strategy: effectiveMraReviewStrategy(review.strategy, review.providerMode, true),
+        forced: args.forced,
+      });
       await this.processReviewRequest({
         channelId,
         threadTs,
         actorUserId,
         text: text.replace(":a:", ":cr:"),
+        origin: "a",
       });
       return;
     }
@@ -782,6 +799,8 @@ export class ReviewCoordinator {
 
   /** Shared core: parse PR refs from the text, then review each (fail-soft). */
   private async processReviewRequest(args: {
+    /** Which command the user typed. `:a:` delegates here for its pre-review. */
+    origin?: "cr" | "a";
     channelId: string;
     threadTs: string;
     actorUserId: string;
@@ -844,6 +863,7 @@ export class ReviewCoordinator {
           review,
           token,
           forceRerun: args.forced,
+          origin: args.origin,
         }, "review");
       } finally {
         try { fs.rmSync(reviewWorkspace, { recursive: true, force: true }); } catch { /* best-effort */ }
@@ -873,6 +893,8 @@ export class ReviewCoordinator {
       token?: string;
       authorizedHeads?: Map<string, string>;
       forceRerun?: boolean;
+      /** Which command the user typed; only affects wording. */
+      origin?: "cr" | "a";
     },
     mode: "review" | "approve",
   ): Promise<void> {
@@ -953,13 +975,16 @@ export class ReviewCoordinator {
       slugParts.length === 2
         ? slugParts
         : [ref.owner, ref.repo];
+    // No contextVersion: the claim identifies the COMMIT, and head.updatedAt
+    // moves on any PR activity — including the review this run is about to
+    // post. Keying on it re-opened the same commit for review (see
+    // reviewClaimKey).
     const claimRef = {
       owner: slugOwner,
       repo: slugRepo,
       pr: ref.number,
       headSha: head.sha,
       intent: isApprove ? "approve" as const : "review" as const,
-      contextVersion: head.updatedAt,
     };
     const projectKey = `${slugOwner}/${slugRepo}`;
     const actorActive = [...this.inFlight].filter((r) => r.actorUserId === ctx.reactorUserId).length;
@@ -1160,7 +1185,7 @@ export class ReviewCoordinator {
       const resultText = isApprove
         ? approveResultText(slug, ref, res)
         : reviewResultText(slug, ref, res, ctx.review.approval.enabled,
-            !!findProtectionExemption(ctx.review.approval, slug));
+            !!findProtectionExemption(ctx.review.approval, slug), ctx.origin);
       if (progress) await progress.finish(resultText);
       else await this.reply(ctx.channelId, ctx.threadTs, resultText);
     } catch (err) {

--- a/packages/cli/test/review-claim.test.ts
+++ b/packages/cli/test/review-claim.test.ts
@@ -54,6 +54,80 @@ describe("review-claim", () => {
     assert.equal(claimReview({ ...r, intent: "approve" }), false);
   });
 
+  // The whole point of the claim is "this exact commit is never reviewed
+  // twice". Folding the PR's updatedAt into the key defeated that, because the
+  // bot's OWN review post bumps updatedAt — as does any teammate comment. The
+  // next trigger then computed a different key, the wx create succeeded, and
+  // the same commit was reviewed again. Observed live 9 times, with the verdict
+  // flipping between CHANGES_REQUESTED and 0-blocker on identical code; a
+  // 0-blocker result is what opens the approve offer, so a blocked PR could
+  // become approvable with no code change. review.ts already refuses to pin
+  // freshness on updatedAt for exactly this reason — the claim never followed.
+  it("ignores PR activity: same SHA stays claimed after updatedAt moves", async () => {
+    const { claimReview } = await import("../src/gateway/review-claim");
+    assert.equal(claimReview({ ...r, contextVersion: "2026-07-13T08:42:44Z" }), true);
+    assert.equal(
+      claimReview({ ...r, contextVersion: "2026-07-14T01:20:08Z" }),
+      false,
+      "a bumped updatedAt must not open a second claim on the same commit",
+    );
+  });
+
+  it("claim key is independent of contextVersion", async () => {
+    const { reviewClaimKey } = await import("../src/gateway/review-claim");
+    assert.equal(
+      reviewClaimKey({ ...r, contextVersion: "2026-07-13T08:42:44Z" }),
+      reviewClaimKey({ ...r, contextVersion: "2026-08-01T09:01:12Z" }),
+    );
+    assert.equal(reviewClaimKey({ ...r, contextVersion: "x" }), reviewClaimKey(r));
+  });
+
+  it("still separates intents and SHAs", async () => {
+    const { reviewClaimKey } = await import("../src/gateway/review-claim");
+    assert.notEqual(
+      reviewClaimKey({ ...r, intent: "approve" }),
+      reviewClaimKey({ ...r, intent: "review" }),
+    );
+    assert.notEqual(reviewClaimKey({ ...r, headSha: "def456" }), reviewClaimKey(r));
+  });
+
+  // Claims written before contextVersion left the key carry it as a trailing
+  // segment. Shortening the key would otherwise orphan every one of them, so
+  // the first trigger after upgrading would re-review an already-reviewed
+  // commit -- reproducing the exact bug this change removes, once per PR.
+  // Recognised on read rather than renamed on disk: production state is not
+  // worth rewriting for a compatibility window.
+  describe("legacy keys (contextVersion suffix)", () => {
+    const claimsDir = () => path.join(tmp, ".pmk", "gateway", "reviews");
+    const writeLegacy = (name: string, done: boolean) => {
+      fs.mkdirSync(claimsDir(), { recursive: true });
+      fs.writeFileSync(
+        path.join(claimsDir(), `${name}.json`),
+        JSON.stringify({ key: name, claimedAt: new Date().toISOString(), done }),
+      );
+    };
+
+    it("a finalized legacy claim still blocks a re-review", async () => {
+      const { claimReview, reviewClaimKey } = await import("../src/gateway/review-claim");
+      writeLegacy(`${reviewClaimKey(r)}__2026-07-13T08_42_44Z`, true);
+      assert.equal(claimReview(r), false);
+    });
+
+    it("an UNfinalized legacy claim does not block (it was an orphan)", async () => {
+      const { claimReview, reviewClaimKey } = await import("../src/gateway/review-claim");
+      writeLegacy(`${reviewClaimKey(r)}__2026-07-13T08_42_44Z`, false);
+      assert.equal(claimReview(r), true);
+    });
+
+    // The approve key is the review key plus "__approve", so a naive prefix
+    // match would let an approve claim block an unrelated review claim.
+    it("an approve claim does not masquerade as a legacy review claim", async () => {
+      const { claimReview, reviewClaimKey } = await import("../src/gateway/review-claim");
+      writeLegacy(reviewClaimKey({ ...r, intent: "approve" }), true);
+      assert.equal(claimReview(r), true, "review intent must be unaffected");
+    });
+  });
+
   it("forceClaimReview archives a finalized claim and reclaims the same SHA", async () => {
     const { claimReview, finalizeReview, forceClaimReview } = await import("../src/gateway/review-claim");
     claimReview(r);

--- a/packages/cli/test/review-coordinator.test.ts
+++ b/packages/cli/test/review-coordinator.test.ts
@@ -5,7 +5,7 @@ import * as os from "node:os";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { FakeWebClient } from "./harness/slack-fakes";
-import { ReviewCoordinator, effectiveMraReviewStrategy, isReviewRequest, isRetryRequest, isRerunRequest, isApproveRequest, isApproveConfirmationRequest, canConfirmApproveFromReview, reviewResultText, approveResultText, describeMraFailure, protectionNotReadyMessage, type ReviewGateway } from "../src/gateway/slack/review";
+import { ReviewCoordinator, effectiveMraReviewStrategy, isReviewRequest, isRetryRequest, isRerunRequest, isApproveRequest, isApproveConfirmationRequest, isReviewCommandMissingPr, canConfirmApproveFromReview, reviewResultText, approveResultText, describeMraFailure, protectionNotReadyMessage, type ReviewGateway } from "../src/gateway/slack/review";
 import { gatewayConfigPath, resolveReviewConfig, saveGatewayConfig } from "../src/gateway/config";
 
 const ORIG_HOME = process.env.HOME; // gatewayDir() is HOME-based; isolate via HOME (not PMK_HOME)
@@ -150,6 +150,74 @@ describe("ReviewCoordinator.fromReaction", () => {
     // arrives via progress.finish() → chat.update (web.updated), not a new postMessage.
     const allTexts = [...web.posted, ...web.updated].map((m) => m.text ?? "");
     assert.ok(allTexts.some((t) => /public/i.test(t)));
+  });
+});
+
+// A message that OPENS with :cr: / :a: is a command attempt. Without a PR ref
+// the typed classifiers both return false, and the message fell through to
+// free-chat -- where the LLM answered from its own vocabulary and told a Slack
+// user that "/code-review 需要指定一個 PR 才能啟動". /code-review is a Claude
+// Code command, not a pmk surface; the classifier gap leaked internal tooling
+// into a user-facing answer. Observed live 2026-08-03 (two consecutive turns).
+// An `:a:` with no offer yet runs a REVIEW first and delegates to the review
+// path, which owns both the wording and the audit line. Two consequences the
+// user saw live: the result told them ":cr: 不會主動 approve" when they had
+// typed `:a:`, and the audit recorded only intent=review, so an `:a:`-initiated
+// run is indistinguishable from a plain `:cr:` after the fact.
+describe("reviewResultText — names the command the user actually typed", () => {
+  const ref = { owner: "o", repo: "r", number: 7, url: "https://github.com/o/r/pull/7" };
+  const approvable = {
+    ok: true, protocolVersion: "1.0" as const, artifactSha256: "a".repeat(64),
+    analyzedHeadSha: "b".repeat(40), blockerCount: 0, status: "COMMENT",
+    commentCount: 0, stdout: "", stderr: "",
+  };
+
+  it("says :cr: for a :cr:-initiated review", () => {
+    const text = reviewResultText("o/r", ref, approvable, true, false, "cr");
+    assert.match(text, /`:cr:` 不會主動 approve/);
+    assert.ok(!/`:a:` 不會主動 approve/.test(text));
+  });
+
+  it("says :a: for an :a:-initiated pre-review", () => {
+    const text = reviewResultText("o/r", ref, approvable, true, false, "a");
+    assert.match(text, /`:a:` 不會主動 approve/);
+    assert.ok(!/`:cr:` 不會主動 approve/.test(text));
+  });
+
+  it("defaults to :cr: when the origin is not supplied", () => {
+    assert.match(reviewResultText("o/r", ref, approvable), /`:cr:`/);
+  });
+});
+
+describe("isReviewCommandMissingPr (classifier fall-through guard)", () => {
+  it("catches a bare command token", () => {
+    assert.equal(isReviewCommandMissingPr(":cr:"), true);
+    assert.equal(isReviewCommandMissingPr(":a:"), true);
+    assert.equal(isReviewCommandMissingPr("  :cr:  "), true);
+  });
+
+  it("catches a command token with an unusable argument", () => {
+    assert.equal(isReviewCommandMissingPr(":cr: 4914"), true);
+    assert.equal(isReviewCommandMissingPr(":a: 那個 PR"), true);
+  });
+
+  it("does NOT catch a command that carries a PR (the typed path owns it)", () => {
+    assert.equal(
+      isReviewCommandMissingPr(":cr: https://github.com/o/r/pull/1"),
+      false,
+    );
+    assert.equal(
+      isReviewCommandMissingPr(":a: https://github.com/o/r/pull/1"),
+      false,
+    );
+  });
+
+  // Ordinary chat that merely mentions the token must stay in free-chat --
+  // answering it with usage help would be its own kind of hijack.
+  it("does NOT catch a mid-sentence mention", () => {
+    assert.equal(isReviewCommandMissingPr("我剛用 :cr: 審過了"), false);
+    assert.equal(isReviewCommandMissingPr("請問 :a: 是什麼意思"), false);
+    assert.equal(isReviewCommandMissingPr("hello"), false);
   });
 });
 


### PR DESCRIPTION
Two defects surfaced by a live usage report on 2026-08-03, plus two smaller things from the same transcript.

The reported symptom itself turned out to be **correct behaviour** — two reviews of `onead/erp#4914` minutes apart gave opposite verdicts because the developer pushed a new commit in between (`562f00a1` → `ed9187ae`, confirmed from the gateway's own `review.posted` events). Investigating it is what surfaced the real bug.

## [HIGH] The same commit gets reviewed twice, and the verdict flips

`reviewClaimKey` folded in `contextVersion` (the PR's `updated_at`). The gateway's **own review post** bumps `updated_at`, as does any teammate comment — so the next trigger computed a different key, the `wx` create succeeded, and the same commit was reviewed again.

Found **9 times** in the event history, all with `forced=None` (not `rerun`). The verdict flipped on byte-identical code:

| PR / SHA | first | second |
|---|---|---|
| `finance-system#239 @b1ecbeb1` | CHANGES_REQUESTED (1) | **COMMENTED (0)** |
| `super-dsp-2.0#791 @1b8cbc80` | CHANGES_REQUESTED (1) | **COMMENTED (0)** |
| `superdsp-ui#546 @5b309e9d` | COMMENTED (0) | **CHANGES_REQUESTED (1)** |

Proof on disk — two claims for the same `(repo, pr, headSha)` differing only in the trailing timestamp:

```
onead__finance-system__239__b1ecbeb1…__2026-07-13T08_42_44Z.json
onead__finance-system__239__b1ecbeb1…__2026-07-14T01_20_08Z.json
```

**Why it matters:** a 0-blocker result is what opens the approve offer. A PR the bot had just blocked could become approvable with no code change — just a re-trigger.

`review.ts` had already reached this exact conclusion for the approve freshness pin ("pin headSha + baseRef, never updatedAt — our own review post bumps it"). The claim key never followed. `contextVersion` was added incidentally alongside `intent` in the codex integration; no test pinned it and no rationale was recorded.

**Migration:** claims written under the old key are recognised on read rather than renamed, so upgrading does not orphan them and re-review every already-reviewed commit once. Shape-matched on the ISO suffix so an `__approve` key cannot masquerade as a legacy review key. Verified against the live store: all 156 legacy claims are finalized, 0 unfinalized — none are falsely blocked.

## [MED] Bare `:cr:` / `:a:` was answered by free-chat

A message opening with a command token but carrying no PR matched neither typed classifier and fell through to free-chat, where the model answered from its own vocabulary:

> `/code-review` 需要指定一個 PR 才能啟動。請問您想要 review 哪一個 PR？

`/code-review` is a Claude Code command, not a pmk surface — the classifier gap leaked internal tooling into a user-facing answer. Confirmed from the events: both turns are `turn.processed` (`audience=biz`, `hadMraAsk=false`), i.e. free-chat.

Now answered with real usage text. Anchored at the **start** of the message, so ordinary chat that merely mentions a token ("我剛用 `:cr:` 審過了") stays in free-chat.

## Two smaller things from the same transcript

- An `:a:`-initiated pre-review told the user "`:cr:` 不會主動 approve" — advice about a command they had not typed. The wording now follows the command actually used.
- That run was audited only as `intent=review`, so the audit could not answer "who asked to approve what". The approve intent is now recorded before delegating.

## Verification

- **1,240 tests pass, 0 fail** across all six workspaces (was 1,227, +13). Typecheck clean.
- Each fix written test-first, with the failing test observed for the right reason first.
- The legacy-claim shim was validated against the real 219-file store, not just fixtures.

## Test plan

- [ ] `npm test --workspaces --if-present` green (done locally: 1,240/1,240)
- [ ] Live: `:cr:` the same PR twice with no new commit → second must say "已經 review 過了", not run again
- [ ] Live: bare `@pmk :cr:` → usage text, not an LLM answer
- [ ] Live: `:a: <PR>` → result line names `:a:`, and `pmk gateway audit` shows a `review.triggered intent=approve`