### PR TITLE
feat(gateway): rotate the launchd-owned logs at startup

### DIFF
--- a/packages/cli/src/gateway/index.ts
+++ b/packages/cli/src/gateway/index.ts
@@ -1,3 +1,4 @@
+import * as os from "node:os";
 import * as path from "node:path";
 import * as fs from "node:fs";
 import { SlackAdapter } from "./slack";
@@ -25,9 +26,19 @@ import {
 } from "./crash-guard";
 import { recoverReviewClaims } from "./review-claim";
 import { sweepApprovalOffers } from "./review-approval";
+import { rotateLogIfLarge } from "./log-rotate";
 import { sweepStaleAudioTemp } from "./audio/temp";
 import { sweepStaleAudioClaims } from "./audio/claim";
 import { sweepStaleAtomMarkers } from "./audio/atom-marker";
+
+/**
+ * Rotate a gateway log once it passes this. 32 MB keeps a normal week of
+ * operation in one file while capping what a churn episode can leave behind
+ * (the 2026-07 incident wrote 151 MB of one repeated warning).
+ */
+const GATEWAY_LOG_MAX_BYTES = 32 * 1024 * 1024;
+/** Archives retained per log. Two generations span the last two incidents. */
+const GATEWAY_LOG_KEEP = 2;
 
 export interface GatewayRunOptions {
   /** Called for each one-line breadcrumb. Defaults to console.log. */
@@ -111,6 +122,23 @@ export async function runGateway(opts: GatewayRunOptions = {}): Promise<void> {
   }
   const sweptOffers = sweepApprovalOffers();
   if (sweptOffers > 0) log(`swept ${sweptOffers} expired review approval offer(s)`);
+
+  // Startup is the only safe moment to trim the launchd-owned logs: nothing of
+  // this run has been written yet, so the copytruncate race costs nothing.
+  // Left unbounded these only grow — one socket-churn episode put 151 MB of
+  // repeated rate-limit warnings into gateway.err.log.
+  for (const name of ["gateway.out.log", "gateway.err.log"]) {
+    const file = path.join(os.homedir(), ".pmk", "logs", name);
+    const res = rotateLogIfLarge(file, {
+      maxBytes: GATEWAY_LOG_MAX_BYTES,
+      keep: GATEWAY_LOG_KEEP,
+    });
+    if (res.rotated) {
+      log(`rotated ${name} (${Math.round((res.bytesArchived ?? 0) / 1_048_576)} MB archived to ${name}.1)`);
+    } else if (res.error) {
+      log(`could not rotate ${name}: ${res.error}`);
+    }
+  }
 
   const sweptTempDirs = sweepStaleAudioTemp();
   if (sweptTempDirs > 0) {

--- a/packages/cli/src/gateway/log-rotate.ts
+++ b/packages/cli/src/gateway/log-rotate.ts
@@ -1,0 +1,74 @@
+/**
+ * Size-bounded rotation for the gateway's launchd-owned stdout/stderr.
+ *
+ * `StandardOutPath` / `StandardErrorPath` are opened by launchd and never
+ * trimmed, so those files only ever grow. One socket-churn episode wrote
+ * 1,204,328 rate-limit warnings into `gateway.err.log` — 151 MB, 96.7% of it a
+ * single repeated line. Beyond the disk cost, a file that size is impractical
+ * to investigate, which is the opposite of what a log is for.
+ *
+ * COPY-then-TRUNCATE, never rename. launchd holds the descriptor: a renamed
+ * file keeps receiving writes and the live path stays empty forever, so the
+ * rotation would silently redirect the log into an archive nobody reads.
+ * Truncating under the held descriptor is safe because launchd opens with
+ * O_APPEND — every write seeks to the current end, so writes resume at offset
+ * 0 rather than leaving a sparse hole (verified empirically before this was
+ * written).
+ *
+ * There is a small race: anything written between the copy and the truncate is
+ * lost. That is the standard copytruncate trade and the right one here — the
+ * alternative needs the writer to reopen, which we do not control.
+ */
+import * as fs from "node:fs";
+
+export interface RotateOptions {
+  /** Rotate once the file exceeds this. */
+  maxBytes: number;
+  /** How many archives to retain (`.1` … `.keep`). */
+  keep: number;
+}
+
+export interface RotateResult {
+  rotated: boolean;
+  /** Bytes moved into `.1`, when rotation happened. */
+  bytesArchived?: number;
+  /** Why rotation was skipped, when it failed. Never thrown at the caller. */
+  error?: string;
+}
+
+/**
+ * Rotate `file` when it exceeds `maxBytes`. Best-effort by contract: a log
+ * that cannot be rotated must never stop the gateway from starting, so every
+ * failure is reported in the result instead of thrown.
+ */
+export function rotateLogIfLarge(
+  file: string,
+  opts: RotateOptions,
+): RotateResult {
+  let size: number;
+  try {
+    size = fs.statSync(file).size;
+  } catch {
+    return { rotated: false }; // absent — nothing to rotate, not an error
+  }
+  if (size <= opts.maxBytes) return { rotated: false };
+
+  try {
+    // Shift generations from the oldest down, so nothing is overwritten while
+    // it is still needed: .2 -> .3, .1 -> .2, and drop whatever falls past keep.
+    for (let gen = opts.keep; gen >= 1; gen--) {
+      const from = `${file}.${gen}`;
+      if (!fs.existsSync(from)) continue;
+      if (gen === opts.keep) {
+        fs.rmSync(from, { force: true });
+      } else {
+        fs.renameSync(from, `${file}.${gen + 1}`);
+      }
+    }
+    fs.copyFileSync(file, `${file}.1`);
+    fs.truncateSync(file, 0);
+    return { rotated: true, bytesArchived: size };
+  } catch (err) {
+    return { rotated: false, error: (err as Error).message };
+  }
+}

--- a/packages/cli/test/log-rotate.test.ts
+++ b/packages/cli/test/log-rotate.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/**
+ * The gateway's stdout/stderr are opened by launchd (StandardOutPath /
+ * StandardErrorPath) and never rotated. One socket-churn episode wrote
+ * 1,204,328 rate-limit warnings into gateway.err.log — 151 MB, 96.7% of it a
+ * single repeated line. Nothing trims it, so the file only ever grows, and at
+ * that size it is also impractical to investigate.
+ *
+ * Rotation must COPY-then-TRUNCATE, never rename: launchd holds the fd, so a
+ * renamed file keeps receiving writes and the live path stays empty forever.
+ * Truncating under the held descriptor is safe because launchd opens with
+ * O_APPEND — each write seeks to the current end, so writes resume at 0
+ * (verified empirically before this was written).
+ */
+describe("rotateLogIfLarge", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-logrot-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const write = (name: string, bytes: number) => {
+    const p = path.join(dir, name);
+    fs.writeFileSync(p, "x".repeat(bytes));
+    return p;
+  };
+
+  it("leaves a file under the threshold alone", async () => {
+    const { rotateLogIfLarge } = await import("../src/gateway/log-rotate");
+    const p = write("a.log", 100);
+    const res = rotateLogIfLarge(p, { maxBytes: 1000, keep: 2 });
+    assert.equal(res.rotated, false);
+    assert.equal(fs.readdirSync(dir).length, 1);
+    assert.equal(fs.statSync(p).size, 100);
+  });
+
+  it("is a no-op for a missing file", async () => {
+    const { rotateLogIfLarge } = await import("../src/gateway/log-rotate");
+    const res = rotateLogIfLarge(path.join(dir, "nope.log"), { maxBytes: 1, keep: 2 });
+    assert.equal(res.rotated, false);
+  });
+
+  it("archives the content and empties the live file IN PLACE", async () => {
+    const { rotateLogIfLarge } = await import("../src/gateway/log-rotate");
+    const p = write("a.log", 5000);
+    const inodeBefore = fs.statSync(p).ino;
+
+    const res = rotateLogIfLarge(p, { maxBytes: 1000, keep: 2 });
+
+    assert.equal(res.rotated, true);
+    assert.equal(res.bytesArchived, 5000);
+    assert.equal(fs.statSync(p).size, 0, "live file must be emptied");
+    assert.equal(
+      fs.statSync(p).ino,
+      inodeBefore,
+      "the live path must keep its inode — launchd's fd points at it",
+    );
+    assert.equal(fs.statSync(`${p}.1`).size, 5000, "content must survive in .1");
+  });
+
+  // The holder keeps writing through the rotation; nothing may be redirected
+  // away from the path launchd opened.
+  it("a writer holding the descriptor keeps landing in the live file", async () => {
+    const { rotateLogIfLarge } = await import("../src/gateway/log-rotate");
+    const p = path.join(dir, "a.log");
+    const fd = fs.openSync(p, "a");
+    try {
+      fs.writeSync(fd, "o".repeat(5000));
+      rotateLogIfLarge(p, { maxBytes: 1000, keep: 2 });
+      fs.writeSync(fd, "new");
+      assert.equal(fs.readFileSync(p, "utf8"), "new", "post-rotation writes land at offset 0");
+    } finally {
+      fs.closeSync(fd);
+    }
+  });
+
+  it("shifts generations and drops the oldest beyond keep", async () => {
+    const { rotateLogIfLarge } = await import("../src/gateway/log-rotate");
+    const p = path.join(dir, "a.log");
+    for (const gen of ["first", "second", "third"]) {
+      fs.writeFileSync(p, gen.repeat(500));
+      rotateLogIfLarge(p, { maxBytes: 100, keep: 2 });
+    }
+    assert.ok(fs.readFileSync(`${p}.1`, "utf8").startsWith("third"));
+    assert.ok(fs.readFileSync(`${p}.2`, "utf8").startsWith("second"));
+    assert.equal(fs.existsSync(`${p}.3`), false, "keep=2 must not retain a third archive");
+  });
+
+  it("never throws — a log that cannot be rotated must not stop the gateway", async () => {
+    const { rotateLogIfLarge } = await import("../src/gateway/log-rotate");
+    const p = write("a.log", 5000);
+    fs.chmodSync(dir, 0o500); // archive cannot be created
+    try {
+      const res = rotateLogIfLarge(p, { maxBytes: 1000, keep: 2 });
+      assert.equal(res.rotated, false);
+      assert.ok(res.error, "the reason must be reported, not swallowed");
+    } finally {
+      fs.chmodSync(dir, 0o700);
+    }
+  });
+});


### PR DESCRIPTION
Follow-up to the socket-churn investigation. This fixes the part that is **actually actionable today**; it deliberately does not touch the churn itself.

## What the investigation found

`gateway.err.log` had reached **151 MB / 1,244,987 lines**. The composition:

| Line | Count | Share |
|---|---|---|
| `A rate limit was exceeded (url: .../apps.connections.open, retry-after: 10)` | **1,204,328** | 96.7% |
| `A pong wasn't received from the server before the timeout of 5000ms!` | 461 | — |

The chain: pong timeout → socket-mode reconnects → hammers `apps.connections.open` → Slack rate-limits → the client retries in a tight loop, apparently ignoring `retry-after`. Roughly **2,600 rate-limit hits per pong timeout**. `gateway.out.log` shows the shape from the other side — one run of **275 consecutive `connected` with no `disconnected`**, another of 175.

The crash guard and watchdog absorbed it: three months, four `crash-recovery` events, one watchdog self-termination.

## Why this PR is only about rotation

The churn has been **dormant since 2026-07-30** — `gateway.err.log` has not grown since, verified through today's heavy usage with the live process's fd 2 still pointing at it. Nothing socket-related shipped that day, so the trigger was most likely environmental; that is not established.

It cannot currently be reproduced, and the runaway retry is inside `@slack/socket-mode`. Changing reconnect behaviour now would be a guess I could not verify, and could disturb the client's own state machine. Rotation is what makes a recurrence **investigable** rather than a 151 MB file nobody can grep.

## The implementation

**COPY-then-TRUNCATE, never rename.** launchd holds the descriptor — a renamed file keeps receiving writes while the live path stays empty forever, so a rename would silently redirect the log into an archive nobody reads.

Truncating under the held descriptor is safe because launchd opens with `O_APPEND`: writes seek to the current end, so they resume at offset 0 rather than leaving a sparse hole. **Verified empirically before the implementation was written**, and pinned by a test that keeps writing through the rotation:

```
before truncate : 1000 bytes
after  truncate : 10 bytes
VERDICT: safe — writes resumed at 0
```

Runs at startup — the only moment nothing of this run has been written, so the copytruncate race costs nothing. 32 MB threshold, two archives kept. Best-effort by contract: a log that cannot be rotated reports the reason and never blocks startup.

## Tests

Six cases pinning behaviour rather than mechanism: under threshold, missing file, **inode preserved** (launchd's fd must stay valid), a holder writing through the rotation, generation shifting with the oldest dropped, and never-throws-on-failure.

**1,246 tests pass, 0 fail** across all six workspaces.

## Test plan

- [ ] `npm test --workspaces --if-present` green (done locally: 1,246/1,246)
- [ ] Deploy, restart the gateway, confirm the log line `rotated gateway.err.log (144 MB archived to gateway.err.log.1)`
- [ ] Confirm the daemon keeps writing to the live `gateway.err.log` afterwards (not to `.1`)
- [ ] Confirm `~/.pmk/logs` shrinks on the following rotation as `.2` is dropped