### PR TITLE
fix(test): stop the suite writing to the operator's real ~/.pmk

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,29 @@ jobs:
       - name: Test (typecheck + unit)
         run: npm test --workspace=${{ matrix.workspace }}
 
+      # A test that exercises production objects without isolating HOME writes
+      # into the operator's real ~/.pmk store. socket-watchdog-alert.test.ts did
+      # this for two months: it constructs a PresenceBroadcaster and calls
+      # watchdogTerminate, which appends the daemon's SELF-TERMINATION record.
+      # By 2026-08-03 the live audit log held 1,056 fabricated terminations
+      # against one genuine incident — the real event was unfindable, and
+      # discovering that cost a full investigation.
+      #
+      # The suite must leave $HOME untouched. Runs after the tests so it sees
+      # whatever they created; the runner's HOME is otherwise pristine.
+      - name: Assert tests did not write to the real ~/.pmk
+        run: |
+          if [ -e "$HOME/.pmk" ]; then
+            echo "::error::the test suite wrote to \$HOME/.pmk — a test is missing HOME isolation"
+            echo "files created:"
+            find "$HOME/.pmk" -type f | head -50
+            echo
+            echo "Fix: use test/helpers/isolated-home.ts (useIsolatedHome()), or inject the"
+            echo "write path instead of letting it default to the real store."
+            exit 1
+          fi
+          echo "ok — \$HOME/.pmk absent; the suite touched no production state"
+
   docs:
     name: docs quality
     runs-on: ubuntu-latest

