### PR TITLE
refactor(gateway): extract review admission, and name the limit that fired

### DIFF
--- a/packages/cli/src/gateway/slack/review-admission.ts
+++ b/packages/cli/src/gateway/slack/review-admission.ts
@@ -1,0 +1,87 @@
+/**
+ * Whether a review may START right now, given what is already running.
+ *
+ * Three independent limits: total concurrency, per-actor concurrency, and
+ * one-review-per-repo (a repo has a single review workspace, so two at once
+ * would collide). They were a single `||` chain inside `runOne`, reachable
+ * only by driving the coordinator with a populated in-flight set — so which
+ * limit fired was never asserted anywhere.
+ *
+ * The decision is pure: a snapshot of what is in flight plus the request. It
+ * takes an iterable rather than the coordinator's Set so it never sees, and
+ * cannot touch, the live collection.
+ */
+
+/** The in-flight facts admission needs. Deliberately narrower than InFlightReview. */
+export interface InFlightSnapshot {
+  actorUserId: string;
+  projectKey: string;
+}
+
+export type AdmissionRefusal =
+  | { limit: "global"; active: number; max: number }
+  | { limit: "per-user"; active: number; max: number }
+  | { limit: "same-repo"; projectKey: string };
+
+export interface AdmissionRequest {
+  actorUserId: string;
+  projectKey: string;
+  maxConcurrent: number;
+  maxConcurrentPerUser: number;
+}
+
+/**
+ * The reason this review may not start, or undefined to admit it.
+ *
+ * Order matches the original short-circuit — global, then per-actor, then
+ * per-repo — so when several apply the reported cause stays the outermost one.
+ */
+export function admissionRefusal(
+  inFlight: Iterable<InFlightSnapshot>,
+  req: AdmissionRequest,
+): AdmissionRefusal | undefined {
+  const running = [...inFlight];
+
+  if (running.length >= req.maxConcurrent) {
+    return { limit: "global", active: running.length, max: req.maxConcurrent };
+  }
+
+  const byActor = running.filter((r) => r.actorUserId === req.actorUserId).length;
+  if (byActor >= req.maxConcurrentPerUser) {
+    return { limit: "per-user", active: byActor, max: req.maxConcurrentPerUser };
+  }
+
+  if (running.some((r) => r.projectKey === req.projectKey)) {
+    return { limit: "same-repo", projectKey: req.projectKey };
+  }
+
+  return undefined;
+}
+
+/**
+ * What to tell the user.
+ *
+ * The previous text named all three causes joined by "或", whichever one had
+ * actually fired — so someone blocked by their own still-running review of the
+ * same repo was told the system was busy, and waited on the wrong thing. The
+ * caller already knows which limit it was; saying so costs nothing.
+ */
+export function admissionRefusalMessage(refusal: AdmissionRefusal): string {
+  switch (refusal.limit) {
+    case "global":
+      return (
+        `:hourglass: 目前有 ${refusal.active} 個 review 正在執行（上限 ${refusal.max}），` +
+        "請稍後重試。"
+      );
+    case "per-user":
+      return (
+        `:hourglass: 你已經有 ${refusal.active} 個 review 正在執行（每人上限 ${refusal.max}），` +
+        "請等其中一個完成後再發。"
+      );
+    case "same-repo":
+      return (
+        `:hourglass: \`${refusal.projectKey}\` 已經有一個 review 正在執行，` +
+        "同一個 repo 一次只能跑一個；請等它完成後再發。"
+      );
+  }
+}

