### PR TITLE
fix(review): the already-reviewed note reports the verdict, not just the skip

### DIFF
--- a/packages/cli/src/gateway/review-approval.ts
+++ b/packages/cli/src/gateway/review-approval.ts
@@ -111,6 +111,23 @@ export function saveApprovalOffer(
   }
 }
 
+/**
+ * Read a thread's live offer WITHOUT touching it — the read-only counterpart to
+ * consume/reserve, used to decide what a message should say ("reply `approve`")
+ * rather than to act. A reserved offer (an approve already in flight) is not
+ * available and reads as absent, so nothing invites a second reply to it.
+ */
+export function peekApprovalOffer(channelId: string, threadTs: string): ApprovalOfferRef[] | undefined {
+  try {
+    const offer = JSON.parse(fs.readFileSync(offerPath(channelId, threadTs), "utf8")) as ApprovalOffer;
+    if (offer.channelId !== channelId || offer.threadTs !== threadTs) return undefined;
+    if (Date.parse(offer.expiresAt) <= Date.now()) return undefined;
+    return offer.refs;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Consume exactly once by renaming before reading. */
 export function consumeApprovalOffer(channelId: string, threadTs: string): ApprovalOfferRef[] | undefined {
   const p = offerPath(channelId, threadTs);

--- a/packages/cli/src/gateway/review-claim.ts
+++ b/packages/cli/src/gateway/review-claim.ts
@@ -30,6 +30,23 @@ interface ClaimRecord {
   done?: boolean;
   status?: string;
   reviewUrl?: string;
+  blockerCount?: number;
+  commentCount?: number;
+  finalizedAt?: string;
+}
+
+/**
+ * What a finished review decided. Read back when a LATER trigger hits the same
+ * commit: the skip note can then say what was decided and where to read it,
+ * instead of only "already reviewed" — which reads as "your push was ignored"
+ * to someone who just pushed a fix.
+ */
+export interface FinalizedReview {
+  status?: string;
+  reviewUrl?: string;
+  blockerCount?: number;
+  commentCount?: number;
+  finalizedAt?: string;
 }
 
 const activeOwners = new Map<string, string>();
@@ -151,7 +168,15 @@ export function forceClaimReview(r: ReviewRef): boolean {
   return false;
 }
 
-export function finalizeReview(r: ReviewRef, info: { reviewUrl?: string; status?: string }): void {
+export function finalizeReview(
+  r: ReviewRef,
+  info: {
+    reviewUrl?: string;
+    status?: string;
+    blockerCount?: number;
+    commentCount?: number;
+  },
+): void {
   const p = claimPath(r);
   const key = reviewClaimKey(r);
   const ownerId = activeOwners.get(key);
@@ -163,9 +188,39 @@ export function finalizeReview(r: ReviewRef, info: { reviewUrl?: string; status?
     return;
   }
   if (rec.ownerId !== ownerId) return;
-  const updated: ClaimRecord = { ...rec, done: true, status: info.status, reviewUrl: info.reviewUrl };
+  const updated: ClaimRecord = {
+    ...rec,
+    done: true,
+    status: info.status,
+    reviewUrl: info.reviewUrl,
+    blockerCount: info.blockerCount,
+    commentCount: info.commentCount,
+    finalizedAt: nowIso(),
+  };
   fs.writeFileSync(p, JSON.stringify(updated), { mode: 0o600 });
   activeOwners.delete(key);
+}
+
+/**
+ * The outcome of a COMPLETED review of this exact commit, or undefined when
+ * there is none (never reviewed, still running, or a pre-upgrade claim that
+ * predates outcome recording). Callers treat undefined as "no detail to add".
+ */
+export function readFinalizedReview(r: ReviewRef): FinalizedReview | undefined {
+  let rec: ClaimRecord;
+  try {
+    rec = JSON.parse(fs.readFileSync(claimPath(r), "utf8")) as ClaimRecord;
+  } catch {
+    return undefined;
+  }
+  if (rec.done !== true) return undefined;
+  return {
+    status: rec.status,
+    reviewUrl: rec.reviewUrl,
+    blockerCount: rec.blockerCount,
+    commentCount: rec.commentCount,
+    finalizedAt: rec.finalizedAt,
+  };
 }
 
 export function releaseReview(r: ReviewRef): void {

--- a/packages/cli/src/gateway/slack/review-messages.ts
+++ b/packages/cli/src/gateway/slack/review-messages.ts
@@ -4,6 +4,7 @@
  * for back-compat) so the coordinator holds orchestration, not copy.
  */
 import type { PrRef } from "../pr-ref";
+import type { FinalizedReview } from "../review-claim";
 
 /** Fields of an mra review result that shape the Slack result line. */
 export interface ReviewOutcome {
@@ -77,6 +78,81 @@ export function approveResultText(slug: string, ref: PrRef, res: ReviewOutcome):
   if (res.status === "CHANGES_REQUESTED")
     return `:no_entry: 未 approve ${slug}#${ref.number} — 發現重大問題，已請求修改（${cc} 則）：${ref.url}`;
   return `:information_source: 已完成 ${slug}#${ref.number} review（GitHub 未回報 approve 狀態，${cc} 則；請至 PR 確認是否已 approve）：${ref.url}`;
+}
+
+/** Taipei-local `MM/DD HH:mm` — the zone everyone reading the thread is in. */
+function taipeiStamp(iso?: string): string | undefined {
+  if (!iso) return undefined;
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return undefined;
+  return new Date(ms).toLocaleString("zh-TW", {
+    timeZone: "Asia/Taipei",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+/**
+ * The note posted when a trigger names a commit that was already reviewed.
+ *
+ * It has to answer the question the user actually has — "so what happened to my
+ * push?" — because the person hitting it has almost always just pushed a fix.
+ * The 2026-08-12 incident (finance-system#363) was the whole failure mode: the
+ * note reported only the skip, so a user whose fix HAD been reviewed clean, and
+ * for whom an approve offer was sitting in the thread, was told to go push a
+ * commit. State the prior verdict, then the ONE next step that is actually open
+ * to this user — the waiting offer, or `rerun` if they may force one.
+ */
+export function alreadyReviewedMessage(input: {
+  slug: string;
+  pr: number;
+  headSha: string;
+  intent: "review" | "approve";
+  /** Which command was typed; `:a:` delegates a review first, so it lands here too. */
+  origin?: "cr" | "a";
+  /** Outcome of the review that claimed this commit; absent for pre-upgrade claims. */
+  prior?: FinalizedReview;
+  /** An unconsumed, unexpired approve offer exists in this thread. */
+  approveOfferPending?: boolean;
+  isAdmin?: boolean;
+}): string {
+  const { slug, pr, headSha, intent, prior } = input;
+  const isApprove = intent === "approve";
+  const what = isApprove ? "approve check" : "review";
+  const when = taipeiStamp(prior?.finalizedAt);
+
+  const lede = when
+    ? `已在 ${when} 完成 ${what}`
+    : prior
+      ? `已完成 ${what}`
+      : isApprove
+        ? "已經執行過 approve check"
+        : "已經 review 過了";
+
+  const facts = [
+    prior?.status,
+    typeof prior?.blockerCount === "number" ? `${prior.blockerCount} 個 blocker` : undefined,
+    typeof prior?.commentCount === "number" ? `${prior.commentCount} 則建議` : undefined,
+  ].filter(Boolean);
+  const verdict = facts.length > 0 ? `：${facts.join("、")}` : "";
+  const link = prior?.reviewUrl ? ` → ${prior.reviewUrl}` : "";
+
+  // The next step, in the order that matters: a waiting offer beats any advice
+  // to push, because the work it is waiting on is already done.
+  const next =
+    input.approveOfferPending && !isApprove
+      ? "這個結果可以 approve — 要核准請在這個 thread 回覆 `approve`。"
+      : isApprove
+        ? "同一 commit 不重複 approve；要重新判斷請推新 commit 後再發 `:a:`。"
+        : "同一 commit 不重複審；有新的修改請 push 後再發 `:cr:`。";
+  const adminHint = input.isAdmin
+    ? "（要對同一 commit 強制重跑：在這個 thread 回覆 `rerun`）"
+    : "";
+
+  return `:information_source: ${slug}#${pr} 這個 commit（\`${headSha.slice(0, 7)}\`）${lede}${verdict}${link}\n${next}${adminHint}`;
 }
 
 /** Last non-empty line of `s`, with ANSI colour escapes stripped and trimmed. */

--- a/packages/cli/src/gateway/slack/review-runner.ts
+++ b/packages/cli/src/gateway/slack/review-runner.ts
@@ -14,13 +14,15 @@ import type { WebClient } from "@slack/web-api";
 import type { GatewayConfig, resolveReviewConfig } from "../config";
 import { appendGatewayEvent } from "../events";
 import type { PrRef } from "../pr-ref";
-import { claimReview, forceClaimReview, finalizeReview, releaseReview, type ReviewRef } from "../review-claim";
-import { saveApprovalOffer } from "../review-approval";
+import { claimReview, forceClaimReview, finalizeReview, readFinalizedReview, releaseReview, type ReviewRef } from "../review-claim";
+import { peekApprovalOffer, saveApprovalOffer } from "../review-approval";
+import { isAdmin } from "../config";
 import { effectiveMraReviewStrategy, findProtectionExemption } from "../review-policy";
 import type { ReviewGateway } from "./review";
 import { admissionRefusal, admissionRefusalMessage } from "./review-admission";
 import { resolveReviewTarget } from "./review-target";
 import {
+  alreadyReviewedMessage,
   canConfirmApproveFromReview,
   reviewResultText,
   approveResultText,
@@ -214,13 +216,28 @@ export class ReviewRunner {
       // ack, so tell them why no result follows. (Benign; no review.skipped
       // event so it doesn't read as a failure.)
       onLog(`review: already done ${slug}#${ref.number}@${head.sha.slice(0, 8)}`);
-      const alreadyDone = isApprove
-        ? `:information_source: ${slug}#${ref.number} 這個 commit（\`${head.sha.slice(0, 7)}\`）已經執行過 approve check，略過（同一 commit 不重複 approve）。要重新判斷請推新 commit 後再發 :a:。`
-        : `:information_source: ${slug}#${ref.number} 這個 commit（\`${head.sha.slice(0, 7)}\`）已經 review 過了，略過（同一 commit 不重複審）。要重審請推新 commit 後再發。`;
+      // An offer for THIS commit means the work the user is re-triggering is
+      // not just done, it is waiting on one word from them. Match on headSha:
+      // an offer left over from an earlier commit is not a way forward for this
+      // one, and pointing at it would authorize the wrong code.
+      const offerPending = (peekApprovalOffer(ctx.channelId, ctx.threadTs) ?? []).some(
+        (o) =>
+          o.owner === slugOwner && o.repo === slugRepo &&
+          o.number === ref.number && o.headSha === head.sha,
+      );
       await this.deps.reply(
         ctx.channelId,
         ctx.threadTs,
-        alreadyDone,
+        alreadyReviewedMessage({
+          slug,
+          pr: ref.number,
+          headSha: head.sha,
+          intent: mode,
+          origin: ctx.origin,
+          prior: readFinalizedReview(claimRef),
+          approveOfferPending: offerPending,
+          isAdmin: isAdmin(this.deps.currentConfig(), ctx.reactorUserId),
+        }),
       );
       return;
     }
@@ -384,7 +401,15 @@ export class ReviewRunner {
       }
 
       posted = true;
-      finalizeReview(claimRef, { status: res.status });
+      // Record the verdict, not just "done": a later trigger on this same commit
+      // has to be able to say WHAT was decided, or its skip note reads as "your
+      // push was ignored" to the person who just pushed the fix.
+      finalizeReview(claimRef, {
+        status: res.status,
+        reviewUrl: ref.url,
+        blockerCount: res.blockerCount,
+        commentCount: res.commentCount,
+      });
       if (!isApprove && ctx.review.approval.enabled && canConfirmApproveFromReview(res)) {
         saveApprovalOffer(ctx.channelId, ctx.threadTs, {
           owner: slugOwner,

--- a/packages/cli/test/review-already-reviewed.test.ts
+++ b/packages/cli/test/review-already-reviewed.test.ts
@@ -1,0 +1,80 @@
+// packages/cli/test/review-already-reviewed.test.ts
+//
+// The skip note a trigger gets when this exact commit was already reviewed.
+// Live incident 2026-08-12 (onead/finance-system#363): the note said only
+// "already reviewed — push a new commit to re-review". The user HAD pushed the
+// fix, it HAD been reviewed clean, and an approve offer was waiting — so the
+// one sentence they got sent them off to push a commit that did not exist.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { alreadyReviewedMessage } from "../src/gateway/slack/review-messages";
+
+const base = {
+  slug: "onead/finance-system",
+  pr: 363,
+  headSha: "f3117a7d79cb8c57e79308477c3086dfc4f2bb6b",
+  intent: "review" as const,
+};
+
+describe("alreadyReviewedMessage", () => {
+  it("reports WHAT the prior review decided and WHERE to read it", () => {
+    const text = alreadyReviewedMessage({
+      ...base,
+      prior: {
+        status: "COMMENTED",
+        blockerCount: 0,
+        commentCount: 1,
+        reviewUrl: "https://github.com/onead/finance-system/pull/363",
+        finalizedAt: "2026-08-12T06:54:59.547Z",
+      },
+    });
+    assert.match(text, /f3117a7/, "names the commit that was skipped");
+    assert.match(text, /COMMENTED/, "carries the prior verdict");
+    assert.match(text, /0 個 blocker/, "carries the blocker count");
+    assert.match(text, /1 則/, "carries the comment count");
+    assert.match(text, /https:\/\/github\.com\/onead\/finance-system\/pull\/363/, "links the review");
+    assert.match(text, /14:54/, "states when it was reviewed, in Taipei time");
+  });
+
+  it("points a waiting approve offer at `approve` instead of telling the user to push", () => {
+    const text = alreadyReviewedMessage({
+      ...base,
+      origin: "a",
+      approveOfferPending: true,
+      prior: { status: "COMMENTED", blockerCount: 0, finalizedAt: "2026-08-12T06:54:59.547Z" },
+    });
+    assert.match(text, /回覆 `approve`/, "the pending offer is the next step");
+    assert.doesNotMatch(
+      text,
+      /推新 commit|push 後再發/,
+      "must not send someone who wants to approve off to push a commit",
+    );
+  });
+
+  it("tells an admin about `rerun`, since only an admin may force one", () => {
+    const text = alreadyReviewedMessage({ ...base, isAdmin: true, prior: { status: "COMMENTED" } });
+    assert.match(text, /`rerun`/, "an admin has a way to re-review the same commit");
+  });
+
+  it("does not offer `rerun` to a non-admin who cannot use it", () => {
+    const text = alreadyReviewedMessage({ ...base, isAdmin: false, prior: { status: "COMMENTED" } });
+    assert.doesNotMatch(text, /rerun/, "advice a non-admin cannot act on is a dead end");
+  });
+
+  it("still reads cleanly when the claim predates outcome recording", () => {
+    const text = alreadyReviewedMessage(base);
+    assert.doesNotMatch(text, /undefined|NaN/, "no placeholder leakage from a missing record");
+    assert.match(text, /不重複審/, "the reason for the skip still comes through");
+    assert.match(text, /push/, "and the way forward is still stated");
+  });
+
+  it("uses approve wording when an approve check (not a review) was skipped", () => {
+    const text = alreadyReviewedMessage({
+      ...base,
+      intent: "approve",
+      prior: { status: "APPROVED", finalizedAt: "2026-08-12T06:54:59.547Z" },
+    });
+    assert.match(text, /approve/, "names the operation that was skipped");
+    assert.doesNotMatch(text, /已經 review 過了/, "an approve skip must not be described as a review skip");
+  });
+});

--- a/packages/cli/test/review-approval.test.ts
+++ b/packages/cli/test/review-approval.test.ts
@@ -3,17 +3,23 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { consumeApprovalOffer, consumeApprovalReservation, listPendingApprovalReconciliations, markApprovalPendingReconcile, releaseApprovalReservation, reserveApprovalOffer, resolveApprovalReconciliation, saveApprovalOffer, sweepApprovalOffers } from "../src/gateway/review-approval";
+import { consumeApprovalOffer, consumeApprovalReservation, listPendingApprovalReconciliations, markApprovalPendingReconcile, peekApprovalOffer, releaseApprovalReservation, reserveApprovalOffer, resolveApprovalReconciliation, saveApprovalOffer, sweepApprovalOffers } from "../src/gateway/review-approval";
 
-const originalHome = process.env.HOME;
+// Never point HOME back at the operator's home. Test files run in separate
+// processes, so restoring buys nothing — and it opens a window that has
+// already caused an outage: a cancelled test's abandoned continuation resumes
+// AFTER afterEach, sees the real HOME, and writes to the live ~/.pmk. On
+// 2026-08-04 that overwrote the gateway config with test fixtures and took the
+// bot down. ORIG_HOME is a throwaway directory, never the real one.
+const ORIG_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-safe-home-"));
+process.env.HOME = ORIG_HOME;
 let tmp: string;
 beforeEach(() => {
   tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pmk-review-offer-"));
   process.env.HOME = tmp;
 });
 afterEach(() => {
-  if (originalHome === undefined) delete process.env.HOME;
-  else process.env.HOME = originalHome;
+  process.env.HOME = ORIG_HOME;
   fs.rmSync(tmp, { recursive: true, force: true });
 });
 
@@ -23,6 +29,32 @@ describe("review approval offers", () => {
     saveApprovalOffer("C1", "1.1", ref);
     assert.deepEqual(consumeApprovalOffer("C1", "1.1"), [ref]);
     assert.equal(consumeApprovalOffer("C1", "1.1"), undefined);
+  });
+
+  it("peeks a pending offer without spending it", () => {
+    const ref = { owner: "o", repo: "r", number: 3, url: "https://github.com/o/r/pull/3", headSha: "abc", baseRef: "main", artifactSha256: "digest" };
+    saveApprovalOffer("C1", "1.1", ref);
+    assert.deepEqual(peekApprovalOffer("C1", "1.1"), [ref]);
+    assert.deepEqual(
+      consumeApprovalOffer("C1", "1.1"),
+      [ref],
+      "peeking must leave the offer claimable — it only decides what to say",
+    );
+  });
+
+  it("does not report an expired offer as pending", () => {
+    saveApprovalOffer("C1", "1.1", { owner: "o", repo: "r", number: 3, url: "u", headSha: "abc", baseRef: "main", artifactSha256: "digest" }, -1);
+    assert.equal(peekApprovalOffer("C1", "1.1"), undefined);
+  });
+
+  it("does not report an offer that an approve already reserved", () => {
+    saveApprovalOffer("C1", "1.1", { owner: "o", repo: "r", number: 3, url: "u", headSha: "abc", baseRef: "main", artifactSha256: "digest" });
+    assert.ok(reserveApprovalOffer("C1", "1.1"));
+    assert.equal(
+      peekApprovalOffer("C1", "1.1"),
+      undefined,
+      "an approve in flight must not be advertised as an offer to reply to",
+    );
   });
 
   it("rejects an expired offer", () => {

--- a/packages/cli/test/review-claim.test.ts
+++ b/packages/cli/test/review-claim.test.ts
@@ -40,6 +40,36 @@ describe("review-claim", () => {
     assert.equal(isReviewDone(r), true);
   });
 
+  it("finalize records the outcome so a later trigger can report what was decided", async () => {
+    const { claimReview, finalizeReview, readFinalizedReview } = await import("../src/gateway/review-claim");
+    claimReview(r);
+    finalizeReview(r, {
+      status: "COMMENTED",
+      reviewUrl: "https://github.com/o/rr/pull/5",
+      blockerCount: 0,
+      commentCount: 1,
+    });
+    const prior = readFinalizedReview(r);
+    assert.equal(prior?.status, "COMMENTED");
+    assert.equal(prior?.reviewUrl, "https://github.com/o/rr/pull/5");
+    assert.equal(prior?.blockerCount, 0);
+    assert.equal(prior?.commentCount, 1);
+    assert.ok(
+      prior?.finalizedAt && !Number.isNaN(Date.parse(prior.finalizedAt)),
+      "finalizedAt must be a parsable instant — the note says WHEN the commit was reviewed",
+    );
+  });
+
+  it("a claim that is still running has no outcome to report", async () => {
+    const { claimReview, readFinalizedReview } = await import("../src/gateway/review-claim");
+    claimReview(r);
+    assert.equal(
+      readFinalizedReview(r),
+      undefined,
+      "an in-flight claim must not read back as a finished review",
+    );
+  });
+
   it("release allows a fresh claim", async () => {
     const { claimReview, releaseReview } = await import("../src/gateway/review-claim");
     claimReview(r);

--- a/packages/cli/test/review-coordinator.test.ts
+++ b/packages/cli/test/review-coordinator.test.ts
@@ -726,8 +726,44 @@ describe("ReviewCoordinator idempotency UX (already-reviewed note)", () => {
     await c.fromMessage({ ...msg, threadTs: "1.2" }); // same PR + head → already done
     const after = web.posted.slice(n);
     assert.ok(
-      after.some((p) => /已經 review 過/.test(p.text ?? "")),
+      after.some((p) => /已經 review 過|完成 review/.test(p.text ?? "")),
       "second review of the same commit must post an 'already reviewed' note, not stay silent",
+    );
+  });
+
+  it("the note reports the prior verdict + link, and offers an admin `rerun`", async () => {
+    const web = new FakeWebClient();
+    const c = coord(web, gw()); // default result: CHANGES_REQUESTED, 2 comments
+    const msg = {
+      channelId: "C1", threadTs: "1.1", userId: "U1", // U1 is an admin
+      text: ":cr: https://github.com/onead/OnePixel/pull/12",
+    };
+    await c.fromMessage(msg);
+    const n = web.posted.length;
+    await c.fromMessage({ ...msg, threadTs: "1.2" });
+    const after = web.posted.slice(n).map((p) => p.text ?? "").join("\n");
+    assert.match(after, /CHANGES_REQUESTED/, "the skip note must carry what was decided last time");
+    assert.match(after, /pull\/12/, "and where to read it");
+    assert.match(after, /`rerun`/, "an admin must learn they can force a re-review");
+  });
+
+  it("`:a:` on an already-reviewed clean commit points at the waiting offer, not at pushing", async () => {
+    const web = new FakeWebClient();
+    const c = coord(web, gw({ runMraReview: async () => eligibleReviewResult() as never }));
+    const thread = { channelId: "C1", threadTs: "1.1", userId: "U1" };
+    // :cr: reviews the commit clean → an approve offer is saved on this thread.
+    await c.fromMessage({ ...thread, text: ":cr: https://github.com/onead/OnePixel/pull/12" });
+    const n = web.posted.length;
+    // Same commit, now via :a: — the pre-review hits the finalized claim.
+    await c.fromMessage({ ...thread, text: ":a: https://github.com/onead/OnePixel/pull/12" });
+    const after = web.posted.slice(n).map((p) => p.text ?? "");
+    assert.ok(
+      after.some((t) => /回覆 `approve`/.test(t)),
+      "the pending offer is the open next step and must be named",
+    );
+    assert.ok(
+      !after.some((t) => /推新 commit|push 後再發/.test(t)),
+      "must not send an approver off to push a commit that does not exist",
     );
   });
 });


### PR DESCRIPTION
## Why

Live on 2026-08-12, `onead/finance-system#363`:

| 時間 (UTC) | 事件 |
|---|---|
| 06:44 | 作者 push `f3117a7`「修正 code review 抓到的兩個高風險問題」 |
| 06:54 | `:cr:` 完成 review — COMMENTED、0 blocker、1 則建議；approve offer 存進 thread |
| 07:11 | 作者發 `:a:` → pre-review 撞到 idempotency claim → 「已經 review 過了，要重審請推新 commit 後再發」 |
| 09:27 | 作者再發 `:cr:` → 同一句話 |

去重機制本身是對的（v0.38.0 加的，擋掉同 commit 重審導致結論翻轉）。壞的是那句話：它只描述「略過」，沒說**上次審出什麼**，也沒說**這個人當下唯一走得通的下一步**——一個等著被核准的 offer 就在同一個 thread 裡。結果最需要那份結果的人，被指去推一個不存在的 commit。

## Fixed

- `finalizeReview` 記下裁決本身（`status` / `blockerCount` / `commentCount` / `reviewUrl` / `finalizedAt`）；`readFinalizedReview` 讀回。未 finalize 的 claim 讀回 `undefined`——進行中的 review 永遠不會被報成「已完成」。
- `alreadyReviewedMessage`（純函式）：先講上次的裁決、時間（台北）、連結，再講這個使用者當下唯一開著的路——待處理的 approve offer，或 admin 的 `rerun`。非 admin 不會拿到一句他用不了的建議。
- `runOne` 指向 offer 前先比對 `headSha`。舊 commit 留下的 offer 不是這個 commit 的出路，指過去等於授權錯的程式碼。
- `peekApprovalOffer`：唯讀查詢，決定「要說什麼」不會花掉 offer；已被 reserve 的 offer（approve 進行中）讀為不存在，不會邀請第二次回覆。

### 實際輸出

`:a:` 撞到已審過的乾淨 commit：

```
:information_source: onead/finance-system#363 這個 commit（`f3117a7`）已在 08/12 14:54 完成 review：COMMENTED、0 個 blocker、1 則建議 → https://github.com/onead/finance-system/pull/363
這個結果可以 approve — 要核准請在這個 thread 回覆 `approve`。（要對同一 commit 強制重跑：在這個 thread 回覆 `rerun`）
```

一般使用者、上次有 blocker、無有效 offer：

```
:information_source: onead/finance-system#363 這個 commit（`f3117a7`）已在 08/12 14:28 完成 review：CHANGES_REQUESTED、2 個 blocker、2 則建議 → https://github.com/onead/finance-system/pull/363
同一 commit 不重複審；有新的修改請 push 後再發 `:cr:`。
```

線上既有 claim 檔沒有新欄位，會降級成 `已完成 review：COMMENTED`（不會漏出 `undefined`）；新審的 commit 才有完整資訊。

### 另外

`test/review-approval.test.ts` 的 `afterEach` 還在把 `HOME` 指回操作者真實家目錄——正是 2026-08-04 讓 gateway 停機的模式。其他測試檔早已改用拋棄式 `ORIG_HOME`，這個檔漏了，一併補上。

## Tests

`1158 → 1171 (+13)`，全綠（含 typecheck）。TDD 三輪，每輪都先看到預期的失敗：

- `review-claim.test.ts` +2：finalize 記錄可讀回、進行中的 claim 沒有結論可報
- `review-already-reviewed.test.ts`（新）+6：裁決摘要、offer 優先於「去 push」、admin 才給 `rerun`、無紀錄時降級不漏 `undefined`、approve 用語
- `review-approval.test.ts` +3：peek 不消耗、過期不算、已 reserve 不算
- `review-coordinator.test.ts` +2：整合驗證裁決與連結真的接上、`:a:` 指向 offer 而非 push

## Test plan

- [x] `npm test`（packages/cli）1171 pass / 0 fail
- [ ] CI rollup 綠（check-frontmatter / docs build）
- [ ] Live-Slack verify：對已審過的 PR 重發 `:cr:`，確認新訊息帶裁決 + 下一步
- [ ] v0.43.0 bump + tag + README 版本列