### PR TITLE
fix(review): 讀不到 thread 不等於沒有 review

### DIFF
--- a/apps/docs/docs/gateway/lifecycle.md
+++ b/apps/docs/docs/gateway/lifecycle.md
@@ -143,7 +143,7 @@ The thread is now "pending escalation". When any subsequent message arrives in t
 1. Does this `(channelId, threadTs)` have a pending marker?
 2. Is the message's sender in `marker.mentionedUserIds`?
 
-If both true → it's an IT contact's reply → run the absorb path. If sender isn't on the list, the marker stays pending. (For channel context the IT contact must `@pmk` their reply because we don't hold `channels:history` scope — DMs don't need this since `im:history` already gives us message visibility.)
+If both true → it's an IT contact's reply → run the absorb path. If sender isn't on the list, the marker stays pending. (For channel context the IT contact must `@pmk` their reply: the gateway only handles raw `message` events in DMs and routes everything else through `app_mention`, so a channel reply that doesn't mention the bot never reaches this path. The `channels:history` scope added in 2026-08 lets the bot *re-read* a named message on demand; it does not subscribe it to channel traffic.)
 
 ## 9. LLM extractor → KnowledgeAtom
 

--- a/apps/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/gateway/lifecycle.md
+++ b/apps/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/gateway/lifecycle.md
@@ -137,7 +137,7 @@ Gateway 透過 `pickEscalationPool(cfg, repo)` 挑一組 IT 聯絡人（repo 特
 1. 這個 `(channelId, threadTs)` 有沒有 pending marker？
 2. 訊息發送者是不是 `marker.mentionedUserIds` 內的人？
 
-兩個都 yes → 就是 IT 同事的回覆 → 走 absorb path。發送者不在名單就維持 pending。（在 channel 場景，IT 同事必須 `@pmk` 才接得到 — 因為我們沒持有 `channels:history` scope；DM 不用這層因為 `im:history` 已經給我們訊息可見性。）
+兩個都 yes → 就是 IT 同事的回覆 → 走 absorb path。發送者不在名單就維持 pending。（在 channel 場景，IT 同事必須 `@pmk` 才接得到：gateway 只在 DM 處理原始 `message` 事件，其他一律走 `app_mention`，所以頻道裡沒 mention bot 的回覆不會進到這條路徑。2026-08 加的 `channels:history` scope 只讓 bot 能主動回讀指定的某一則訊息，不等於訂閱頻道流量。）
 
 ## 9. LLM extractor → KnowledgeAtom
 

--- a/packages/cli/src/gateway/doctor-checks/index.ts
+++ b/packages/cli/src/gateway/doctor-checks/index.ts
@@ -2,6 +2,7 @@ import type { DoctorCheck } from "../doctor";
 import { configFileCheck } from "./config-file";
 import { slackAppTokenCheck } from "./slack-app-token";
 import { slackBotTokenCheck } from "./slack-bot-token";
+import { slackBotScopesCheck } from "./slack-bot-scopes";
 import { anthropicKeyCheck } from "./anthropic-key";
 import { mraWorkspaceCheck } from "./mra-workspace";
 import { pkbContentCheck } from "./pkb-content";
