### PR TITLE
test(gateway): guard the approve fences, and drop the runtime import cycle

### DIFF
--- a/packages/cli/src/gateway/authorization-lock.ts
+++ b/packages/cli/src/gateway/authorization-lock.ts
@@ -3,7 +3,7 @@
  * writers and the GitHub-approve POST path (#90 — the #70 release-veto
  * precondition).
  *
- * Why it exists: `publishApprovalReservation` re-validates live policy with
+ * Why it exists: `ApproveFlow.publishReservation` re-validates live policy with
  * a three-phase revision fence before POSTing, but fences are reads — they
  * cannot exclude a writer landing between the last read and the POST. This
  * lock makes them mutually exclusive: while the approve critical section

--- a/packages/cli/src/gateway/review-policy.ts
+++ b/packages/cli/src/gateway/review-policy.ts
@@ -3,7 +3,7 @@ import type { ProtectionExemption } from "./config";
 
 // Release veto — LIFTED (#90, 2026-07-17): config writers
 // (saveGatewayConfig) and the approve POST critical section
-// (publishApprovalReservation) now share the cross-process authorization
+// (ApproveFlow.publishReservation) now share the cross-process authorization
 // lock (gateway/authorization-lock.ts), closing the TOCTOU the veto guarded
 // against. GitHub APPROVE additionally requires the runtime gate
 // `review.approval.enabled` (admin-togglable, default false) plus the
@@ -45,4 +45,44 @@ export function findProtectionExemption(
   slug: string,
 ): ProtectionExemption | undefined {
   return approval.protectionExemptions?.find((e) => e.repo === slug);
+}
+
+/**
+ * The refusal shown when approve preflight finds the repo not approval-ready.
+ *
+ * Two very different situations reach this point and the old single sentence
+ * covered both, leaving the reader nothing to act on — one admin retried the
+ * same `approve` seven times over two hours against an underprotected repo.
+ *
+ * `approvalProtectionReady` returning false already establishes that the two
+ * controls are not both on, so that is the default explanation — it holds even
+ * when the gate probe was never consulted (the flag is off). The probe only
+ * adds one distinction: if it ran and came back unknown, the Rules API is
+ * unreadable, which also makes the `false` above untrustworthy. Say that
+ * instead of naming controls we could not actually observe.
+ *
+ * @param gateStatus probe result; meaningful only when `gateProbed` is true
+ * @param gateProbed whether the gate probe was consulted at all
+ */
+export function protectionNotReadyMessage(
+  slug: string,
+  branch: string,
+  gateStatus: boolean | undefined,
+  gateProbed = false,
+): string {
+  if (gateProbed && gateStatus === undefined) {
+    return (
+      `無法確認 ${slug} 的 \`${branch}\` 保護狀態（Rules API 讀取失敗），` +
+      "為安全起見不予核准。請 repo admin 確認 pmk 的 review 身分是否有讀取權限；" +
+      "在確認之前，請直接在 GitHub 上人工核准。"
+    );
+  }
+  return (
+    `${slug} 的 \`${branch}\` 需要 review 核准，但缺少兩項必要保護：` +
+    "`dismiss_stale_reviews_on_push` 與 `require_last_push_approval`（目前皆為 false）。" +
+    "少了它們，核准後推的新 commit 不會讓核准失效，未經審查的變更就能合併。\n" +
+    "請 repo admin 於 ruleset 開啟這兩項；" +
+    "若需在調整前先行放行，請 PMK admin 將此 repo 加入 `review.approval.protectionExemptions`。" +
+    "在此之前，請直接在 GitHub 上人工核准。"
+  );
 }

--- a/packages/cli/src/gateway/slack/review-approve-flow.ts
+++ b/packages/cli/src/gateway/slack/review-approve-flow.ts
@@ -27,7 +27,7 @@ import { parsePrRefs, type PrRef } from "../pr-ref";
 import { AUTOMATIC_APPROVAL_RELEASE_READY, findProtectionExemption } from "../review-policy";
 import { withAuthorizationLock } from "../authorization-lock";
 import type { ReviewGateway } from "./review";