--- a/packages/cli/src/gateway/slack/review.ts
+++ b/packages/cli/src/gateway/slack/review.ts
@@ -71,6 +71,7 @@ import {
 // tests keep importing them from "./review" unchanged.
 import { isReviewRequest, isApproveRequest } from "./review-requests";
 import { resolveReviewTarget } from "./review-target";
+import { admissionRefusal, admissionRefusalMessage } from "./review-admission";
 export {
   isReviewRequest,
   isApproveRequest,
@@ -950,9 +951,16 @@ export class ReviewCoordinator {
       intent: isApprove ? "approve" as const : "review" as const,
     };
     const projectKey = `${slugOwner}/${slugRepo}`;
-    const actorActive = [...this.inFlight].filter((r) => r.actorUserId === ctx.reactorUserId).length;
-    if (this.inFlight.size >= ctx.review.maxConcurrent || actorActive >= ctx.review.maxConcurrentPerUser || [...this.inFlight].some((r) => r.projectKey === projectKey)) {
-      await skip("busy", `:hourglass: review 目前已達併發上限，或同一 repo 正在 review；請稍後重試。`);
+    // Which of the three limits fired is decided in review-admission, so the
+    // reply can name it instead of listing all three joined by "或".
+    const refusal = admissionRefusal(this.inFlight, {
+      actorUserId: ctx.reactorUserId,
+      projectKey,
+      maxConcurrent: ctx.review.maxConcurrent,
+      maxConcurrentPerUser: ctx.review.maxConcurrentPerUser,
+    });
+    if (refusal) {
+      await skip("busy", admissionRefusalMessage(refusal));
       return;
     }
     const claimed = ctx.forceRerun ? forceClaimReview(claimRef) : claimReview(claimRef);

--- a/packages/cli/test/review-admission.test.ts
+++ b/packages/cli/test/review-admission.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import {
+  admissionRefusal,
+  admissionRefusalMessage,
+} from "../src/gateway/slack/review-admission";
+
+/**
+ * Three independent limits guard a review start: total concurrency, per-actor
+ * concurrency, and one-review-per-repo. They were a single `||` chain inside
+ * runOne, reachable only by driving the coordinator with a populated in-flight
+ * set — so which limit fired was never asserted anywhere, and the user was told
+ * "已達併發上限，或同一 repo 正在 review" for all three. The code knew; the
+ * message did not.
+ */
+const entry = (actorUserId: string, projectKey: string) => ({ actorUserId, projectKey });
+const limits = { maxConcurrent: 3, maxConcurrentPerUser: 2 };
+
+describe("admissionRefusal", () => {
+  it("admits when nothing is in flight", () => {
+    assert.equal(
+      admissionRefusal([], { actorUserId: "U1", projectKey: "o/r", ...limits }),
+      undefined,
+    );
+  });
+
+  it("admits below every limit", () => {
+    const inFlight = [entry("U2", "o/other")];
+    assert.equal(
+      admissionRefusal(inFlight, { actorUserId: "U1", projectKey: "o/r", ...limits }),
+      undefined,
+    );
+  });
+
+  it("refuses on the global limit", () => {
+    const inFlight = [entry("U2", "a/a"), entry("U3", "b/b"), entry("U4", "c/c")];
+    const res = admissionRefusal(inFlight, { actorUserId: "U1", projectKey: "o/r", ...limits });
+    assert.equal(res?.limit, "global");
+    if (res?.limit === "global") {
+      assert.equal(res.active, 3);
+      assert.equal(res.max, 3);
+    }
+  });
+
+  it("refuses on the per-actor limit while the global limit still has room", () => {
+    const inFlight = [entry("U1", "a/a"), entry("U1", "b/b")];
+    const res = admissionRefusal(inFlight, { actorUserId: "U1", projectKey: "o/r", ...limits });
+    assert.equal(res?.limit, "per-user");
+    if (res?.limit === "per-user") assert.equal(res.active, 2);
+  });
+
+  it("counts only the asking actor toward the per-actor limit", () => {
+    const inFlight = [entry("U9", "a/a"), entry("U9", "b/b")];
+    const res = admissionRefusal(inFlight, { actorUserId: "U1", projectKey: "o/r", ...limits });
+    assert.equal(res, undefined, "another user's reviews must not block this one");
+  });
+
+  it("refuses a second review of the same repo", () => {
+    const inFlight = [entry("U9", "o/r")];
+    const res = admissionRefusal(inFlight, { actorUserId: "U1", projectKey: "o/r", ...limits });
+    assert.equal(res?.limit, "same-repo");
+    if (res?.limit === "same-repo") assert.equal(res.projectKey, "o/r");
+  });
+
+  // Preserves the original short-circuit order, so the reported cause stays
+  // the outermost one when several apply at once.
+  it("reports the global limit first when several limits apply", () => {
+    const inFlight = [entry("U1", "o/r"), entry("U1", "b/b"), entry("U5", "c/c")];
+    const res = admissionRefusal(inFlight, { actorUserId: "U1", projectKey: "o/r", ...limits });
+    assert.equal(res?.limit, "global");
+  });
+});
+
+describe("admissionRefusalMessage", () => {
+  // The old text named all three causes with "或" regardless of which fired.
+  // A user hitting the per-repo limit was told the system was busy, when in
+  // fact their own earlier review was still running on that repo.
+  it("names the actual cause, and each cause reads differently", () => {
+    const texts = [
+      admissionRefusalMessage({ limit: "global", active: 3, max: 3 }),
+      admissionRefusalMessage({ limit: "per-user", active: 2, max: 2 }),
+      admissionRefusalMessage({ limit: "same-repo", projectKey: "o/r" }),
+    ];
+    assert.equal(new Set(texts).size, 3, "each cause must produce distinct text");
+    for (const t of texts) assert.ok(t.length > 0);
+  });
+
+  it("names the repo when the repo is the reason", () => {
+    assert.match(
+      admissionRefusalMessage({ limit: "same-repo", projectKey: "onead/erp" }),
+      /onead\/erp/,
+    );
+  });
+
+  it("shows the limit that was reached", () => {
+    assert.match(admissionRefusalMessage({ limit: "global", active: 3, max: 3 }), /3/);
+    assert.match(admissionRefusalMessage({ limit: "per-user", active: 2, max: 2 }), /2/);
+  });
+});

--- a/packages/cli/test/review-coordinator.test.ts
+++ b/packages/cli/test/review-coordinator.test.ts
@@ -1618,7 +1618,15 @@ describe("ReviewCoordinator project concurrency", () => {
     await new Promise((resolve) => setImmediate(resolve));
     await c.fromMessage({ channelId: "C1", threadTs: "1.2", userId: "U1", text: ":cr: https://github.com/onead/OnePixel/pull/13" });
     assert.equal(calls, 1);
-    assert.ok(web.posted.some((p) => /同一 repo 正在 review|併發上限/.test(p.text ?? "")));
+    // Asserts the CAUSE, not just that something was refused. The previous
+    // assertion allowed either wording because the message itself named all
+    // three limits joined by "或" — a user blocked by their own still-running
+    // review of this repo was told the system was busy. admissionRefusal now
+    // reports which limit fired, so the reply names the repo.
+    assert.ok(
+      web.posted.some((p) => /onead\/OnePixel/.test(p.text ?? "") && /同一個 repo/.test(p.text ?? "")),
+      `expected a same-repo refusal naming the repo, got: ${JSON.stringify(web.posted.map((p) => p.text))}`,
+    );
     release();
     await first;
   });


### PR DESCRIPTION
Phase B of the `runOne` decomposition. **This one is not a pure refactor** — it changes a user-facing message on purpose, called out below.

## The defect this surfaced

Three independent limits guard a review start: total concurrency, per-actor concurrency, and one-review-per-repo. They were a single `||` chain:

```ts
if (this.inFlight.size >= maxConcurrent
    || actorActive >= maxConcurrentPerUser
    || [...this.inFlight].some(r => r.projectKey === projectKey)) {
  await skip("busy", ":hourglass: review 目前已達併發上限，或同一 repo 正在 review；請稍後重試。");
}
```

The code knew which limit fired. The message did not — it listed all three joined by 「或」 every time. Someone blocked by **their own still-running review of that repo** was told the system was busy, and waited on the wrong thing.

That the message had to be ambiguous shows up in the existing test, which asserted it with an alternation:

```ts
assert.ok(web.posted.some((p) => /同一 repo 正在 review|併發上限/.test(p.text ?? "")));
```

It could not assert the cause, because the message did not carry one.

## What changed

- `admissionRefusal()` returns **which** limit fired, as a value, over an iterable snapshot rather than the coordinator's live `Set`
- `admissionRefusalMessage()` names it — count and cap for the two concurrency limits, the repo for the per-repo one
- the original short-circuit order is preserved, so when several apply the reported cause stays the outermost one

**Deliberate behaviour change**: the refusal text now differs per cause. The coordinator test is updated to assert the actual cause and that the repo is named — a stronger contract than it could previously express.

| Cause | Before | After |
|---|---|---|
| global | 已達併發上限，或同一 repo 正在 review | 目前有 3 個 review 正在執行（上限 3） |
| per-user | *(same text)* | 你已經有 2 個 review 正在執行（每人上限 2） |
| same-repo | *(same text)* | `onead/erp` 已經有一個 review 正在執行，同一個 repo 一次只能跑一個 |

## Honest accounting on size

**`runOne` goes 282 → 289 lines. This slice does not shrink it.** The call site is more verbose than the one-line `if` it replaced.

The value is elsewhere: 10 tests over a decision that had none, and a reply that tells the user what to actually wait for. If the goal were only line count, this slice would not be worth doing — the goal is that each piece of `runOne` becomes something you can reason about and test on its own.

## Tests

10 new cases: each limit in isolation, another user's reviews not counting toward your per-actor limit, ordering when several apply, and that the three messages are mutually distinct.

**1,257 tests pass, 0 fail** across all six workspaces.

## Test plan

- [ ] `npm test --workspaces --if-present` green (done locally: 1,257/1,257)
- [ ] Live: fire `:cr:` twice on the same repo in quick succession → the second names the repo, not a generic "busy"