### PR TITLE
refactor(gateway): extract the pre-claim review guards from runOne

### DIFF
--- a/packages/cli/src/gateway/slack/review-target.ts
+++ b/packages/cli/src/gateway/slack/review-target.ts
@@ -1,0 +1,119 @@
+/**
+ * The pre-claim decision: may this PR be reviewed at all, and against what?
+ *
+ * Six guards run in order — workspace membership, GitHub slug, PR head, the
+ * approve-time head authorisation, the repo allowlist, and repo visibility.
+ * Two of them are containment controls rather than conveniences: the allowlist,
+ * and the refusal to review a public repo (which would publish internal
+ * analysis into a public PR).
+ *
+ * Extracted from `runOne`, where these 68 lines sat inside 320 alongside the
+ * claim, the progress bar, the workspace clone and the mra backend — so
+ * exercising a single guard meant driving all of it. They belong together and
+ * apart from that: the decision needs only the gateway and the request, holds
+ * no state, and every outcome is a value.
+ *
+ * All of this happens BEFORE a claim is taken, so a refused PR never burns one.
+ * The order matters for the same reason: the allowlist is a local check, the
+ * visibility probe is a network round trip, so the cheap refusal goes first.
+ */
+import type { PrRef } from "../pr-ref";
+
+/** Just enough of the gateway to decide. Keeps the seam small and injectable. */
+export interface ReviewTargetGateway {
+  resolveProjectByRemote: (workspace: string, slug: string) => string | undefined;
+  resolveRepoSlug: (workspace: string, project: string) => Promise<string | undefined>;
+  getPrHead: (args: { slug: string; pr: number; token?: string }) => Promise<
+    { sha: string; baseRef: string; updatedAt?: string } | undefined
+  >;
+  repoVisibility: (args: { slug: string; token?: string }) => Promise<string>;
+}
+
+export interface ReviewTargetContext {
+  workspace: string;
+  review: { repoAllowlist?: string[]; allowPublicRepos?: boolean };
+  token?: string;
+  /**
+   * Head SHAs an admin authorised at approve time, keyed `owner/repo#number`.
+   * Present only on the approve path.
+   */
+  authorizedHeads?: Map<string, string>;
+}
+
+export type ReviewTarget =
+  | {
+      ok: true;
+      project: string;
+      slug: string;
+      head: { sha: string; baseRef: string; updatedAt?: string };
+    }
+  | { ok: false; reason: string; message: string };
+
+export async function resolveReviewTarget(
+  ref: PrRef,
+  ctx: ReviewTargetContext,
+  gateway: ReviewTargetGateway,
+): Promise<ReviewTarget> {
+  const slugDisplay = `${ref.owner}/${ref.repo}`;
+
+  const project = gateway.resolveProjectByRemote(ctx.workspace, slugDisplay);
+  if (!project) {
+    return {
+      ok: false,
+      reason: "not-in-workspace",
+      message: `:information_source: \`${slugDisplay}\` 不在 mra workspace，略過 PR #${ref.number}`,
+    };
+  }
+
+  const slug = await gateway.resolveRepoSlug(ctx.workspace, project);
+  if (!slug) {
+    return {
+      ok: false,
+      reason: "slug",
+      message: `:warning: 無法從 \`${project}\` 推出 GitHub slug，略過 PR #${ref.number}`,
+    };
+  }
+
+  const head = await gateway.getPrHead({ slug, pr: ref.number, token: ctx.token });
+  if (!head) {
+    return {
+      ok: false,
+      reason: "pr-head",
+      message: `:warning: 取不到 PR #${ref.number} 的 head，略過`,
+    };
+  }
+
+  // The approve path authorised ONE commit. A newer one means the admin would
+  // be approving code nobody reviewed.
+  const authorizedHead = ctx.authorizedHeads?.get(`${ref.owner}/${ref.repo}#${ref.number}`);
+  if (authorizedHead && authorizedHead !== head.sha) {
+    return {
+      ok: false,
+      reason: "approval-head-changed",
+      message: `:warning: PR #${ref.number} 在 approve 授權後已有新 commit；未 approve，請重新執行 :cr:。`,
+    };
+  }
+
+  if (ctx.review.repoAllowlist && !ctx.review.repoAllowlist.includes(slug)) {
+    return {
+      ok: false,
+      reason: "allowlist",
+      message: `:no_entry: \`${slug}\` 不在 review allowlist，略過 PR #${ref.number}`,
+    };
+  }
+
+  if (!ctx.review.allowPublicRepos) {
+    const vis = await gateway.repoVisibility({ slug, token: ctx.token });
+    // Anything that is not positively private fails closed — "unknown" is not
+    // permission to publish internal analysis.
+    if (vis !== "private") {
+      return {
+        ok: false,
+        reason: "public-repo",
+        message: `:no_entry: \`${slug}\` 為 public（或無法判定），略過 PR #${ref.number} 以免外洩`,
+      };
+    }
+  }
+
+  return { ok: true, project, slug, head };
+}