-import { protectionNotReadyMessage } from "./review";
+import { protectionNotReadyMessage } from "../review-policy";
 
 export interface ApproveFlowDeps {
   gateway: ReviewGateway;
@@ -44,6 +44,14 @@ export interface ApproveFlowDeps {
 export class ApproveFlow {
   constructor(private readonly deps: ApproveFlowDeps) {}
 
+  /**
+   * Public, deliberately: this is the seam the fence tests drive directly
+   * (approve-flow-fences.test.ts). `confirmInThread` is the only production
+   * caller and the guard chain callers must not skip lives there — but the
+   * fences below independently re-check admin, allowlist and approval-enabled,
+   * so a direct call cannot bypass authorisation, only the offer bookkeeping.
+   * The module is internal: no barrel, no package export.
+   */
   async publishReservation(reservation: ApprovalReservation, actorUserId: string): Promise<void> {
     const { gateway } = this.deps;
     let mutationStarted = false;

--- a/packages/cli/src/gateway/slack/review.ts
+++ b/packages/cli/src/gateway/slack/review.ts
@@ -41,6 +41,10 @@ import {
 } from "../../adapters/mra";
 import { effectiveMraReviewStrategy, findProtectionExemption } from "../review-policy";
 export { effectiveMraReviewStrategy } from "../review-policy";
+// protectionNotReadyMessage moved to the leaf review-policy module so
+// review-approve-flow can import it without a runtime cycle back through here.
+// Re-exported so existing importers keep working unchanged.
+export { protectionNotReadyMessage } from "../review-policy";
 import {
   resolveRepoSlug as resolveRepoSlugImpl,
   repoVisibility as repoVisibilityImpl,
@@ -154,45 +158,6 @@ interface InFlightReview {
   projectKey: string;
 }
 
-/**
- * The refusal shown when approve preflight finds the repo not approval-ready.
- *
- * Two very different situations reach this point and the old single sentence
- * covered both, leaving the reader nothing to act on — one admin retried the
- * same `approve` seven times over two hours against an underprotected repo.
- *
- * `approvalProtectionReady` returning false already establishes that the two
- * controls are not both on, so that is the default explanation — it holds even
- * when the gate probe was never consulted (the flag is off). The probe only
- * adds one distinction: if it ran and came back unknown, the Rules API is
- * unreadable, which also makes the `false` above untrustworthy. Say that
- * instead of naming controls we could not actually observe.
- *
- * @param gateStatus probe result; meaningful only when `gateProbed` is true
- * @param gateProbed whether the gate probe was consulted at all
- */
-export function protectionNotReadyMessage(
-  slug: string,
-  branch: string,
-  gateStatus: boolean | undefined,
-  gateProbed = false,
-): string {
-  if (gateProbed && gateStatus === undefined) {
-    return (
-      `無法確認 ${slug} 的 \`${branch}\` 保護狀態（Rules API 讀取失敗），` +
-      "為安全起見不予核准。請 repo admin 確認 pmk 的 review 身分是否有讀取權限；" +
-      "在確認之前，請直接在 GitHub 上人工核准。"
-    );
-  }
-  return (
-    `${slug} 的 \`${branch}\` 需要 review 核准，但缺少兩項必要保護：` +
-    "`dismiss_stale_reviews_on_push` 與 `require_last_push_approval`（目前皆為 false）。" +
-    "少了它們，核准後推的新 commit 不會讓核准失效，未經審查的變更就能合併。\n" +
-    "請 repo admin 於 ruleset 開啟這兩項；" +
-    "若需在調整前先行放行，請 PMK admin 將此 repo 加入 `review.approval.protectionExemptions`。" +
-    "在此之前，請直接在 GitHub 上人工核准。"
-  );
-}
 
 export class ReviewCoordinator {
   /** Reviews running right now (detached). Drained on shutdown (A). */

--- a/packages/cli/test/approve-flow-fences.test.ts
+++ b/packages/cli/test/approve-flow-fences.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ApproveFlow, type ApproveFlowDeps } from "../src/gateway/slack/review-approve-flow";
+import type { ApprovalReservation } from "../src/gateway/review-approval";
+
+/**
+ * `publishReservation` runs three revision fences. Each re-reads live gateway
+ * config, so a policy change landing mid-approve — an admin revoked, the repo
+ * dropped from the allowlist, approval switched off — is caught before the
+ * GitHub POST. These tests hold that property directly, by handing in a
+ * `currentConfig` that returns a DIFFERENT config on later calls.
+ *
+ * What these tests guard: that the METHOD keeps re-reading. Hoisting the first
+ * read into a single `const live` reused by all three fences would leave them
+ * comparing one value against itself — always passing — and no
+ * coordinator-level test would notice, because the wiring would still be
+ * correct and the fences would simply always agree.
+ *
+ * What they do NOT guard, despite an earlier claim to the contrary: the
+ * COORDINATOR's wiring of `currentConfig`. Both ways of breaking it are
+ * already caught, verified empirically:
+ *
+ *   currentConfig: this.currentConfig()   → TS2322, does not compile
+ *   currentConfig: this.currentConfig     → compiles, but loses `this`;
+ *                                           review-coordinator.test.ts fails 21×
+ *
+ * These tests bypass ReviewCoordinator entirely, so they pass under either
+ * break. Keeping the distinction straight matters: a test file that claims to
+ * guard something it cannot is worse than no test, because it stops anyone
+ * from writing the one that would.
+ */
+
+const ORIG_HOME = process.env.HOME;
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-approve-fences-"));
+  process.env.HOME = tmp;
+});
+afterEach(() => {
+  if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+const HEAD = "a".repeat(40);
+const ARTIFACT = "b".repeat(64);
+
+function config(over: Record<string, unknown> = {}) {
+  return {
+    version: 3,
+    admins: ["U_ADMIN"],
+    blocklist: [],
+    audience: { default: "biz", users: {}, channels: {}, domainExamples: { biz: [], pm: [] } },
+    escalation: { default: [], repos: {} },
+    slack: {},
+    github: { token: "gh-token" },
+    review: {
+      enabled: true,
+      approval: { enabled: true, allowWhenNoReviewGate: true },
+      providerMode: "codex",
+    },
+    ...over,
+  } as never;
+}
+
+function reservation(): ApprovalReservation {
+  // The reservation file must exist on disk: both terminal paths
+  // (consumeApprovalReservation on success, releaseApprovalReservation /
+  // markApprovalPendingReconcile on failure) rename it.
+  const reservedPath = path.join(tmp, "reserved.json");
+  fs.writeFileSync(reservedPath, JSON.stringify({ channelId: "C1", threadTs: "1.1" }));
+  return {
+    id: "res-1",
+    channelId: "C1",
+    threadTs: "1.1",
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    reservedPath,
+    refs: [
+      {
+        owner: "o",
+        repo: "r",
+        number: 7,
+        url: "https://github.com/o/r/pull/7",
+        headSha: HEAD,
+        baseRef: "main",
+        artifactSha256: ARTIFACT,
+      },
+    ],
+  };
+}
+
+/** Records every GitHub call so a test can assert the POST never happened. */
+function deps(over: Partial<ApproveFlowDeps> = {}) {
+  const posted: unknown[] = [];
+  const replies: string[] = [];
+  const base: ApproveFlowDeps = {
+    gateway: {
+      getAuthUser: async () => "pmk-bot",
+      getPrHead: async () => ({ sha: HEAD, baseRef: "main", updatedAt: "2026-08-01T00:00:00Z" }),
+      approvalProtectionReady: async () => true,
+      reviewGateStatus: async () => false,
+      createPullRequestApproval: async (a: unknown) => {
+        posted.push(a);
+        return { reviewId: 1, state: "APPROVED", commitId: HEAD };
+      },
+      hasPullRequestApproval: async () => false,
+    } as never,
+    currentConfig: () => config(),
+    fetchMessageText: async () => undefined,
+    reply: async (_c, _t, text) => {
+      replies.push(text);
+    },
+    ...over,
+  };
+  return { deps: base, posted, replies };
+}
+
+describe("publishReservation revision fences", () => {
+  it("approves when policy is unchanged across all three reads", async () => {
+    const { deps: d, posted } = deps();
+    await new ApproveFlow(d).publishReservation(reservation(), "U_ADMIN");
+    assert.equal(posted.length, 1, "a stable policy must reach the GitHub POST");
+  });
+
+  // The core guard: the method must READ config again after the first fence.
+  // Hoisting that read would make every fence compare a value against itself.
+  it("refuses when live policy changes between the first and second read", async () => {
+    let call = 0;
+    const { deps: d, posted, replies } = deps({
+      currentConfig: () => {
+        call += 1;
+        // First read: U_ADMIN is an admin. Every read after: revoked.
+        return call === 1 ? config() : config({ admins: ["U_SOMEONE_ELSE"] });
+      },
+    });
+
+    await new ApproveFlow(d).publishReservation(reservation(), "U_ADMIN");
+
+    assert.equal(posted.length, 0, "a revoked admin must not reach the GitHub POST");
+    assert.ok(
+      replies.some((r) => /preflight 未通過/.test(r)),
+      `expected a preflight refusal, got: ${JSON.stringify(replies)}`,
+    );
+    assert.ok(call >= 2, "the method must re-read config, not reuse the first read");
+  });
+
+  it("refuses when the repo leaves the allowlist mid-approve", async () => {
+    let call = 0;
+    const { deps: d, posted } = deps({
+      currentConfig: () => {
+        call += 1;
+        return call === 1
+          ? config()
+          : config({ review: { enabled: true, approval: { enabled: true, allowWhenNoReviewGate: true }, providerMode: "codex", repoAllowlist: ["other/repo"] } });
+      },
+    });
+    await new ApproveFlow(d).publishReservation(reservation(), "U_ADMIN");
+    assert.equal(posted.length, 0);
+  });
+
+  it("refuses when approval is switched off mid-approve", async () => {
+    let call = 0;
+    const { deps: d, posted } = deps({
+      currentConfig: () => {
+        call += 1;
+        return call === 1
+          ? config()
+          : config({ review: { enabled: true, approval: { enabled: false }, providerMode: "codex" } });
+      },
+    });
+    await new ApproveFlow(d).publishReservation(reservation(), "U_ADMIN");
+    assert.equal(posted.length, 0);
+  });
+
+  // The fences guard policy; this guards the code being approved.
+  it("refuses when the PR head moves after the authorisation", async () => {
+    const { deps: d, posted } = deps({
+      gateway: {
+        getAuthUser: async () => "pmk-bot",
+        getPrHead: async () => ({ sha: "c".repeat(40), baseRef: "main" }),
+        approvalProtectionReady: async () => true,
+        reviewGateStatus: async () => false,
+        createPullRequestApproval: async () => ({ reviewId: 1, state: "APPROVED", commitId: HEAD }),
+        hasPullRequestApproval: async () => false,
+      } as never,
+    });
+    await new ApproveFlow(d).publishReservation(reservation(), "U_ADMIN");
+    assert.equal(posted.length, 0, "a new commit must invalidate the authorisation");
+  });
+
+  it("refuses a multi-PR reservation outright", async () => {
+    const { deps: d, posted } = deps();
+    const multi = reservation();
+    multi.refs = [...multi.refs, { ...multi.refs[0], number: 8 }];
+    await new ApproveFlow(d).publishReservation(multi, "U_ADMIN");
+    assert.equal(posted.length, 0);
+  });
+});


### PR DESCRIPTION
Follow-up to the `ApproveFlow` extraction (#previous). Clears the three items the final whole-branch review deferred.

## 1. Direct fence tests

`publishReservation` runs three revision fences. Each re-reads live gateway config, so a policy change landing mid-approve — admin revoked, repo dropped from the allowlist, approval switched off — is caught **before** the GitHub POST.

Six tests hold that directly. Proven to bite: hoisting the three reads into one reused value fails 3 of them.

### A correction to the stated rationale

The final review said these tests were needed because a snapshot wiring would pass all 25 existing assertions. **I repeated that as fact. It is wrong**, and I only found out by measuring:

| Break form | tsc | `review-coordinator.test.ts` |
|---|---|---|
| `currentConfig: this.currentConfig()` | **TS2322 — does not compile** | n/a |
| `currentConfig: this.currentConfig` | compiles | **fails 21×** |

Both ways of breaking the wiring are already guarded. So these tests do **not** guard the wiring — they guard something different and real: that the **method** keeps re-reading between fences. Hoist that and every fence compares one value against itself; no coordinator-level test would notice, because the wiring would still be correct and the fences would simply always agree.

The test file's header says exactly this, including what it cannot guard. A test file that claims to protect something it cannot is worse than none — it stops anyone from writing the one that would.

## 2. Two comments pointing at a dead symbol

`authorization-lock.ts:6` and `review-policy.ts:6` still named `publishApprovalReservation`, which no longer exists. Those comments explain *why the authorization lock exists* — they point a reader at the most safety-critical code in this system, by a name they cannot grep. Both now name `ApproveFlow.publishReservation`.

Neither file appeared in any task diff, which is why the per-task reviews could not have caught this.

## 3. The runtime import cycle is gone

`protectionNotReadyMessage` moved to the leaf `review-policy` module, so `review-approve-flow` no longer imports a **value** from `review.ts`. The remaining `import type { ReviewGateway }` edge is erased at compile time and is not a cycle. Re-exported from `review.ts`, so every existing importer — including `review-coordinator.test.ts` — is untouched.

This also unblocks the thing the final review warned about: direct `ApproveFlow` tests would otherwise have transitively dragged in all of `review.ts`.

## Not done, deliberately

**Narrowing `publishReservation` to `private`.** It is the seam these tests drive, and TypeScript `private` is compile-time only — it buys documentation, not enforcement. Trading a real regression guard for a theoretical visibility nicety is the wrong trade.

Documented at the declaration instead, including why a direct call cannot bypass authorisation: the fences independently re-check admin, allowlist, and approval-enabled. A direct caller skips the offer bookkeeping, not the authorisation.

## Verification

**1,273 tests pass, 0 fail** — cli 1151, core 50, llm 13, rag 13, shared 32, desktop 14. Counted per workspace.

Every claim above was measured, not reasoned: the TS2322, the 21 failures, and the 3-test failure under hoisting were each produced by temporarily breaking the code and restoring it.

## Test plan

- [ ] `npm test --workspaces --if-present` green (done locally: 1,273/1,273)
- [ ] No behaviour change to ship — this PR is tests plus two comments plus one module move