@@ -17,6 +18,7 @@ export {
   configFileCheck,
   slackAppTokenCheck,
   slackBotTokenCheck,
+  slackBotScopesCheck,
   anthropicKeyCheck,
   mraWorkspaceCheck,
   pkbContentCheck,
@@ -39,6 +41,9 @@ export const DEFAULT_CHECKS: DoctorCheck[] = [
   secretSourcesCheck,
   slackAppTokenCheck,
   slackBotTokenCheck,
+  // Right after the token check: a valid token with the wrong scopes fails
+  // silently at runtime, so the two belong side by side in the output.
+  slackBotScopesCheck,
   anthropicKeyCheck,
   mraWorkspaceCheck,
   pkbContentCheck,

--- a/packages/cli/src/gateway/doctor-checks/slack-bot-scopes.ts
+++ b/packages/cli/src/gateway/doctor-checks/slack-bot-scopes.ts
@@ -1,0 +1,60 @@
+// What the INSTALLED Slack app actually holds, as opposed to what the repo's
+// manifest declares. manifest-alignment.ts compares two things the operator's
+// workspace never touches (the template file and expectedScopes()), so an app
+// installed before a scope was added keeps passing every check.
+//
+// 2026-08-14, finance-system#378: the live bot token held `im:history` but not
+// `channels:history`. Every thread-root re-read in a channel threw
+// missing_scope, `rerun` told users their thread had no review, and the `:cr:`
+// reaction path posted nothing at all — while `pmk gateway doctor` reported
+// zero failures. auth.test returns the granted scopes; this check reads them.
+import { expectedScopes } from "../slack/manifest-version";
+import type { DoctorCheckResult, DoctorContext } from "../doctor";
+
+export async function slackBotScopesCheck(
+  ctx: DoctorContext,
+): Promise<DoctorCheckResult> {
+  const name = "slack-bot-scopes";
+  const token = ctx.config?.slack?.botToken;
+  if (!token) {
+    return {
+      name,
+      severity: "fail",
+      message: "no Bot User OAuth Token (xoxb-...) to inspect",
+      hint: "run: pmk gateway init",
+    };
+  }
+  const res = await ctx.runners.slackBotAuth(token);
+  if (!res.ok) {
+    return {
+      name,
+      severity: "fail",
+      message: `cannot read granted scopes — Slack rejected the Bot Token: ${res.error ?? "unknown"}`,
+      hint: "fix the token first (see slack-bot-token)",
+    };
+  }
+  if (!res.scopes) {
+    // Reporting "pass" here would claim knowledge this check does not have.
+    return {
+      name,
+      severity: "warn",
+      message: "Slack returned no scope list; granted scopes not verified",
+      hint: "compare manually: curl -sD- -o/dev/null -XPOST https://slack.com/api/auth.test -H 'Authorization: Bearer <xoxb-…>' | grep -i x-oauth-scopes",
+    };
+  }
+  const granted = new Set(res.scopes);
+  const missing = expectedScopes().filter((s) => !granted.has(s));
+  if (missing.length > 0) {
+    return {
+      name,
+      severity: "fail",
+      message: `installed Slack app is missing ${missing.length} granted bot scope(s)`,
+      hint: `add at api.slack.com/apps → OAuth & Permissions → Bot Token Scopes, then reinstall: ${missing.join(", ")}`,
+    };
+  }
+  return {
+    name,
+    severity: "pass",
+    message: `all ${expectedScopes().length} expected bot scopes granted`,
+  };
+}

--- a/packages/cli/src/gateway/doctor.ts
+++ b/packages/cli/src/gateway/doctor.ts
@@ -43,6 +43,12 @@ export interface DoctorRunners {
     user?: string;
     botId?: string;
     error?: string;
+    /**
+     * Scopes Slack reports as granted to THIS token (auth.test's
+     * `response_metadata.scopes`). Absent when the response omits it — that is
+     * "unknown", never "none": the scopes check warns rather than passing.
+     */
+    scopes?: readonly string[];
   }>;
   anthropicEcho: (
     apiKey: string,
@@ -270,16 +276,19 @@ async function defaultSlackBotAuth(
   user?: string;
   botId?: string;
   error?: string;
+  scopes?: readonly string[];
 }> {
   if (!token) return { ok: false, error: "no bot token configured" };
   try {
     const res = await new WebClient(token).auth.test();
     if (!res.ok) return { ok: false, error: res.error ?? "unknown" };
+    const granted = (res.response_metadata as { scopes?: string[] } | undefined)?.scopes;
     return {
       ok: true,
       team: res.team,
       user: res.user,
       botId: res.bot_id,
+      scopes: granted,
     };
   } catch (err) {
     return {

--- a/packages/cli/src/gateway/slack/index.ts
+++ b/packages/cli/src/gateway/slack/index.ts
@@ -722,7 +722,7 @@ export class SlackAdapter {
     // silently swallowed regardless of which coordinators are enabled.
     if (isRerunRequest(text)) {
       if (this.review.isEnabled()) {
-        await this.review.rerunInThread({ channelId, threadTs: replyThreadTs, userId }).catch((err) =>
+        await this.review.rerunInThread({ channelId, threadTs: replyThreadTs, userId, text }).catch((err) =>
           this.onLog(`review: mention rerun failed: ${(err as Error).message}`),
         );
       }
@@ -915,7 +915,7 @@ export class SlackAdapter {
     // silently swallowed regardless of which coordinators are enabled.
     if (isRerunRequest(text)) {
       if (this.review.isEnabled()) {
-        await this.review.rerunInThread({ channelId, threadTs, userId }).catch((err) =>
+        await this.review.rerunInThread({ channelId, threadTs, userId, text }).catch((err) =>
           this.onLog(`review: DM rerun failed: ${(err as Error).message}`),
         );
       }

--- a/packages/cli/src/gateway/slack/manifest-version.ts
+++ b/packages/cli/src/gateway/slack/manifest-version.ts
@@ -20,6 +20,14 @@ const BOT_SCOPES = [
   "im:write",
   "users:read",
   "reactions:read",
+  // The review flow re-reads a thread's root message (conversations.history)
+  // for `rerun`, `retry`, and the `:cr:` / `:a:` reaction paths. `im:history`
+  // only covers DMs; without these two, every one of those commands fails in a
+  // channel with missing_scope. Added 2026-08-14 after finance-system#378,
+  // where `rerun` reported the thread as having no review because the read
+  // itself was refused.
+  "channels:history",
+  "groups:history",
 ] as const;
 
 const BOT_EVENTS = [

--- a/packages/cli/src/gateway/slack/manifest.template.json
+++ b/packages/cli/src/gateway/slack/manifest.template.json
@@ -20,7 +20,9 @@
         "im:read",
         "im:write",
         "users:read",
-        "reactions:read"
+        "reactions:read",
+        "channels:history",
+        "groups:history"
       ]
     }
   },

--- a/packages/cli/src/gateway/slack/review-messages.ts
+++ b/packages/cli/src/gateway/slack/review-messages.ts
@@ -155,6 +155,34 @@ export function alreadyReviewedMessage(input: {
   return `:information_source: ${slug}#${pr} 這個 commit（\`${headSha.slice(0, 7)}\`）${lede}${verdict}${link}\n${next}${adminHint}`;
 }
 
+/**
+ * The reply when the bot cannot READ the thread root it needs. Distinct from
+ * "this thread has no PR review": that one is a fact about the thread, this one
+ * is a fact about the bot's own access, and reporting the second as the first
+ * sends the user to debug their own thread.
+ *
+ * Live on 2026-08-14 (finance-system#378): the bot token holds `im:history` but
+ * not `channels:history`, so every thread-root re-read in a CHANNEL threw
+ * missing_scope. `rerun` answered "這個 thread 沒有可重跑的 PR review" about a thread
+ * whose root was a valid `:a:` request, and the `:cr:` reaction path posted
+ * nothing at all. Both blamed the user for a scope the bot was never granted.
+ */
+export function threadReadFailedMessage(input: {
+  /** The Slack error, verbatim. Named so the operator can act without reading logs. */
+  error: string;
+  /** What the user did, so the suggested fallback matches their intent. */
+  command: "rerun" | "retry" | "cr" | "a";
+}): string {
+  const inline = input.command === "a" ? ":a:" : ":cr:";
+  const scopeHint = /missing_scope/.test(input.error)
+    ? "\n這是 bot 的權限問題，不是你的操作問題：在頻道回讀 thread 需要 `channels:history`（私有頻道另需 `groups:history`），DM 不受影響。"
+    : "";
+  return (
+    `:warning: 我讀不到這個 thread 的原始訊息（Slack 回：${input.error}），無法判斷要處理哪個 PR。\n` +
+    `請改用 \`${inline} <PR 連結>\` 直接發起。${scopeHint}`
+  );
+}
+
 /** Last non-empty line of `s`, with ANSI colour escapes stripped and trimmed. */
 function lastNonEmptyLine(s?: string): string | undefined {
   if (!s) return undefined;

--- a/packages/cli/src/gateway/slack/review-messages.ts
+++ b/packages/cli/src/gateway/slack/review-messages.ts
@@ -148,8 +148,13 @@ export function alreadyReviewedMessage(input: {
       : isApprove
         ? "同一 commit 不重複 approve；要重新判斷請推新 commit 後再發 `:a:`。"
         : "同一 commit 不重複審；有新的修改請 push 後再發 `:cr:`。";
+  // Name the PR in the offered command. A bare `rerun` has to re-read the thread
+  // root to learn which PR it means, and in a channel without `channels:history`
+  // that read fails — which on 2026-08-14 left an admin holding a command this
+  // very note had just told them to use. A self-contained command runs wherever
+  // it is pasted.
   const adminHint = input.isAdmin
-    ? "（要對同一 commit 強制重跑：在這個 thread 回覆 `rerun`）"
+    ? `（要對同一 commit 強制重跑：回覆 \`rerun https://github.com/${slug}/pull/${pr}\`）`
     : "";
 
   return `:information_source: ${slug}#${pr} 這個 commit（\`${headSha.slice(0, 7)}\`）${lede}${verdict}${link}\n${next}${adminHint}`;

--- a/packages/cli/src/gateway/slack/review-requests.ts
+++ b/packages/cli/src/gateway/slack/review-requests.ts
@@ -4,7 +4,7 @@
  * kind of review command. Extracted from review.ts to keep the coordinator lean;
  * re-exported from there for back-compat.
  */
-import { parsePrRefs } from "../pr-ref";
+import { parsePrRefs, type PrRef } from "../pr-ref";
 
 /** True when a message is a `:cr:` review request with at least one PR link. */
 export function isReviewRequest(text: string): boolean {
@@ -106,5 +106,29 @@ export function isRetryRequest(text: string): boolean {
 
 export function isRerunRequest(text: string): boolean {
   const t = text.trim().toLowerCase();
-  return t === "rerun" || t === "重跑";
+  if (t === "rerun" || t === "重跑") return true;
+  return rerunPrRefs(text).length > 0;
+}
+
+/**
+ * PR refs carried by a `rerun <PR 連結>` command; empty for a bare `rerun` and
+ * for ordinary chat.
+ *
+ * A bare `rerun` has to re-read the thread root to learn which PR it means, and
+ * that read is precisely what fails in a channel the bot lacks
+ * `channels:history` for (2026-08-14, finance-system#378) — leaving the user
+ * with a command the bot had just told them to use and no way to run it.
+ * Naming the PR on the command line keeps the text in hand, so the forced
+ * re-review works anywhere the user can type.
+ *
+ * The token must LEAD, matching `isReviewCommandMissingPr`: a sentence that
+ * merely mentions a rerun ("我剛 rerun 過 <link>") is chat, and hijacking it
+ * would force a re-review nobody asked for. Requiring whitespace after the
+ * token also keeps "rerunning …" out.
+ */
+export function rerunPrRefs(text: string): PrRef[] {
+  const t = text.trim();
+  const lead = /^(?:rerun|重跑)\s+/i.exec(t);
+  if (!lead) return [];
+  return parsePrRefs(t.slice(lead[0].length));
 }

--- a/packages/cli/src/gateway/slack/review.ts
+++ b/packages/cli/src/gateway/slack/review.ts
@@ -61,7 +61,7 @@ import { ReviewRunner } from "./review-runner";
 // Pure request classifiers + result-text formatters live in sibling modules.
 // Imported for internal use, and re-exported so slack/index.ts and the review
 // tests keep importing them from "./review" unchanged.
-import { isReviewRequest, isApproveRequest } from "./review-requests";
+import { isReviewRequest, isApproveRequest, rerunPrRefs } from "./review-requests";
 import { threadReadFailedMessage } from "./review-messages";
 export {
   isReviewRequest,
@@ -71,6 +71,7 @@ export {
   reviewCommandUsageText,
   isRetryRequest,
   isRerunRequest,
+  rerunPrRefs,
 } from "./review-requests";
 export {
   type ReviewOutcome,
@@ -458,12 +459,34 @@ export class ReviewCoordinator {
     else await this.processReviewRequest(req);
   }
 
-  /** Admin-only forced re-review of an already finalized same-SHA claim. */
-  async rerunInThread(args: { channelId: string; threadTs: string; userId: string }): Promise<void> {
+  /**
+   * Admin-only forced re-review of an already finalized same-SHA claim.
+   *
+   * `rerun <PR 連結>` names its own target and skips the thread-root read
+   * entirely, so it works in a channel the bot cannot read back. A bare `rerun`
+   * still resolves the PR from the thread root.
+   */
+  async rerunInThread(args: {
+    channelId: string;
+    threadTs: string;
+    userId: string;
+    /** The rerun message itself; a PR link in it takes precedence over the root. */
+    text?: string;
+  }): Promise<void> {
     const config = this.currentConfig();
     if (!resolveReviewConfig(config.review).enabled) return;
     if (!isAdmin(config, args.userId)) {
       await this.reply(args.channelId, args.threadTs, ":no_entry: `rerun` 會略過同 commit 的完成紀錄，只允許 PMK admin 執行。");
+      return;
+    }
+    if (args.text && rerunPrRefs(args.text).length > 0) {
+      await this.processReviewRequest({
+        channelId: args.channelId,
+        threadTs: args.threadTs,
+        actorUserId: args.userId,
+        text: args.text,
+        forced: true,
+      });
       return;
     }
     const read = await this.readMessageText(args.channelId, args.threadTs);

--- a/packages/cli/src/gateway/slack/review.ts
+++ b/packages/cli/src/gateway/slack/review.ts
@@ -62,6 +62,7 @@ import { ReviewRunner } from "./review-runner";
 // Imported for internal use, and re-exported so slack/index.ts and the review
 // tests keep importing them from "./review" unchanged.
 import { isReviewRequest, isApproveRequest } from "./review-requests";
+import { threadReadFailedMessage } from "./review-messages";
 export {
   isReviewRequest,
   isApproveRequest,
@@ -77,7 +78,17 @@ export {
   reviewResultText,
   approveResultText,
   describeMraFailure,
+  threadReadFailedMessage,
 } from "./review-messages";
+
+/**
+ * Outcome of reading one Slack message. `ok: true` with an undefined `text`
+ * means the read succeeded and the message carries no text; `ok: false` means
+ * the read itself failed and NOTHING is known about the message.
+ */
+export type MessageTextRead =
+  | { readonly ok: true; readonly text: string | undefined }
+  | { readonly ok: false; readonly error: string };
 
 export interface ReviewGateway {
   resolveProjectByRemote: typeof resolveProjectByRemoteImpl;
@@ -209,12 +220,22 @@ export class ReviewCoordinator {
     messageTs: string;
     reactorUserId: string;
   }): Promise<void> {
-    const text = await this.fetchMessageText(args.channelId, args.messageTs);
+    const read = await this.readMessageText(args.channelId, args.messageTs);
+    if (!read.ok) {
+      // Without the text there are no PR refs, and processReviewRequest returns
+      // early on zero refs — so this used to be a completely silent drop.
+      await this.reply(
+        args.channelId,
+        args.messageTs,
+        threadReadFailedMessage({ error: read.error, command: "cr" }),
+      );
+      return;
+    }
     await this.processReviewRequest({
       channelId: args.channelId,
       threadTs: args.messageTs,
       actorUserId: args.reactorUserId,
-      text: text ?? "",
+      text: read.text ?? "",
     });
   }
 
@@ -243,12 +264,20 @@ export class ReviewCoordinator {
     messageTs: string;
     reactorUserId: string;
   }): Promise<void> {
-    const text = await this.fetchMessageText(args.channelId, args.messageTs);
+    const read = await this.readMessageText(args.channelId, args.messageTs);
+    if (!read.ok) {
+      await this.reply(
+        args.channelId,
+        args.messageTs,
+        threadReadFailedMessage({ error: read.error, command: "a" }),
+      );
+      return;
+    }
     await this.processApproveRequest({
       channelId: args.channelId,
       threadTs: args.messageTs,
       actorUserId: args.reactorUserId,
-      text: text ?? "",
+      text: read.text ?? "",
     });
   }
 
@@ -392,7 +421,16 @@ export class ReviewCoordinator {
     userId: string;
   }): Promise<void> {
     if (!resolveReviewConfig(this.currentConfig().review).enabled) return;
-    const rootText = await this.fetchMessageText(args.channelId, args.threadTs);
+    const read = await this.readMessageText(args.channelId, args.threadTs);
+    if (!read.ok) {
+      await this.reply(
+        args.channelId,
+        args.threadTs,
+        threadReadFailedMessage({ error: read.error, command: "retry" }),
+      );
+      return;
+    }
+    const rootText = read.text;
     // An approve thread (`:a:`) is drained the same way as a `:cr:` review and its
     // interruption notice tells the user to reply `retry` — so retry must re-run
     // the APPROVE flow for an `:a:` root, not fall through to the nudge (which
@@ -428,7 +466,16 @@ export class ReviewCoordinator {
       await this.reply(args.channelId, args.threadTs, ":no_entry: `rerun` 會略過同 commit 的完成紀錄，只允許 PMK admin 執行。");
       return;
     }
-    const rootText = await this.fetchMessageText(args.channelId, args.threadTs);
+    const read = await this.readMessageText(args.channelId, args.threadTs);
+    if (!read.ok) {
+      await this.reply(
+        args.channelId,
+        args.threadTs,
+        threadReadFailedMessage({ error: read.error, command: "rerun" }),
+      );
+      return;
+    }
+    const rootText = read.text;
     const approve = rootText ? isApproveRequest(rootText) : false;
     const review = rootText ? isReviewRequest(rootText) : false;
     if (!rootText || (!approve && !review)) {
@@ -528,10 +575,14 @@ export class ReviewCoordinator {
     }
   }
 
-  private async fetchMessageText(
-    channel: string,
-    ts: string,
-  ): Promise<string | undefined> {
+  /**
+   * Read one message's text. The result distinguishes "read it, here is the
+   * text" from "could not read it" — collapsing both into `undefined` is what
+   * let a missing `channels:history` scope surface to users as "this thread has
+   * no PR review" (2026-08-14, finance-system#378). Callers that speak to the
+   * user MUST branch on `ok` rather than on the text being empty.
+   */
+  private async readMessageText(channel: string, ts: string): Promise<MessageTextRead> {
     try {
       const res = (await this.opts.web.conversations.history({
         channel,
@@ -540,10 +591,20 @@ export class ReviewCoordinator {
         inclusive: true,
         limit: 1,
       } as never)) as { messages?: Array<{ text?: string }> };
-      return res.messages?.[0]?.text;
+      return { ok: true, text: res.messages?.[0]?.text };
     } catch (err) {
-      this.opts.onLog(`review: fetch message failed: ${(err as Error).message}`);
-      return undefined;
+      const error = (err as Error).message;
+      this.opts.onLog(`review: fetch message failed: ${error}`);
+      return { ok: false, error };
     }
+  }
+
+  /**
+   * Text-or-undefined view of {@link readMessageText}, for callers whose
+   * behaviour on a read failure is already the same as on a missing message.
+   */
+  private async fetchMessageText(channel: string, ts: string): Promise<string | undefined> {
+    const read = await this.readMessageText(channel, ts);
+    return read.ok ? read.text : undefined;
   }
 }

--- a/packages/cli/test/gateway-doctor.test.ts
+++ b/packages/cli/test/gateway-doctor.test.ts
@@ -17,6 +17,7 @@ import {
   configFileCheck,
   slackAppTokenCheck,
   slackBotTokenCheck,
+  slackBotScopesCheck,
   anthropicKeyCheck,
   mraWorkspaceCheck,
   pkbContentCheck,
@@ -26,6 +27,7 @@ import {
   DEFAULT_CHECKS,
 } from "../src/gateway/doctor-checks";
 import type { GatewayConfig } from "../src/gateway/config";
+import { expectedScopes } from "../src/gateway/slack/manifest-version";
 
 const REPO_MANIFEST = path.resolve(
   __dirname,
@@ -166,6 +168,85 @@ describe("doctor — slack-bot-token check (FR2 #3)", () => {
     const r = await slackBotTokenCheck(makeCtx());
     assert.equal(r.severity, "pass");
     assert.match(r.message, /team=T123/);
+  });
+});
+
+// manifest-alignment compares the repo's manifest template against
+// expectedScopes() — both sides of a comparison the operator's INSTALLED app
+// never enters. On 2026-08-14 the installed app was missing `channels:history`
+// while doctor reported 0 failures, because nothing ever asked Slack what the
+// live token actually holds. auth.test returns the granted scopes in
+// response_metadata; this check is the one that would have caught it.
+describe("doctor — slack-bot-scopes check", () => {
+  it("FAILs and names the scopes the installed app is missing", async () => {
+    const r = await slackBotScopesCheck(
+      makeCtx({
+        runners: {
+          ...makeOkRunners(),
+          slackBotAuth: async () => ({
+            ok: true,
+            team: "T123",
+            user: "pmk",
+            scopes: ["app_mentions:read", "chat:write", "im:history"],
+          }),
+        },
+      }),
+    );
+    assert.equal(r.severity, "fail");
+    assert.match(
+      r.hint ?? "",
+      /channels:history/,
+      "the operator must learn WHICH scope to add, not just that something is missing",
+    );
+  });
+
+  it("PASSes when every expected scope is granted", async () => {
+    const r = await slackBotScopesCheck(
+      makeCtx({
+        runners: {
+          ...makeOkRunners(),
+          slackBotAuth: async () => ({
+            ok: true,
+            team: "T123",
+            user: "pmk",
+            scopes: [...expectedScopes()],
+          }),
+        },
+      }),
+    );
+    assert.equal(r.severity, "pass");
+  });
+
+  // Not knowing is not the same as being fine: a token check that cannot read
+  // the scope list must say so rather than report a clean bill of health.
+  it("WARNs when Slack returns no scope list", async () => {
+    const r = await slackBotScopesCheck(makeCtx());
+    assert.equal(r.severity, "warn");
+  });
+
+  it("FAILs when the token itself is rejected", async () => {
+    const r = await slackBotScopesCheck(
+      makeCtx({
+        runners: {
+          ...makeOkRunners(),
+          slackBotAuth: async () => ({ ok: false, error: "token_expired" }),
+        },
+      }),
+    );
+    assert.equal(r.severity, "fail");
+  });
+});
+
+// The review flow re-reads a thread's root message via conversations.history.
+// In a DM that needs `im:history`; in a channel it needs `channels:history`
+// (private: `groups:history`). The expected-scope list must carry them, or
+// both doctor and the manifest keep declaring an app that cannot run `rerun`,
+// `retry`, or the `:cr:` / `:a:` reaction paths outside a DM.
+describe("expectedScopes — channel thread re-read", () => {
+  it("includes the channel history scopes the review flow depends on", () => {
+    const scopes = expectedScopes() as readonly string[];
+    assert.ok(scopes.includes("channels:history"), "public channels");
+    assert.ok(scopes.includes("groups:history"), "private channels");
   });
 });
 
@@ -492,20 +573,10 @@ describe("doctor — manifest-alignment check (FR2 #8)", () => {
     fs.writeFileSync(
       file,
       JSON.stringify({
-        oauth_config: {
-          scopes: {
-            bot: [
-              "app_mentions:read",
-              "chat:write",
-              "files:read",
-              "im:history",
-              "im:read",
-              "im:write",
-              "users:read",
-              "reactions:read",
-            ],
-          },
-        },
+        // Complete on purpose: this fixture exercises the socket-mode branch,
+        // which is only reached once the scope and event checks pass. Spelling
+        // the list out by hand made an unrelated scope addition fail here.
+        oauth_config: { scopes: { bot: [...expectedScopes()] } },
         settings: {
           socket_mode_enabled: false,
           event_subscriptions: {
@@ -806,14 +877,15 @@ describe("doctor — allowWhenNoReviewGate", () => {
 });
 
 describe("doctor — DEFAULT_CHECKS shape", () => {
-  it("exports exactly 13 checks (FR2 + secret-sources + github-token + review + audio + audit-log)", () => {
-    assert.equal(DEFAULT_CHECKS.length, 13);
+  it("exports exactly 14 checks (FR2 + secret-sources + bot-scopes + github-token + review + audio + audit-log)", () => {
+    assert.equal(DEFAULT_CHECKS.length, 14);
     const names = DEFAULT_CHECKS.map((c) => c.name);
     assert.deepEqual(names, [
       "configFileCheck",
       "secretSourcesCheck",
       "slackAppTokenCheck",
       "slackBotTokenCheck",
+      "slackBotScopesCheck",
       "anthropicKeyCheck",
       "mraWorkspaceCheck",
       "pkbContentCheck",

--- a/packages/cli/test/gateway-manifest.test.ts
+++ b/packages/cli/test/gateway-manifest.test.ts
@@ -21,6 +21,11 @@ const REQUIRED_BOT_SCOPES = [
   "im:write",
   "users:read",
   "reactions:read",
+  // Thread-root re-reads (rerun / retry / the :cr: and :a: reaction paths) call
+  // conversations.history. `im:history` covers DMs only — these two cover
+  // public and private channels. Added 2026-08-14 (finance-system#378).
+  "channels:history",
+  "groups:history",
 ] as const;
 
 const REQUIRED_BOT_EVENTS = [

--- a/packages/cli/test/review-already-reviewed.test.ts
+++ b/packages/cli/test/review-already-reviewed.test.ts
@@ -51,9 +51,18 @@ describe("alreadyReviewedMessage", () => {
     );
   });
 
-  it("tells an admin about `rerun`, since only an admin may force one", () => {
+  // 2026-08-14 (finance-system#378): the note offered a bare `rerun`, which has
+  // to re-read the thread root — the exact call that fails in a channel the bot
+  // lacks `channels:history` for. The admin was handed a command this note had
+  // just recommended and could not run. It now names the PR, so the command is
+  // self-contained wherever it is pasted.
+  it("offers an admin a self-contained `rerun` that names the PR", () => {
     const text = alreadyReviewedMessage({ ...base, isAdmin: true, prior: { status: "COMMENTED" } });
-    assert.match(text, /`rerun`/, "an admin has a way to re-review the same commit");
+    assert.match(
+      text,
+      /`rerun https:\/\/github\.com\/onead\/finance-system\/pull\/363`/,
+      "an admin has a way to re-review the same commit that does not depend on a thread read",
+    );
   });
 
   it("does not offer `rerun` to a non-admin who cannot use it", () => {

--- a/packages/cli/test/review-coordinator.test.ts
+++ b/packages/cli/test/review-coordinator.test.ts
@@ -5,7 +5,7 @@ import * as os from "node:os";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { FakeWebClient } from "./harness/slack-fakes";
-import { ReviewCoordinator, effectiveMraReviewStrategy, isReviewRequest, isRetryRequest, isRerunRequest, isApproveRequest, isApproveConfirmationRequest, isReviewCommandMissingPr, canConfirmApproveFromReview, reviewResultText, approveResultText, describeMraFailure, protectionNotReadyMessage, type ReviewGateway } from "../src/gateway/slack/review";
+import { ReviewCoordinator, effectiveMraReviewStrategy, isReviewRequest, isRetryRequest, isRerunRequest, rerunPrRefs, isApproveRequest, isApproveConfirmationRequest, isReviewCommandMissingPr, canConfirmApproveFromReview, reviewResultText, approveResultText, describeMraFailure, protectionNotReadyMessage, type ReviewGateway } from "../src/gateway/slack/review";
 import { gatewayConfigPath, resolveReviewConfig, saveGatewayConfig } from "../src/gateway/config";
 
 // Never point HOME back at the operator's home. Test files run in separate
@@ -744,7 +744,15 @@ describe("ReviewCoordinator idempotency UX (already-reviewed note)", () => {
     const after = web.posted.slice(n).map((p) => p.text ?? "").join("\n");
     assert.match(after, /CHANGES_REQUESTED/, "the skip note must carry what was decided last time");
     assert.match(after, /pull\/12/, "and where to read it");
-    assert.match(after, /`rerun`/, "an admin must learn they can force a re-review");
+    // The whole point of the 2026-08-14 incident: the note told an admin to
+    // reply `rerun`, and a bare `rerun` needs a thread read the bot could not
+    // do in that channel. The command it hands over must be one that runs
+    // wherever it is pasted, so it names the PR itself.
+    assert.match(
+      after,
+      /`rerun https:\/\/github\.com\/onead\/OnePixel\/pull\/12`/,
+      "the offered command must be copy-pasteable and self-contained",
+    );
   });
 
   it("`:a:` on an already-reviewed clean commit points at the waiting offer, not at pushing", async () => {
@@ -873,6 +881,87 @@ describe("isRetryRequest", () => {
     for (const t of ["please retry", "retry the build", "", ":cr: x"]) {
       assert.equal(isRetryRequest(t), false, `should not match: '${t}'`);
     }
+  });
+});
+
+// A bare `rerun` needs the thread root to know WHICH PR to re-review, and that
+// read is exactly what fails in a channel without `channels:history`. Carrying
+// the link on the command itself is the escape hatch: the text is already in
+// hand, so it works wherever the user can type.
+describe("isRerunRequest with an inline PR link", () => {
+  const PR = "https://github.com/onead/finance-system/pull/378";
+
+  it("matches `rerun <PR 連結>` in bare and Slack-wrapped forms", () => {
+    for (const t of [`rerun ${PR}`, `重跑 ${PR}`, `RERUN <${PR}>`, `rerun <${PR}|#378>`]) {
+      assert.equal(isRerunRequest(t), true, `should match: '${t}'`);
+    }
+  });
+
+  it("exposes the PR refs the command carried", () => {
+    const refs = rerunPrRefs(`rerun ${PR}`);
+    assert.equal(refs.length, 1);
+    assert.equal(refs[0]?.number, 378);
+    assert.equal(refs[0]?.repo, "finance-system");
+  });
+
+  it("reports no refs for a bare rerun, so the thread-root path still runs", () => {
+    assert.deepEqual(rerunPrRefs("rerun"), []);
+    assert.deepEqual(rerunPrRefs("重跑"), []);
+  });
+
+  // The token has to LEAD. Chat that mentions a rerun must stay in free chat,
+  // or an offhand sentence quoting a PR link would force a re-review.
+  it("does not match chat that merely mentions rerun and a PR", () => {
+    for (const t of [`我剛 rerun 過 ${PR}`, `rerunning ${PR}`, `要不要 rerun`, `rerun 沒有連結`]) {
+      assert.deepEqual(rerunPrRefs(t), [], `should carry no refs: '${t}'`);
+    }
+    assert.equal(isRerunRequest(`我剛 rerun 過 ${PR}`), false);
+    assert.equal(isRerunRequest(`rerunning ${PR}`), false);
+  });
+});
+
+describe("ReviewCoordinator.rerunInThread with an inline PR link", () => {
+  const PR = "https://github.com/onead/OnePixel/pull/12";
+
+  it("re-reviews the linked PR without reading the thread root", async () => {
+    const web = new FakeWebClient();
+    web.conversations.history = async () => {
+      throw new Error("An API error occurred: missing_scope");
+    };
+    let calls = 0;
+    const c = coord(web, gw({
+      runMraReview: async () => {
+        calls++;
+        return { ok: true, status: "COMMENT", commentCount: 0, stdout: "", stderr: "" };
+      },
+    } as unknown as Partial<ReviewGateway>));
+    await c.rerunInThread({ channelId: "C1", threadTs: "1.1", userId: "U1", text: `rerun ${PR}` });
+    assert.equal(calls, 1, "the linked PR must be reviewed even though the thread is unreadable");
+  });
+
+  it("forces a re-review of a commit already finalized", async () => {
+    const web = new FakeWebClient();
+    let calls = 0;
+    const c = coord(web, gw({
+      runMraReview: async () => {
+        calls++;
+        return { ok: true, status: "COMMENT", commentCount: 0, stdout: "", stderr: "" };
+      },
+    } as unknown as Partial<ReviewGateway>));
+    await c.fromMessage({ channelId: "C1", threadTs: "1.1", userId: "U1", text: `:cr: ${PR}` });
+    await c.rerunInThread({ channelId: "C1", threadTs: "1.1", userId: "U1", text: `rerun ${PR}` });
+    assert.equal(calls, 2, "rerun must skip the same-SHA already-done guard");
+  });
+
+  it("still refuses a non-admin, link or no link", async () => {
+    const web = new FakeWebClient();
+    let calls = 0;
+    const c = coord(web, gw({
+      runMraReview: async () => { calls++; return { ok: true, status: "COMMENT", commentCount: 0, stdout: "", stderr: "" }; },
+    } as unknown as Partial<ReviewGateway>));
+    await c.rerunInThread({ channelId: "C1", threadTs: "1.1", userId: "U-not-admin", text: `rerun ${PR}` });
+    assert.equal(calls, 0, "an inline link must not become a way around the admin gate");
+    assert.ok(web.posted.some((p) => /admin/.test(p.text ?? "")), "and the refusal must say why");
   });
 });
 

--- a/packages/cli/test/review-coordinator.test.ts
+++ b/packages/cli/test/review-coordinator.test.ts
@@ -1652,6 +1652,88 @@ describe("ReviewCoordinator forced rerun", () => {
   });
 });
 
+// 2026-08-14 live: `rerun` in a PUBLIC channel answered "這個 thread 沒有可重跑的
+// PR review". The thread root WAS an `:a:` request — the bot simply could not read
+// it, because the bot token holds `im:history` but not `channels:history`, so
+// conversations.history threw missing_scope and fetchMessageText swallowed the
+// error into `undefined`. Every caller then read that `undefined` as "the root is
+// not a review request" and blamed the user for the bot's own missing scope.
+// A read failure and an absent review are different facts and must read differently.
+describe("ReviewCoordinator thread-root read failure", () => {
+  function unreadableWeb(message = "An API error occurred: missing_scope"): FakeWebClient {
+    const web = new FakeWebClient();
+    web.conversations.history = async () => {
+      throw new Error(message);
+    };
+    return web;
+  }
+
+  it("rerun names the read failure instead of claiming the thread has no review", async () => {
+    const web = unreadableWeb();
+    await coord(web, gw()).rerunInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+    const texts = web.posted.map((p) => p.text ?? "");
+    assert.ok(
+      !texts.some((t) => /沒有可重跑/.test(t)),
+      `an unreadable thread must not be reported as having no review, got: ${JSON.stringify(texts)}`,
+    );
+    assert.ok(
+      texts.some((t) => /missing_scope/.test(t)),
+      `the reply must carry the real Slack error, got: ${JSON.stringify(texts)}`,
+    );
+  });
+
+  it("retry names the read failure instead of the no-review nudge", async () => {
+    const web = unreadableWeb();
+    await coord(web, gw()).retryInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+    const texts = web.posted.map((p) => p.text ?? "");
+    assert.ok(
+      !texts.some((t) => /沒有可重試/.test(t)),
+      `an unreadable thread must not be reported as having no review, got: ${JSON.stringify(texts)}`,
+    );
+    assert.ok(
+      texts.some((t) => /missing_scope/.test(t)),
+      `the reply must carry the real Slack error, got: ${JSON.stringify(texts)}`,
+    );
+  });
+
+  // The reaction paths are worse than a wrong message: `text ?? ""` parses to zero
+  // PR refs and processReviewRequest returns early, so a `:cr:` reaction in a
+  // channel produces NO reply at all. The user sees the bot ignore them.
+  it(":cr: reaction answers instead of silently doing nothing", async () => {
+    const web = unreadableWeb();
+    await coord(web, gw()).fromReaction({ channelId: "C1", messageTs: "1.1", reactorUserId: "U1" });
+    const texts = web.posted.map((p) => p.text ?? "");
+    assert.ok(texts.length > 0, "a reaction the bot cannot read must not be silently dropped");
+    assert.ok(
+      texts.some((t) => /missing_scope/.test(t)),
+      `the reply must carry the real Slack error, got: ${JSON.stringify(texts)}`,
+    );
+  });
+
+  it(":a: reaction answers instead of silently doing nothing", async () => {
+    const web = unreadableWeb();
+    await coord(web, gw()).fromApproveReaction({ channelId: "C1", messageTs: "1.1", reactorUserId: "U1" });
+    const texts = web.posted.map((p) => p.text ?? "");
+    assert.ok(texts.length > 0, "a reaction the bot cannot read must not be silently dropped");
+    assert.ok(
+      texts.some((t) => /missing_scope/.test(t)),
+      `the reply must carry the real Slack error, got: ${JSON.stringify(texts)}`,
+    );
+  });
+
+  // A readable thread whose root genuinely is not a review request keeps the
+  // existing nudge — the fix must separate the two facts, not merge them.
+  it("keeps the no-review nudge when the root IS readable and is not a review", async () => {
+    const web = new FakeWebClient();
+    web.conversationsHistoryResponse = { ok: true, messages: [{ text: "just chatting" }] };
+    await coord(web, gw()).rerunInThread({ channelId: "C1", threadTs: "1.1", userId: "U1" });
+    assert.ok(
+      web.posted.some((p) => /沒有可重跑/.test(p.text ?? "")),
+      "a readable non-review thread must still get the nudge",
+    );
+  });
+});
+
 describe("ReviewCoordinator project concurrency", () => {
   it("does not run two reviews against the same shared project checkout", async () => {
     const web = new FakeWebClient();


### PR DESCRIPTION
## Why

線上 2026-08-14，`onead/finance-system#378`：

| 時間 | 事件 |
|---|---|
| 09:58 | Jamie 在 DM 完成 `#378@ba8bf0a` 的 review：COMMENTED、0 blocker |
| 10:05 | Jamie 在頻道發 `:a:` → 撞到同 commit 的已審過訊息，訊息說「要強制重跑：回覆 `rerun`」 |
| 10:36 | hanfour 回 `rerun` → 「這個 thread 沒有可重跑的 PR review」 |
| 10:36 | 再發 `:cr: <連結>`、再回 `rerun` → 同一句話 |

那個 thread 的 root 是一則有效的 `:a:` 請求。bot 只是讀不到它。

bot token 持有 `im:history`，從未被授予 `channels:history`。`rerun` 用 `conversations.history` 回讀 thread root，在頻道丟 `missing_scope`，而 `fetchMessageText` 把錯誤 catch 成 `undefined`，呼叫端無法分辨「讀不到」與「root 不是 review 請求」，於是輸出後者。

驗證方式是同一個 API 對兩個 channel 各打一次：

```
hanfour 的 DM (D0B0E9UV52M)   conversations.history → ok
頻道 (C0AVD1XD946)            conversations.history → missing_scope, needed: channels:history
```

過去的驗證都在 DM，或在頻道用 inline `@pmk :cr: <連結>`（訊息文字直接在手上，不需要回讀），所以這個缺口一直沒被發現。v0.43.0 的已審過訊息第一次主動把使用者導向 `rerun`，才讓它浮出來。

同一個根因下，頻道內還有兩個更安靜的失效：`:cr:` / `:a:` 貼圖觸發拿到空字串，解析出 0 個 PR，`processReviewRequest` 直接 return，bot 完全不回應。

## Fixed

### 1. 讀不到就說讀不到

`readMessageText` 回傳 `{ok:true,text}` / `{ok:false,error}`。四條使用者看得到的路徑（`rerun`、`retry`、兩個貼圖觸發）改為判斷 `ok`，讀取失敗時回報 Slack 的原始錯誤，並給出當下走得通的下一步。root 讀得到但確實不是 review 請求時，維持原本的提示。

```
:warning: 我讀不到這個 thread 的原始訊息（Slack 回：An API error occurred: missing_scope），
無法判斷要處理哪個 PR。
請改用 `:cr: <PR 連結>` 直接發起。
這是 bot 的權限問題，不是你的操作問題：在頻道回讀 thread 需要 `channels:history`
（私有頻道另需 `groups:history`），DM 不受影響。
```

### 2. doctor 檢查實際被授予的 scope

`manifest-alignment` 比對的是 repo 的 manifest 範本與 `expectedScopes()`，兩邊都不經過使用者實際安裝的 app，所以一個裝在 scope 加入之前的 app 會一直通過檢查。

`auth.test` 的 `response_metadata.scopes` 會回傳實際授予清單（`slack-bot-token.ts` 原本的註解說拿不到，是錯的）。新的 `slack-bot-scopes` 檢查讀它並指名缺哪幾個。Slack 沒回 scope 清單時報 warn 而非 pass。

線上實際輸出：

```
[FAIL] slack-bot-scopes — installed Slack app is missing 2 granted bot scope(s)
        hint: add at api.slack.com/apps → OAuth & Permissions → Bot Token Scopes,
              then reinstall: channels:history, groups:history
[PASS] slack-bot-token — Bot Token accepted (team=slack-webhook, user=pmk)
```

`BOT_SCOPES` 與 `manifest.template.json` 同步加上這兩個 scope。加它們不會讓 bot 收到頻道所有訊息：`handleMessage` 對非 DM 直接 return，頻道一律走 `app_mention`。`lifecycle.md` 原本把「必須 @pmk」歸因於缺 scope，改成說明真正的原因是事件路由。

### 3. rerun 可以直接帶連結

`rerun <PR 連結>` 的目標寫在訊息裡，不必回讀 thread，缺 scope 也能用。指令必須置頂且後接空白，所以「我剛 rerun 過 <連結>」「rerunning <連結>」留在 free chat，不會誤觸強制重審。admin 檢查不變。

已審過訊息的 admin 提示從裸 `rerun` 改成填好 PR 的完整指令：

```
（要對同一 commit 強制重跑：回覆 `rerun https://github.com/onead/finance-system/pull/378`）
```

`retry` 刻意維持需要 thread：它的目標是剛失敗的那次 review，帶連結後語意等同 `:cr: <連結>`（失敗的 claim 已釋放，同 commit 會重審），使用者本來就有路。

## Test plan

- [x] 1,188 測試全過（新增 17 個：4 條路徑的讀取失敗行為、可讀但非 review 的對照組、scope 檢查的 4 種狀態、`rerunPrRefs` 的置頂與誤判邊界、帶連結 rerun 的強制重審與 admin 護欄）
- [x] `tsc --noEmit` 乾淨
- [x] 線上 gateway 已 build + 重啟，doctor 實跑抓到缺的兩個 scope
- [x] 線上 Slack 確認新訊息取代舊的謊報訊息
- [ ] 線上 Slack 實測 `@pmk rerun <PR 連結>` 在頻道強制重審
- [ ] Slack app 加上兩個 scope 後，`slack-bot-scopes` 轉 PASS、貼圖觸發在頻道恢復