--- a/packages/cli/src/gateway/slack/review.ts
+++ b/packages/cli/src/gateway/slack/review.ts
@@ -70,6 +70,7 @@ import {
 // Imported for internal use, and re-exported so slack/index.ts and the review
 // tests keep importing them from "./review" unchanged.
 import { isReviewRequest, isApproveRequest } from "./review-requests";
+import { resolveReviewTarget } from "./review-target";
 export {
   isReviewRequest,
   isApproveRequest,
@@ -922,53 +923,15 @@ export class ReviewCoordinator {
       else await this.reply(ctx.channelId, ctx.threadTs, msg);
     };
 
-    const project = gateway.resolveProjectByRemote(ctx.workspace, slugDisplay);
-    if (!project) {
-      await skip(
-        "not-in-workspace",
-        `:information_source: \`${slugDisplay}\` 不在 mra workspace，略過 PR #${ref.number}`,
-      );
+    // Every pre-claim guard (workspace, slug, head, approve-head authorisation,
+    // allowlist, visibility) lives in resolveReviewTarget. Refusals never reach
+    // a claim, so a rejected PR does not burn one.
+    const target = await resolveReviewTarget(ref, ctx, gateway);
+    if (!target.ok) {
+      await skip(target.reason, target.message);
       return;
     }
-
-    const slug = await gateway.resolveRepoSlug(ctx.workspace, project);
-    if (!slug) {
-      await skip(
-        "slug",
-        `:warning: 無法從 \`${project}\` 推出 GitHub slug，略過 PR #${ref.number}`,
-      );
-      return;
-    }
-
-    const head = await gateway.getPrHead({ slug, pr: ref.number, token: ctx.token });
-    if (!head) {
-      await skip("pr-head", `:warning: 取不到 PR #${ref.number} 的 head，略過`);
-      return;
-    }
-    const authorizedHead = ctx.authorizedHeads?.get(`${ref.owner}/${ref.repo}#${ref.number}`);
-    if (authorizedHead && authorizedHead !== head.sha) {
-      await skip("approval-head-changed", `:warning: PR #${ref.number} 在 approve 授權後已有新 commit；未 approve，請重新執行 :cr:。`);
-      return;
-    }
-
-    // public-repo / allowlist guard (checked BEFORE claim to avoid wasted claims)
-    if (ctx.review.repoAllowlist && !ctx.review.repoAllowlist.includes(slug)) {
-      await skip(
-        "allowlist",
-        `:no_entry: \`${slug}\` 不在 review allowlist，略過 PR #${ref.number}`,
-      );
-      return;
-    }
-    if (!ctx.review.allowPublicRepos) {
-      const vis = await gateway.repoVisibility({ slug, token: ctx.token });
-      if (vis !== "private") {
-        await skip(
-          "public-repo",
-          `:no_entry: \`${slug}\` 為 public（或無法判定），略過 PR #${ref.number} 以免外洩`,
-        );
-        return;
-      }
-    }
+    const { project, slug, head } = target;
 
     const slugParts = slug.split("/");
     const [slugOwner, slugRepo] =

--- a/packages/cli/test/review-target.test.ts
+++ b/packages/cli/test/review-target.test.ts
@@ -1,0 +1,143 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import { resolveReviewTarget } from "../src/gateway/slack/review-target";
+
+/**
+ * These six guards decide whether a PR may be reviewed AT ALL, and two of them
+ * are containment controls: the allowlist, and the refusal to review a public
+ * repo (which would leak internal analysis into a public PR). They lived inside
+ * runOne's 320 lines, so exercising them meant driving the whole coordinator —
+ * claims, progress bar, workspace clone and mra backend included. Extracted so
+ * the decision can be tested as a decision.
+ */
+const ref = { owner: "o", repo: "r", number: 7, url: "https://github.com/o/r/pull/7" };
+
+const head = { sha: "a".repeat(40), baseRef: "main", updatedAt: "2026-08-01T00:00:00Z" };
+
+function gw(over: Record<string, unknown> = {}) {
+  return {
+    resolveProjectByRemote: () => "proj",
+    resolveRepoSlug: async () => "o/r",
+    getPrHead: async () => head,
+    repoVisibility: async () => "private",
+    ...over,
+  } as never;
+}
+
+const ctx = (over: Record<string, unknown> = {}) =>
+  ({
+    workspace: "/ws",
+    review: { allowPublicRepos: false },
+    token: "t",
+    ...over,
+  }) as never;
+
+describe("resolveReviewTarget", () => {
+  it("returns the resolved target when every guard passes", async () => {
+    const res = await resolveReviewTarget(ref, ctx(), gw());
+    assert.equal(res.ok, true);
+    if (res.ok) {
+      assert.equal(res.project, "proj");
+      assert.equal(res.slug, "o/r");
+      assert.equal(res.head.sha, head.sha);
+    }
+  });
+
+  it("refuses a repo that is not in the mra workspace", async () => {
+    const res = await resolveReviewTarget(ref, ctx(), gw({ resolveProjectByRemote: () => undefined }));
+    assert.equal(res.ok, false);
+    if (!res.ok) {
+      assert.equal(res.reason, "not-in-workspace");
+      assert.match(res.message, /不在 mra workspace/);
+    }
+  });
+
+  it("refuses when the GitHub slug cannot be derived", async () => {
+    const res = await resolveReviewTarget(ref, ctx(), gw({ resolveRepoSlug: async () => undefined }));
+    assert.equal(res.ok, false);
+    if (!res.ok) assert.equal(res.reason, "slug");
+  });
+
+  it("refuses when the PR head is unreadable", async () => {
+    const res = await resolveReviewTarget(ref, ctx(), gw({ getPrHead: async () => undefined }));
+    assert.equal(res.ok, false);
+    if (!res.ok) assert.equal(res.reason, "pr-head");
+  });
+
+  // An approve authorised one commit. If a new one landed since, the approve
+  // must not silently apply to code nobody reviewed.
+  it("refuses when a new commit landed after the approve authorisation", async () => {
+    const res = await resolveReviewTarget(
+      ref,
+      ctx({ authorizedHeads: new Map([["o/r#7", "b".repeat(40)]]) }),
+      gw(),
+    );
+    assert.equal(res.ok, false);
+    if (!res.ok) {
+      assert.equal(res.reason, "approval-head-changed");
+      assert.match(res.message, /未 approve/);
+    }
+  });
+
+  it("accepts when the authorised head still matches", async () => {
+    const res = await resolveReviewTarget(
+      ref,
+      ctx({ authorizedHeads: new Map([["o/r#7", head.sha]]) }),
+      gw(),
+    );
+    assert.equal(res.ok, true);
+  });
+
+  it("refuses a repo outside the allowlist", async () => {
+    const res = await resolveReviewTarget(
+      ref,
+      ctx({ review: { allowPublicRepos: false, repoAllowlist: ["other/repo"] } }),
+      gw(),
+    );
+    assert.equal(res.ok, false);
+    if (!res.ok) assert.equal(res.reason, "allowlist");
+  });
+
+  // Containment: reviewing a public repo would publish internal analysis.
+  // "unknown" must fail closed alongside "public".
+  for (const vis of ["public", "unknown"]) {
+    it(`refuses a ${vis} repo when allowPublicRepos is off`, async () => {
+      const res = await resolveReviewTarget(ref, ctx(), gw({ repoVisibility: async () => vis }));
+      assert.equal(res.ok, false);
+      if (!res.ok) assert.equal(res.reason, "public-repo");
+    });
+  }
+
+  it("skips the visibility probe entirely when allowPublicRepos is on", async () => {
+    let probed = false;
+    const res = await resolveReviewTarget(
+      ref,
+      ctx({ review: { allowPublicRepos: true } }),
+      gw({
+        repoVisibility: async () => {
+          probed = true;
+          return "public";
+        },
+      }),
+    );
+    assert.equal(res.ok, true);
+    assert.equal(probed, false, "no probe should be issued when the guard is disabled");
+  });
+
+  // Ordering is load-bearing: both containment guards must be settled before a
+  // claim is taken, so a refused PR never burns one.
+  it("checks the allowlist before spending a visibility probe", async () => {
+    let probed = false;
+    await resolveReviewTarget(
+      ref,
+      ctx({ review: { allowPublicRepos: false, repoAllowlist: ["other/repo"] } }),
+      gw({
+        repoVisibility: async () => {
+          probed = true;
+          return "private";
+        },
+      }),
+    );
+    assert.equal(probed, false);
+  });
+});


### PR DESCRIPTION
First slice of the `runOne` decomposition (item 6 of the original audit). Pure refactor — no behaviour change.

## Why this slice first

`runOne` is 320 lines against a 50-line guideline, and **every review and every approve flows through it**. It is the highest-risk function in the repo, so it gets taken apart in coherent pieces rather than in one pass.

Its first 68 lines are a self-contained decision — *may this PR be reviewed at all, and against what* — made of six ordered guards:

| # | Guard | Refusal |
|---|---|---|
| 1 | in the mra workspace | `not-in-workspace` |
| 2 | GitHub slug derivable | `slug` |
| 3 | PR head readable | `pr-head` |
| 4 | head matches the approve authorisation | `approval-head-changed` |
| 5 | repo allowlist | `allowlist` |
| 6 | repo visibility | `public-repo` |

**Two of these are containment controls, not conveniences**: the allowlist, and the refusal to review a public repo (which would publish internal analysis into a public PR). Testing either meant driving the whole coordinator — claim, progress bar, workspace clone, mra backend — so in practice they were only ever exercised end to end.

They also share a property that makes them separable: the decision needs only the gateway and the request, holds no state, and every outcome is a value.

## What changed

Moved to `review-target.ts` behind a narrow injectable gateway interface. The caller turns a refusal into the same `skip(reason, message)` it always did.

**Messages and ordering are unchanged byte for byte** — including that the allowlist (a local check) is evaluated before the visibility probe (a network round trip), so a cheap refusal stays cheap, and that everything runs *before* a claim is taken so a refused PR never burns one.

## Tests

11 new cases covering the decision directly, including three that pin properties easy to lose in a refactor:

- no visibility probe is issued when `allowPublicRepos` is on
- no visibility probe is issued when the allowlist already refused
- `unknown` visibility fails closed alongside `public`

**1,257 tests pass, 0 fail** across all six workspaces.

## On the line count

`runOne` 320 → 282. That is a modest reduction and it is **not the point** — the extracted module carries its own types and documentation, so the net saving is 38 lines. The win is that six security-relevant guards are now testable as a decision instead of as a side effect of a full review run.

## Remaining phases (not in this PR)

| Phase | Lines | Note |
|---|---|---|
| B — concurrency + claim | ~15 | touches `this.inFlight` instance state |
| C — workspace prep + progress | ~65 | |
| D — backend invoke | ~47 | |
| E — finalize | ~33 | |
| F — catch/finally | ~12 | |

C–F share `progress` / `posted` / `claimRef` and are genuinely entangled; they need their own design pass rather than a mechanical move.

## Test plan

- [ ] `npm test --workspaces --if-present` green (done locally: 1,257/1,257)
- [ ] Live: `:cr:` a PR in the workspace still reviews normally
- [ ] Live: `:cr:` a repo not in the mra workspace still says "不在 mra workspace"