### PR TITLE
fix(test): never point HOME back at the operator's home

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,16 @@ jobs:
         run: npm test --workspace=${{ matrix.workspace }}
 
       # A test that exercises production objects without isolating HOME writes
-      # into the operator's real ~/.pmk store. socket-watchdog-alert.test.ts did
+      # into the operator's real ~/.pmk store.
+      #
+      # This catches DETERMINISTIC pollution. It cannot catch the cancellation
+      # race that took the gateway down on 2026-08-04: a cancelled test's
+      # abandoned continuation resumed after afterEach had restored the real
+      # HOME, and overwrote ~/.pmk/gateway.json with fixtures. CI never sees it
+      # because cancellations only happen once another test has already failed.
+      # That one is handled in the tests themselves — HOME is now pointed at a
+      # throwaway for the whole process and never restored (test/helpers/
+      # isolated-home.ts). socket-watchdog-alert.test.ts did
       # this for two months: it constructs a PresenceBroadcaster and calls
       # watchdogTerminate, which appends the daemon's SELF-TERMINATION record.
       # By 2026-08-03 the live audit log held 1,056 fabricated terminations

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmk/desktop",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "private": true,
   "description": "Desktop app for pm-workspace-kit — Electron + Vite + React",
   "license": "MIT",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmk/docs",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "private": true,
   "description": "Docusaurus docs site for pm-workspace-kit",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-workspace-kit",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-workspace-kit",