--- a/packages/cli/test/crash-guard.test.ts
+++ b/packages/cli/test/crash-guard.test.ts
@@ -39,7 +39,10 @@ describe("installUnhandledRejectionGuard", () => {
     // suppresses Node's crash (covered by the test above); here we verify the
     // handler itself logs + doesn't throw on the exact reason we saw live.
     const logs: string[] = [];
-    const handler = makeRejectionHandler((m) => logs.push(m));
+    // Inject the emitter. Left to its default this reaches appendGatewayEvent
+    // and writes a real gateway.rejection into the operator's live audit log —
+    // this test did exactly that until 2026-08-03.
+    const handler = makeRejectionHandler((m) => logs.push(m), () => {});
     assert.doesNotThrow(() => handler(undefined));
     assert.ok(
       logs.some((l) => /\[unhandledRejection\] survived.*socket-mode/.test(l)),

--- a/packages/cli/test/helpers/isolated-home.ts
+++ b/packages/cli/test/helpers/isolated-home.ts
@@ -1,0 +1,44 @@
+import { beforeEach, afterEach } from "node:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/**
+ * Point `~` at a throwaway directory for the enclosing describe block.
+ *
+ * Everything the gateway persists — the event log, claims, atoms, sessions,
+ * config — resolves through `os.homedir()`. A test that exercises real
+ * production objects without this writes into the OPERATOR'S store.
+ *
+ * That is not hypothetical: `socket-watchdog-alert.test.ts` constructed a real
+ * PresenceBroadcaster and called `watchdogTerminate`, which appends
+ * `gateway.offline reason=watchdog-unhealthy` — the daemon's self-termination
+ * record. Every suite run wrote three of them to the live audit log. By
+ * 2026-08-03 there were 1,056 such entries against ONE genuine incident, so
+ * the log said the gateway had self-terminated a thousand times when it had
+ * done so once. An audit trail that reports imaginary incidents is worse than
+ * one that reports none: it buries the real event and it burns an
+ * investigation to find that out.
+ *
+ * Use this in any test that touches production objects rather than pure
+ * functions. Where the write path is injectable, prefer injecting a fake —
+ * this is the fallback for objects that reach the filesystem directly.
+ */
+export function useIsolatedHome(prefix = "pmk-test-home-"): { dir: () => string } {
+  const original = process.env.HOME;
+  let tmp = "";
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    process.env.HOME = tmp;
+  });
+  afterEach(() => {
+    if (original !== undefined) process.env.HOME = original;
+    else delete process.env.HOME;
+    try {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
+  });
+  return { dir: () => tmp };
+}

--- a/packages/cli/test/socket-watchdog-alert.test.ts
+++ b/packages/cli/test/socket-watchdog-alert.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import * as assert from "node:assert/strict";
 import type { WebClient } from "@slack/web-api";
+import { useIsolatedHome } from "./helpers/isolated-home";
 
 function fakeWeb(opts: { hang?: boolean } = {}) {
   const posts: Array<{ channel: string; text: string }> = [];
@@ -20,6 +21,13 @@ function fakeWeb(opts: { hang?: boolean } = {}) {
 }
 
 describe("PresenceBroadcaster.watchdogTerminate", () => {
+  // watchdogTerminate APPENDS the daemon's self-termination record to the
+  // event log before it DMs anyone. Without an isolated home that lands in the
+  // operator's live audit trail — which is exactly what happened here: three
+  // entries per suite run, 1,056 fabricated self-terminations against one real
+  // incident.
+  useIsolatedHome("pmk-watchdog-alert-");
+
   it("DMs each admin via conversations.open → postMessage", async () => {
     const { PresenceBroadcaster } = await import("../src/gateway/slack/presence");
     const { web, posts } = fakeWeb();


### PR DESCRIPTION
Investigating the `watchdog-unhealthy` events from the v0.38.0 deploy. The finding is not what the events said.

## What the log claimed

`gateway.offline reason=watchdog-unhealthy` is the daemon's **self-termination** record — emitted by `presence.watchdogTerminate`, the watchdog's loud-exit path ("Socket-Mode unrecoverable after N reconnect attempts"). The live audit log held **1,057** of them, going back to 2026-06-03.

## What actually happened

**1,056 were written by the test suite. One was real.**

`socket-watchdog-alert.test.ts` constructs a real `PresenceBroadcaster` and calls `watchdogTerminate`, which appends that event before it DMs anyone — and the file never isolated `HOME`. Every suite run wrote three entries straight into `~/.pmk/gateway/events-*.log`.

`crash-guard.test.ts` (added in v0.37.0 — mine) did the same for `gateway.rejection`, by letting the emitter default to `appendGatewayEvent`.

### Evidence

| Signal | Finding |
|---|---|
| `seq` distribution | **1056 of 1057 are `seq=1`**. `seq` increments per `PresenceBroadcaster` instance, so `seq=1` = a freshly constructed one. Three test cases → three instances → three events. A daemon that really self-terminated 1056 times would show incrementing `seq`. |
| Burst shape | **349 of 355 bursts are exactly 3 events within 2s** — the three test cases. |
| Reproduction | Running that one file moved the production count **57 → 60**. |
| Missing pair | No `gateway.online` follows any of them, because no process ever exited. |

The single `seq=2` entry — `2026-07-15T04:14:09Z` — is the one genuine incident: followed an hour later by `gateway.online reason=crash-recovery`, i.e. the process really died and launchd restarted it.

## Why this mattered more than "noisy test"

- **46% of the event log was fictional.**
- The one real self-termination was buried among a thousand fakes.
- It manufactured a false lead: the `gateway.rejection` entries sitting seconds before each "termination" looked like socket churn causing a watchdog fire. Both sides were test output. An investigation was spent proving that.
- v0.37.0 shipped work specifically to make this log trustworthy (`gateway.rejection`, the `audit-log` doctor check). That work was landing next to a channel that was already lying.

## The fix

- `test/helpers/isolated-home.ts` — `useIsolatedHome()`, applied to the presence test
- crash-guard test injects a no-op emitter instead of defaulting to the real one
- **CI fails if the suite leaves anything in `$HOME/.pmk`**, so the next test to reach production state is caught before a human is

## Verification

- Full suite under a sandbox `HOME` creates **no `~/.pmk` at all** (before: 4 events)
- The CI guard was simulated locally: fails on the old code, passes on the new
- **1,240 tests pass, 0 fail** across all six workspaces

## Not done here — needs a decision

The 1,056 contaminated entries are still in the live log. They are precisely identifiable (`reason=watchdog-unhealthy` + `seq=1`), and removing them would shrink the log by 46% while preserving the one genuine incident. Editing an audit log is the operator's call, so this PR does not touch it.