-      "version": "0.40.0",
+      "version": "0.41.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",
@@ -18,7 +18,7 @@
     },
     "apps/desktop": {
       "name": "@pmk/desktop",
-      "version": "0.40.0",
+      "version": "0.41.0",
       "license": "MIT",
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",
@@ -57,7 +57,7 @@
     },
     "apps/docs": {
       "name": "@pmk/docs",
-      "version": "0.40.0",
+      "version": "0.41.0",
       "license": "MIT",
       "dependencies": {
         "@docusaurus/core": "3.10.0",
@@ -25215,7 +25215,7 @@
     },
     "packages/cli": {
       "name": "@pmk/cli",
-      "version": "0.40.0",
+      "version": "0.41.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.7.0",
@@ -25266,7 +25266,7 @@
     },
     "packages/core": {
       "name": "@pmk/core",
-      "version": "0.40.0",
+      "version": "0.41.0",
       "license": "MIT",
       "dependencies": {
         "gray-matter": "^4.0.3"
@@ -25281,7 +25281,7 @@
     },
     "packages/llm": {
       "name": "@pmk/llm",
-      "version": "0.40.0",
+      "version": "0.41.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.165",
@@ -25299,7 +25299,7 @@
     },
     "packages/rag": {
       "name": "@pmk/rag",
-      "version": "0.40.0",
+      "version": "0.41.0",
       "license": "MIT",
       "dependencies": {
         "gray-matter": "^4.0.3"
@@ -25315,7 +25315,7 @@
     },
     "packages/shared": {
       "name": "@pmk/shared",
-      "version": "0.40.0",
+      "version": "0.41.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-workspace-kit",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "private": true,
   "description": "An opinionated PM/SA workspace kit — Docusaurus docs site, traceability scripts, CLI (pmk), and desktop app. Monorepo.",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmk/cli",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "pmk — command-line interface for pm-workspace-kit",
   "license": "MIT",
   "bin": {

--- a/packages/cli/test/acme-ads-seed.test.ts
+++ b/packages/cli/test/acme-ads-seed.test.ts
@@ -4,7 +4,14 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 
 describe("acme-ads-seed", () => {
   let tmpHome: string;
@@ -14,7 +21,7 @@ describe("acme-ads-seed", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("seeds exactly 5 approved atoms tagged acme-ads-demo, scope acme-ads", async () => {

--- a/packages/cli/test/admin-review.test.ts
+++ b/packages/cli/test/admin-review.test.ts
@@ -6,10 +6,17 @@ import * as path from "node:path";
 import { adminReview } from "../src/gateway/slack/admin-review";
 import { loadRawGatewayConfig, saveGatewayConfig } from "../src/gateway/config";
 
-const ORIG_HOME = process.env.HOME; // gatewayDir() is HOME-based
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME; // gatewayDir() is HOME-based
 let tmp: string;
 beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-ar-")); process.env.HOME = tmp; });
-afterEach(() => { if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME; fs.rmSync(tmp, { recursive: true, force: true }); });
+afterEach(() => { process.env.HOME = ORIG_HOME; fs.rmSync(tmp, { recursive: true, force: true }); });
 
 describe("adminReview approval toggle", () => {
   it("preserves protectionExemptions across an enable/disable cycle", () => {

--- a/packages/cli/test/adoption.test.ts
+++ b/packages/cli/test/adoption.test.ts
@@ -6,7 +6,14 @@ import * as path from "node:path";
 import type { AuditReport } from "../src/gateway/audit";
 import type { AtomTelemetryStore } from "../src/gateway/atom-telemetry";
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 
 describe("run-markers", () => {
   let tmpHome: string;
@@ -16,7 +23,7 @@ describe("run-markers", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("readMarkers returns nulls + preExisting:false when absent", async () => {
@@ -179,7 +186,7 @@ describe("propose records first-prd on success (marker contract)", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome2, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("recordFirstPrd sets the marker (same fn the success path calls)", async () => {

--- a/packages/cli/test/approve-flow-fences.test.ts
+++ b/packages/cli/test/approve-flow-fences.test.ts
@@ -33,14 +33,21 @@ import type { ApprovalReservation } from "../src/gateway/review-approval";
  * from writing the one that would.
  */
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 let tmp: string;
 beforeEach(() => {
   tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-approve-fences-"));
   process.env.HOME = tmp;
 });
 afterEach(() => {
-  if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+  process.env.HOME = ORIG_HOME;
   fs.rmSync(tmp, { recursive: true, force: true });
 });
 

--- a/packages/cli/test/audio-routing.test.ts
+++ b/packages/cli/test/audio-routing.test.ts
@@ -6,7 +6,14 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 
 describe("audio routing helpers", () => {
   it("isAudioMessage true only when an audio file is present", () => {
@@ -23,8 +30,7 @@ describe("audio routing helpers", () => {
       assert.equal(needsConsentNotice("C1"), false);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
-      if (ORIG_HOME) process.env.HOME = ORIG_HOME;
-      else delete process.env.HOME;
+      process.env.HOME = ORIG_HOME;
     }
   });
 
@@ -40,8 +46,7 @@ describe("audio routing helpers", () => {
       assert.equal(needsConsentNotice("C1:UB"), true);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
-      if (ORIG_HOME) process.env.HOME = ORIG_HOME;
-      else delete process.env.HOME;
+      process.env.HOME = ORIG_HOME;
     }
   });
 });

--- a/packages/cli/test/authorization-lock.test.ts
+++ b/packages/cli/test/authorization-lock.test.ts
@@ -12,14 +12,21 @@ import {
   AuthorizationLockBusyError,
 } from "../src/gateway/authorization-lock";
 
-const ORIG_HOME = process.env.HOME; // gatewayDir() is HOME-based
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME; // gatewayDir() is HOME-based
 let tmp: string;
 beforeEach(() => {
   tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-authlock-"));
   process.env.HOME = tmp;
 });
 afterEach(() => {
-  if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+  process.env.HOME = ORIG_HOME;
   fs.rmSync(tmp, { recursive: true, force: true });
 });
 

--- a/packages/cli/test/case.test.ts
+++ b/packages/cli/test/case.test.ts
@@ -26,7 +26,14 @@ import {
   withCaseLock,
 } from "../src/case";
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 
 describe("case file lifecycle", () => {
   let tmpHome: string;
@@ -38,7 +45,7 @@ describe("case file lifecycle", () => {
 
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("save → load round-trips and bumps updatedAt", async () => {

--- a/packages/cli/test/channel-log.test.ts
+++ b/packages/cli/test/channel-log.test.ts
@@ -16,7 +16,14 @@ import {
   type ChannelLogEntry,
 } from "../src/gateway/channel-log";
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 
 function isoOffset(seconds: number): string {
   return new Date(Date.UTC(2026, 4, 19, 10, 0, seconds)).toISOString();
@@ -32,8 +39,7 @@ describe("channel-log: round-trip + filters", () => {
 
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
-    else delete process.env.HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("append → load returns entries in write order", () => {
@@ -138,8 +144,7 @@ describe("channel-log: race-free under concurrent appends", () => {
 
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
-    else delete process.env.HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("20 parallel appends from 4 simulated users all persist (no last-write-wins drop)", async () => {
@@ -193,8 +198,7 @@ describe("channel-log: migration from legacy chat-session.json", () => {
 
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
-    else delete process.env.HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   function writeLegacy(

--- a/packages/cli/test/context-retry-hook.test.ts
+++ b/packages/cli/test/context-retry-hook.test.ts
@@ -4,7 +4,14 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 
 describe("chatWithContextRetry onBeforeRetry", () => {
   let tmpHome: string;
@@ -16,8 +23,7 @@ describe("chatWithContextRetry onBeforeRetry", () => {
 
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
-    else delete process.env.HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("fires the hook after the first context failure, before the retry build", async () => {

--- a/packages/cli/test/context-retry.test.ts
+++ b/packages/cli/test/context-retry.test.ts
@@ -4,7 +4,14 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 
 describe("chatWithContextRetry (T11)", () => {
   let tmpHome: string;
@@ -16,8 +23,7 @@ describe("chatWithContextRetry (T11)", () => {
 
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
-    else delete process.env.HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("happy path: returns full + empty scissorsPrefix", async () => {

--- a/packages/cli/test/escalation-sanitize.test.ts
+++ b/packages/cli/test/escalation-sanitize.test.ts
@@ -24,7 +24,14 @@ import {
 } from "../src/gateway/config";
 import type { LlmProvider } from "../src/llm";
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 
 // Extractor returns valid JSON (question/summary/tags only — answer comes
 // verbatim from the expert reply, not from LLM output).
@@ -87,7 +94,7 @@ describe("EscalationCoordinator.maybeAbsorbReply — injection flagging", () => 
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("flags the saved atom when answerText contains an injection phrase", async () => {

--- a/packages/cli/test/escalation.test.ts
+++ b/packages/cli/test/escalation.test.ts
@@ -18,7 +18,14 @@ import {
 } from "../src/gateway/config";
 import type { LlmProvider } from "../src/llm";
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 
 const ATOM_JSON = JSON.stringify({
   question: "where is the campaign budget enforced?",
@@ -81,7 +88,7 @@ describe("claimThreadEscalation (atomic claim)", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("first claim wins, second gets undefined, marker is consumed", () => {
@@ -115,7 +122,7 @@ describe("EscalationCoordinator.maybeAbsorbReply", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("absorbs a tagged contributor's reply: atom saved, event, asker synthesis", async () => {

--- a/packages/cli/test/gateway-admin-doctor.test.ts
+++ b/packages/cli/test/gateway-admin-doctor.test.ts
@@ -8,7 +8,14 @@ import { SlashCommandHandler } from "../src/gateway/slack/slash-command";
 import { writeRunState } from "../src/gateway/run-state";
 import type { GatewayConfig } from "../src/gateway/config";
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return {
@@ -44,7 +51,7 @@ describe("/pmk admin doctor", () => {
   });
   afterEach(() => {
     fs.rmSync(tmp, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("reads the provider at COMMAND time (not construction)", async () => {

--- a/packages/cli/test/gateway-atom-telemetry.test.ts
+++ b/packages/cli/test/gateway-atom-telemetry.test.ts
@@ -7,7 +7,14 @@ import type { WebClient } from "@slack/web-api";
 import type { EscalationCoordinator } from "../src/gateway/slack/escalation";
 import { GATEWAY_CONFIG_VERSION, type GatewayConfig } from "../src/gateway/config";
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 
 describe("atom-telemetry sidecar", () => {
   let tmpHome: string;
@@ -17,7 +24,7 @@ describe("atom-telemetry sidecar", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("missing sidecar reads as empty", async () => {
@@ -82,7 +89,7 @@ describe("free-chat-turn telemetry wiring", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("bumpReuse is called after a successful LLM reply that injected an atom", async () => {

--- a/packages/cli/test/gateway-audit.test.ts
+++ b/packages/cli/test/gateway-audit.test.ts
@@ -4,7 +4,14 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 
 function seedEvent(homeDir: string, atIso: string, payload: object): void {
   const dir = path.join(homeDir, ".pmk", "gateway");
@@ -66,7 +73,7 @@ describe("gateway audit aggregator (#24)", () => {
 
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("returns an empty-ish report when nothing has been recorded", async () => {
@@ -571,7 +578,7 @@ describe("audit — gateway.rejection rollup", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   const now = () => new Date().toISOString();

--- a/packages/cli/test/gateway-config-conflict.test.ts
+++ b/packages/cli/test/gateway-config-conflict.test.ts
@@ -4,7 +4,14 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 
 /**
  * The gateway config is edited through a read-modify-write: every admin
@@ -30,7 +37,7 @@ describe("gateway config concurrent-write conflict", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   const seed = async () => {

--- a/packages/cli/test/gateway-events.test.ts
+++ b/packages/cli/test/gateway-events.test.ts
@@ -4,7 +4,14 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 
 describe("gateway events log (#24)", () => {
   let tmpHome: string;
@@ -16,7 +23,7 @@ describe("gateway events log (#24)", () => {
 
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("appendGatewayEvent → readGatewayEvents round-trips a turn.processed event", async () => {

--- a/packages/cli/test/gateway-ops.test.ts
+++ b/packages/cli/test/gateway-ops.test.ts
@@ -8,11 +8,18 @@ import { stopCmdImpl, type OpsDeps } from "../src/commands/gateway/ops";
 import { restartCmdImpl, type RestartDeps } from "../src/commands/gateway/ops";
 import { writeRunState } from "../src/gateway/run-state";
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 describe("gateway status (persisted)", () => {
   let tmp: string;
   beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-ops-")); process.env.HOME = tmp; });
-  afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME; });
+  afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); process.env.HOME = ORIG_HOME; });
 
   it("dead pid → 🔴 down; never executes a {cmd} secret", () => {
     const sentinel = path.join(tmp, "RAN");
@@ -42,7 +49,7 @@ describe("gateway status (persisted)", () => {
 describe("gateway stop", () => {
   let tmp: string;
   beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-stop-")); process.env.HOME = tmp; });
-  afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME; });
+  afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); process.env.HOME = ORIG_HOME; });
 
   function deps(over: Partial<OpsDeps> = {}): OpsDeps & { calls: string[][] } {
     const calls: string[][] = [];
@@ -75,7 +82,7 @@ describe("gateway stop", () => {
 describe("gateway restart", () => {
   let tmp: string;
   beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-restart-")); process.env.HOME = tmp; });
-  afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME; });
+  afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); process.env.HOME = ORIG_HOME; });
 
   function base(over: Partial<RestartDeps> & { calls?: string[][] } = {}): RestartDeps & { calls: string[][] } {
     const calls = over.calls ?? [];

--- a/packages/cli/test/gateway-run-state.test.ts
+++ b/packages/cli/test/gateway-run-state.test.ts
@@ -11,7 +11,14 @@ import {
   serviceLabelValid,
 } from "../src/gateway/run-state";
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 describe("gateway run-state", () => {
   let tmp: string;
   beforeEach(() => {
@@ -20,7 +27,7 @@ describe("gateway run-state", () => {
   });
   afterEach(() => {
     fs.rmSync(tmp, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("writeRunState then readRaw round-trips (incl phase)", () => {

--- a/packages/cli/test/gateway.test.ts
+++ b/packages/cli/test/gateway.test.ts
@@ -87,7 +87,14 @@ import { extractKnowledgeAtom } from "../src/gateway/extractor";
 import { slashCommandArgsFromBody } from "../src/gateway/slack";
 import type { LlmProvider } from "../src/llm";
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 const ORIG_APP_TOKEN = process.env.PMK_SLACK_APP_TOKEN;
 const ORIG_BOT_TOKEN = process.env.PMK_SLACK_BOT_TOKEN;
 
@@ -103,7 +110,7 @@ describe("gateway config", () => {
 
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
     if (ORIG_APP_TOKEN !== undefined)
       process.env.PMK_SLACK_APP_TOKEN = ORIG_APP_TOKEN;
     if (ORIG_BOT_TOKEN !== undefined)
@@ -447,7 +454,7 @@ describe("heartbeat", () => {
   afterEach(() => {
     clearHeartbeat();
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("first start reports wasOffline=true (no prior heartbeat)", () => {
@@ -572,7 +579,7 @@ describe("session-store", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("loadUserSession returns empty session for new user", () => {
@@ -1120,7 +1127,7 @@ describe("mraDoctor workspace override", () => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
     fs.rmSync(validWs, { recursive: true, force: true });
     fs.rmSync(invalidWs, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("explicit valid workspace short-circuits cwd walk", () => {
@@ -1158,7 +1165,7 @@ describe("thread-aware sessions", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("thread A and thread B have isolated histories", () => {
@@ -1199,7 +1206,7 @@ describe("audience picker", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("falls back to default when no override", () => {
@@ -1367,7 +1374,7 @@ describe("escalation pool picker", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("repo pool wins over default; default is fallback", () => {
@@ -1468,7 +1475,7 @@ describe("knowledge store", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("slugifyQuestion produces filesystem-safe slugs (CJK + ASCII)", () => {
@@ -1608,7 +1615,7 @@ describe("atom TTL approval", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("pending atoms are excluded from searchAtoms", () => {
@@ -1769,7 +1776,7 @@ describe("atom-index BM25 (#19)", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   function seedThreeApprovedAtoms() {
@@ -1922,7 +1929,7 @@ describe("findAtomByApprovalMessage (#21)", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("finds atom by approval anchor (channelId + messageTs)", () => {
@@ -2013,7 +2020,7 @@ describe("extractKnowledgeAtom", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   function stubLlm(reply: string): LlmProvider {
@@ -2112,7 +2119,7 @@ describe("thread escalation marker", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("save → load → clear", () => {
@@ -2148,7 +2155,7 @@ describe("isAdmin + admins back-fill (#31)", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("default empty admins → isAdmin returns false", async () => {
@@ -2201,7 +2208,7 @@ describe("admin-log (#31)", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("appendAdminLog → readAdminLog round-trips one entry", async () => {
@@ -2333,7 +2340,7 @@ describe("Slack admin handler (#31)", () => {
   });
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("extractUserId handles <@U…> mention, <@U…|name>, bare U…, garbage", async () => {

--- a/packages/cli/test/helpers/isolated-home.ts
+++ b/packages/cli/test/helpers/isolated-home.ts
@@ -25,15 +25,24 @@ import * as path from "node:path";
  * this is the fallback for objects that reach the filesystem directly.
  */
 export function useIsolatedHome(prefix = "pmk-test-home-"): { dir: () => string } {
-  const original = process.env.HOME;
-  let tmp = "";
+  // Point HOME away from the operator's home ONCE, at module load, and never
+  // point it back. Test files run in separate processes, so there is nothing
+  // to restore for — and restoring opens a window that has already caused a
+  // production outage: a cancelled test's abandoned continuation resumes AFTER
+  // afterEach, sees the real HOME, and writes to the live ~/.pmk. That is how
+  // the gateway config was overwritten with test fixtures on 2026-08-04,
+  // taking the bot down.
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}base-`));
+  process.env.HOME = base;
+
+  let tmp = base;
   beforeEach(() => {
     tmp = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
     process.env.HOME = tmp;
   });
   afterEach(() => {
-    if (original !== undefined) process.env.HOME = original;
-    else delete process.env.HOME;
+    // Back to the throwaway base, NEVER to the operator's home.
+    process.env.HOME = base;
     try {
       fs.rmSync(tmp, { recursive: true, force: true });
     } catch {

--- a/packages/cli/test/llm-anthropic-api.test.ts
+++ b/packages/cli/test/llm-anthropic-api.test.ts
@@ -4,7 +4,14 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 
 describe("AnthropicApiKeyProvider token.usage emission (T5 / v0.12.0)", () => {
   let tmpHome: string;
@@ -16,8 +23,7 @@ describe("AnthropicApiKeyProvider token.usage emission (T5 / v0.12.0)", () => {
 
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
-    else delete process.env.HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("emits token.usage event after stream completes (when actor is provided)", async () => {

--- a/packages/cli/test/review-claim.test.ts
+++ b/packages/cli/test/review-claim.test.ts
@@ -6,14 +6,21 @@ import * as path from "node:path";
 
 // gatewayDir() resolves under os.homedir(); existing gateway-storage tests
 // isolate by overriding HOME (NOT PMK_HOME — that env var is not honored).
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 let tmp: string;
 beforeEach(() => {
   tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-review-claim-"));
   process.env.HOME = tmp;
 });
 afterEach(() => {
-  if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+  process.env.HOME = ORIG_HOME;
   fs.rmSync(tmp, { recursive: true, force: true });
 });
 

--- a/packages/cli/test/review-coordinator.test.ts
+++ b/packages/cli/test/review-coordinator.test.ts
@@ -8,10 +8,17 @@ import { FakeWebClient } from "./harness/slack-fakes";
 import { ReviewCoordinator, effectiveMraReviewStrategy, isReviewRequest, isRetryRequest, isRerunRequest, isApproveRequest, isApproveConfirmationRequest, isReviewCommandMissingPr, canConfirmApproveFromReview, reviewResultText, approveResultText, describeMraFailure, protectionNotReadyMessage, type ReviewGateway } from "../src/gateway/slack/review";
 import { gatewayConfigPath, resolveReviewConfig, saveGatewayConfig } from "../src/gateway/config";
 
-const ORIG_HOME = process.env.HOME; // gatewayDir() is HOME-based; isolate via HOME (not PMK_HOME)
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME; // gatewayDir() is HOME-based; isolate via HOME (not PMK_HOME)
 let tmp: string;
 beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-rc-")); process.env.HOME = tmp; });
-afterEach(() => { if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME; fs.rmSync(tmp, { recursive: true, force: true }); });
+afterEach(() => { process.env.HOME = ORIG_HOME; fs.rmSync(tmp, { recursive: true, force: true }); });
 
 function gw(over: Partial<ReviewGateway> = {}): ReviewGateway {
   return {

--- a/packages/cli/test/session.test.ts
+++ b/packages/cli/test/session.test.ts
@@ -5,7 +5,14 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Session, listParks, parkPath, parksDir } from "../src/session";
 
-const ORIG_HOME = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took
+// the bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 
 describe("Session.park + resumeFromPark", () => {
   let tmpHome: string;
@@ -17,7 +24,7 @@ describe("Session.park + resumeFromPark", () => {
 
   afterEach(() => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
-    if (ORIG_HOME !== undefined) process.env.HOME = ORIG_HOME;
+    process.env.HOME = ORIG_HOME;
   });
 
   it("parks and restores message history", () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmk/core",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "Core scripts — traceability matrix, Confluence sync, shared utilities",
   "license": "MIT",
   "main": "src/index.js",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmk/llm",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "LLM provider runtime shared by the pmk CLI and desktop app",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmk/rag",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "RAG engine for pmk — pure-JS TF-IDF retrieval over pm-workspace-kit docs (no native deps)",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmk/shared",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "Shared types and utilities for pm-workspace-kit packages",
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
**This is a post-incident fix. The gateway went down today because of it.**

## What happened

`~/.pmk/gateway.json` was overwritten with test fixtures. launchd crash-looped on `gateway not configured`, and the bot was offline until the config was restored from a 5-day-old backup plus a hand-reconstructed exemption.

The overwritten file was unmistakably from the test suite:

```json
{ "version": 1, "admins": ["U1"], "slack": {},
  "mraWorkspace": "/var/folders/.../T/pmk-rc-nSXV7Z/ws",
  "review": { "expectedGhUser": "expected-bot",
    "approval": { "protectionExemptions": [
      { "repo": "onead/OnePixel", "reason": "injected mid-approve" }]}}}
```

## Mechanism

Test files isolate by setting `process.env.HOME` to a tmpdir in `beforeEach` and **restoring the real home** in `afterEach`.

That restore is the bug. Files run in separate processes, so restoring buys nothing — but it opens a window:

1. `node:test` **cancels** a test (it does this once another test has failed)
2. the cancelled test's continuation is abandoned mid-`await`
3. `afterEach` runs and restores the **real** `HOME`
4. the abandoned continuation resumes — and writes there

`review-coordinator.test.ts` has exactly the shape that triggers it: an `await`, then a `saveGatewayConfig` it *expects to throw* (`AuthorizationLockBusyError`). When it doesn't throw, it writes. When the test was cancelled, it wrote to the operator's home.

Demonstrated directly:

```
late write would land in:
  OLD pattern: /Users/hanfourhuang   <-- THE OUTAGE
  NEW pattern: /tmp/safe-base        (throwaway — safe)
```

## Why CI didn't catch it

The `$HOME/.pmk` guard added in an earlier PR is sound, but it only finds **deterministic** pollution. Cancellations happen only after some other test has already failed — so on any run that would expose this, CI is already red for another reason, and on green runs the window never opens.

This is not fixable in CI. It has to be fixed in the tests.

## The fix

`ORIG_HOME` becomes a **throwaway directory** created at module load, with `HOME` pointed at it immediately. `beforeEach` still gives each test a fresh tmpdir; `afterEach` returns `HOME` to the throwaway — **never to the real home**.

At no instant during a test process does `HOME` name the operator's directory, so a late write cannot reach it regardless of when it resumes.

Applied to **all 24 affected files**, including `test/helpers/isolated-home.ts` — the helper written to prevent this very class of bug had the same flaw.

## Verification

- **1,273 tests pass, 0 fail** across all six workspaces
- the window is demonstrated closed by direct simulation (above)
- no file under `packages/cli/test/` still assigns the real home back

## Test plan

- [ ] `npm test --workspaces --if-present` green (done locally: 1,273/1,273)
- [ ] `grep -l "const ORIG_HOME = process.env.HOME;" packages/cli/test/*.test.ts` returns nothing